### PR TITLE
frontend: display default Docker base image in workspace forms

### DIFF
--- a/frontend/src/common/workspaces/BaseDockerImageNotice.tsx
+++ b/frontend/src/common/workspaces/BaseDockerImageNotice.tsx
@@ -1,0 +1,18 @@
+// Copyright © 2026 Jalapeno Labs
+
+// Misc
+import { DEFAULT_DOCKER_BASE_IMAGE } from '@common/constants'
+
+export function BaseDockerImageNotice() {
+  return <div className='relaxed'>
+    <p className='opacity-80'>
+      Workspace builds always start from our default base image:
+    </p>
+    <p className='font-mono text-sm break-all'>
+      {DEFAULT_DOCKER_BASE_IMAGE}
+    </p>
+    <p className='opacity-80'>
+      Your custom Dockerfile commands are appended after this base image so you can layer project-specific tools on top.
+    </p>
+  </div>
+}

--- a/frontend/src/pages/workspaces/CreateWorkspace.tsx
+++ b/frontend/src/pages/workspaces/CreateWorkspace.tsx
@@ -22,6 +22,7 @@ import { Button, Card, Form, Input, Textarea } from '@heroui/react'
 import { BuildLogsPanel } from '@frontend/common/BuildLogsPanel'
 import { EnvironmentInputs } from '@frontend/common/env/EnvironmentInputs'
 import { Monaco } from '@frontend/common/Monaco'
+import { BaseDockerImageNotice } from '@frontend/common/workspaces/BaseDockerImageNotice'
 
 // Utility
 import { useApiBuildSocket } from '@frontend/hooks/useApiBuildSocket'
@@ -103,6 +104,7 @@ export function CreateWorkspace() {
       <div className='w-full'>
         <div className='relaxed w-full'>
           <label className='text-sm font-medium'>Custom Dockerfile commands</label>
+          <BaseDockerImageNotice />
           <Monaco
             height='220px'
             fileLanguage='dockerfile'

--- a/frontend/src/pages/workspaces/EditWorkspace.tsx
+++ b/frontend/src/pages/workspaces/EditWorkspace.tsx
@@ -18,6 +18,7 @@ import { Button, Card, Input, Textarea } from '@heroui/react'
 import { BuildLogsPanel } from '@frontend/common/BuildLogsPanel'
 import { EnvironmentInputs } from '@frontend/common/env/EnvironmentInputs'
 import { Monaco } from '@frontend/common/Monaco'
+import { BaseDockerImageNotice } from '@frontend/common/workspaces/BaseDockerImageNotice'
 
 // Utility
 import { useApiBuildSocket } from '@frontend/hooks/useApiBuildSocket'
@@ -103,6 +104,7 @@ export function EditWorkspace() {
       <div className='w-full'>
         <div className='relaxed w-full'>
           <label className='text-sm font-medium'>Custom Dockerfile commands</label>
+          <BaseDockerImageNotice />
           <Monaco
             height='220px'
             fileLanguage='dockerfile'


### PR DESCRIPTION
### Motivation
- Make it explicit to users which base image workspace builds start from and that custom Dockerfile commands are appended after it, using the shared constant for accuracy.

### Description
- Add a new reusable component `BaseDockerImageNotice` that reads and displays the `DEFAULT_DOCKER_BASE_IMAGE` constant (value: `mcr.microsoft.com/devcontainers/universal:5.1.4-noble`).
- Render `BaseDockerImageNotice` above the custom Dockerfile commands editor in both the Create Workspace and Edit Workspace pages so the base image is visible when editing or creating a workspace.

### Testing
- Ran `yarn --cwd frontend typecheck`, which failed due to existing repository-wide `@prisma/client` type export issues unrelated to this change. (Type errors pre-existed and are not introduced by this PR.)
- Launched the frontend with `yarn --cwd frontend dev --host 0.0.0.0 --port 4173` and verified the new UI visually, capturing a screenshot for validation which confirmed the notice renders correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69855e91b4308322819c7910d9335bbc)