### PR TITLE
Add Git dropdown UI, placeholder Git APIs, and Task git fields

### DIFF
--- a/electron/src/api/routes/v1/protected/tasks/postReUpTaskGitRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/postReUpTaskGitRoute.ts
@@ -1,0 +1,43 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Request, Response } from 'express'
+
+// Lib
+import { z } from 'zod'
+
+// Utility
+import { parseRequestParams } from '../../validation'
+
+type RouteParams = {
+  taskId: string
+}
+
+const taskParamsSchema = z.object({
+  taskId: z.string().trim().min(1),
+})
+
+export async function handleReUpTaskGitRequest(
+  request: Request<RouteParams>,
+  response: Response,
+): Promise<void> {
+  const params = parseRequestParams(
+    taskParamsSchema,
+    request,
+    response,
+    {
+      context: 'Re-up task git API',
+      errorMessage: 'Task ID is required',
+    },
+  )
+  if (!params) {
+    return
+  }
+
+  console.debug('Re-up task git route called', {
+    taskId: params.taskId,
+  })
+
+  response.status(200).json({
+    message: 'Not implemented yet',
+  })
+}

--- a/electron/src/api/routes/v1/protected/tasks/postRefreshTaskGitRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/postRefreshTaskGitRoute.ts
@@ -1,0 +1,43 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Request, Response } from 'express'
+
+// Lib
+import { z } from 'zod'
+
+// Utility
+import { parseRequestParams } from '../../validation'
+
+type RouteParams = {
+  taskId: string
+}
+
+const taskParamsSchema = z.object({
+  taskId: z.string().trim().min(1),
+})
+
+export async function handleRefreshTaskGitRequest(
+  request: Request<RouteParams>,
+  response: Response,
+): Promise<void> {
+  const params = parseRequestParams(
+    taskParamsSchema,
+    request,
+    response,
+    {
+      context: 'Refresh task git API',
+      errorMessage: 'Task ID is required',
+    },
+  )
+  if (!params) {
+    return
+  }
+
+  console.debug('Refresh task git route called', {
+    taskId: params.taskId,
+  })
+
+  response.status(200).json({
+    message: 'Not implemented yet',
+  })
+}

--- a/electron/src/api/routes/v1/protected/tasks/postTaskPullRequestRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/postTaskPullRequestRoute.ts
@@ -1,0 +1,43 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Request, Response } from 'express'
+
+// Lib
+import { z } from 'zod'
+
+// Utility
+import { parseRequestParams } from '../../validation'
+
+type RouteParams = {
+  taskId: string
+}
+
+const taskParamsSchema = z.object({
+  taskId: z.string().trim().min(1),
+})
+
+export async function handleTaskPullRequestRequest(
+  request: Request<RouteParams>,
+  response: Response,
+): Promise<void> {
+  const params = parseRequestParams(
+    taskParamsSchema,
+    request,
+    response,
+    {
+      context: 'Task pull request API',
+      errorMessage: 'Task ID is required',
+    },
+  )
+  if (!params) {
+    return
+  }
+
+  console.debug('Task pull request route called', {
+    taskId: params.taskId,
+  })
+
+  response.status(200).json({
+    message: 'Not implemented yet',
+  })
+}

--- a/electron/src/api/routes/v1/protected/tasks/postViewTaskRepositoryRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/postViewTaskRepositoryRoute.ts
@@ -1,0 +1,43 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Request, Response } from 'express'
+
+// Lib
+import { z } from 'zod'
+
+// Utility
+import { parseRequestParams } from '../../validation'
+
+type RouteParams = {
+  taskId: string
+}
+
+const taskParamsSchema = z.object({
+  taskId: z.string().trim().min(1),
+})
+
+export async function handleViewTaskRepositoryRequest(
+  request: Request<RouteParams>,
+  response: Response,
+): Promise<void> {
+  const params = parseRequestParams(
+    taskParamsSchema,
+    request,
+    response,
+    {
+      context: 'View task repository API',
+      errorMessage: 'Task ID is required',
+    },
+  )
+  if (!params) {
+    return
+  }
+
+  console.debug('View task repository route called', {
+    taskId: params.taskId,
+  })
+
+  response.status(200).json({
+    message: 'Not implemented yet',
+  })
+}

--- a/electron/src/api/routes/v1/protected/tasksRouter.ts
+++ b/electron/src/api/routes/v1/protected/tasksRouter.ts
@@ -10,6 +10,10 @@ import { handleCreateTaskRequest } from './tasks/createTaskRoute'
 import { handleDeleteTaskRequest } from './tasks/deleteTaskRoute'
 import { handleGetTaskRequest } from './tasks/getTaskRoute'
 import { handleListTasksRequest } from './tasks/listTasksRoute'
+import { handleReUpTaskGitRequest } from './tasks/postReUpTaskGitRoute'
+import { handleRefreshTaskGitRequest } from './tasks/postRefreshTaskGitRoute'
+import { handleTaskPullRequestRequest } from './tasks/postTaskPullRequestRoute'
+import { handleViewTaskRepositoryRequest } from './tasks/postViewTaskRepositoryRoute'
 import { handleStreamTaskLogsRequest } from './tasks/streamTaskLogsRoute'
 import { handleUpdateTaskRequest } from './tasks/updateTaskRoute'
 
@@ -28,6 +32,14 @@ export function createTasksRouter(): Router {
   tasksRouter.patch('/:taskId', handleUpdateTaskRequest)
   // /api/v1/protected/tasks/:taskId
   tasksRouter.delete('/:taskId', handleDeleteTaskRequest)
+  // /api/v1/protected/tasks/:taskId/git/refresh
+  tasksRouter.post('/:taskId/git/refresh', handleRefreshTaskGitRequest)
+  // /api/v1/protected/tasks/:taskId/git/re-up
+  tasksRouter.post('/:taskId/git/re-up', handleReUpTaskGitRequest)
+  // /api/v1/protected/tasks/:taskId/git/pull-request
+  tasksRouter.post('/:taskId/git/pull-request', handleTaskPullRequestRequest)
+  // /api/v1/protected/tasks/:taskId/git/view-repository
+  tasksRouter.post('/:taskId/git/view-repository', handleViewTaskRepositoryRequest)
 
   return tasksRouter
 }

--- a/frontend/src/lib/routes/taskRoutes.ts
+++ b/frontend/src/lib/routes/taskRoutes.ts
@@ -59,3 +59,29 @@ export function deleteTask(taskId: string) {
   return apiClient
     .delete(`v1/protected/tasks/${taskId}`)
 }
+
+type TaskGitActionResponse = {
+  message: string
+}
+
+function postTaskGitAction(taskId: string, actionPath: string) {
+  return apiClient
+    .post(`v1/protected/tasks/${taskId}/git/${actionPath}`)
+    .json<TaskGitActionResponse>()
+}
+
+export function refreshTaskGit(taskId: string) {
+  return postTaskGitAction(taskId, 'refresh')
+}
+
+export function reUpTaskGit(taskId: string) {
+  return postTaskGitAction(taskId, 're-up')
+}
+
+export function createOrUpdateTaskPullRequest(taskId: string) {
+  return postTaskGitAction(taskId, 'pull-request')
+}
+
+export function viewTaskRepository(taskId: string) {
+  return postTaskGitAction(taskId, 'view-repository')
+}

--- a/frontend/src/pages/tasks/TaskView.tsx
+++ b/frontend/src/pages/tasks/TaskView.tsx
@@ -1,6 +1,6 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { Message } from '@prisma/client'
+import type { Message, Task } from '@prisma/client'
 
 // Core
 import { useState } from 'react'
@@ -9,9 +9,13 @@ import { useState } from 'react'
 import { Button, Skeleton, Textarea } from '@heroui/react'
 import { TaskFilesView } from './TaskFilesView'
 
+// Misc
+import { GitTaskDropdown } from './gitActions/GitTaskDropdown'
+
 type Props = {
   messages: Message[]
   taskName: string
+  task?: Task
   isLoading?: boolean
   containerName?: string
 }
@@ -73,7 +77,7 @@ function getSkeletonWidths() {
 }
 
 export function TaskView(props: Props) {
-  const { messages, taskName, isLoading = false, containerName } = props
+  const { messages, taskName, task, isLoading = false, containerName } = props
   const [ draftMessage, setDraftMessage ] = useState<string>('')
   const [ activeTabId, setActiveTabId ] = useState<TaskTabId>('conversation')
   const skeletonWidths = getSkeletonWidths()
@@ -181,16 +185,26 @@ export function TaskView(props: Props) {
 
   return <div className='flex h-full flex-col'>
     <div className='relaxed'>
-      <h2 className='text-2xl'>
-        <strong>{
-          taskName
-        }</strong>
-      </h2>
-      {containerName && (
-        <p className='text-xs opacity-60'>
-          Container: {containerName}
-        </p>
-      )}
+      <div className='level'>
+        <div>
+          <h2 className='text-2xl'>
+            <strong>{
+              taskName
+            }</strong>
+          </h2>
+          {containerName && (
+            <p className='text-xs opacity-60'>
+              Container: {containerName}
+            </p>
+          )}
+        </div>
+        {task && (
+          <GitTaskDropdown
+            task={task}
+            provider='github'
+          />
+        )}
+      </div>
     </div>
     <div className='level-centered relaxed'>
       <div className='flex flex-wrap justify-center gap-2'>

--- a/frontend/src/pages/tasks/Tasks.tsx
+++ b/frontend/src/pages/tasks/Tasks.tsx
@@ -103,6 +103,7 @@ export function Tasks() {
 
   const isTaskLoading = Boolean(taskId && !taskQuery.data && !taskQuery.error)
   const taskMessages = taskQuery.data?.task.messages || []
+  const resolvedTask = taskQuery.data?.task || selectedTask
   const shouldShowEmpty = !taskId
   const taskName = taskQuery.data?.task.name || selectedTask?.name || 'Untitled task'
   const taskContainerName = taskQuery.data?.task.containerName || selectedTask?.containerName
@@ -116,6 +117,7 @@ export function Tasks() {
           <TaskView
             messages={[]}
             taskName={taskName}
+            task={resolvedTask}
             containerName={taskContainerName}
             isLoading
           />
@@ -137,6 +139,7 @@ export function Tasks() {
           <TaskView
             messages={taskMessages}
             taskName={taskName}
+            task={resolvedTask}
             containerName={taskContainerName}
           />
         )}

--- a/frontend/src/pages/tasks/gitActions/CreateOrUpdatePullRequestButton.tsx
+++ b/frontend/src/pages/tasks/gitActions/CreateOrUpdatePullRequestButton.tsx
@@ -1,0 +1,53 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { TaskGitActionContext } from './types'
+
+// Core
+import { useState } from 'react'
+
+// User interface
+import { Button } from '@heroui/react'
+
+// Misc
+import { createOrUpdateTaskPullRequest } from '@frontend/lib/routes/taskRoutes'
+
+type Props = {
+  context: TaskGitActionContext
+}
+
+export function CreateOrUpdatePullRequestButton(props: Props) {
+  const { context } = props
+  const [ isLoading, setIsLoading ] = useState<boolean>(false)
+
+  let label = 'Create PR'
+  if (context.task.pullRequestLink) {
+    label = 'Update PR'
+  }
+
+  async function handleClick() {
+    console.debug('CreateOrUpdatePullRequestButton clicked', context)
+    setIsLoading(true)
+
+    try {
+      const response = await createOrUpdateTaskPullRequest(context.task.id)
+      console.debug('CreateOrUpdatePullRequestButton response', response)
+    }
+    catch (error) {
+      console.debug('CreateOrUpdatePullRequestButton request failed', {
+        error,
+        context,
+      })
+    }
+    finally {
+      setIsLoading(false)
+    }
+  }
+
+  return <Button
+    size='sm'
+    onPress={handleClick}
+    isLoading={isLoading}
+  >
+    <span>{label}</span>
+  </Button>
+}

--- a/frontend/src/pages/tasks/gitActions/GitTaskDropdown.tsx
+++ b/frontend/src/pages/tasks/gitActions/GitTaskDropdown.tsx
@@ -1,0 +1,70 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Task } from '@prisma/client'
+
+// User interface
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownSection,
+  DropdownTrigger,
+} from '@heroui/react'
+
+// Misc
+import { CreateOrUpdatePullRequestButton } from './CreateOrUpdatePullRequestButton'
+import { RefreshGitButton } from './RefreshGitButton'
+import { ReUpGitButton } from './ReUpGitButton'
+import { ViewOnRepositoryButton } from './ViewOnRepositoryButton'
+
+type Props = {
+  task: Task
+  provider?: string
+}
+
+function resolveGitProvider(provider?: string) {
+  if (!provider) {
+    console.debug('GitTaskDropdown did not receive a provider, defaulting to GitHub')
+    return 'github'
+  }
+
+  return provider
+}
+
+export function GitTaskDropdown(props: Props) {
+  const { task, provider } = props
+
+  const context = {
+    task,
+    provider: resolveGitProvider(provider),
+  }
+
+  return <Dropdown placement='bottom-end'>
+    <DropdownTrigger>
+      <Button color='default' variant='flat'>
+        <span>Git</span>
+      </Button>
+    </DropdownTrigger>
+    <DropdownMenu
+      aria-label='Git actions'
+      variant='flat'
+      closeOnSelect={false}
+    >
+      <DropdownSection>
+        <DropdownItem key='refresh-git' textValue='Refresh git'>
+          <RefreshGitButton context={context} />
+        </DropdownItem>
+        <DropdownItem key='re-up-git' textValue='Re-up git'>
+          <ReUpGitButton context={context} />
+        </DropdownItem>
+        <DropdownItem key='create-or-update-pr' textValue='Create or update pull request'>
+          <CreateOrUpdatePullRequestButton context={context} />
+        </DropdownItem>
+        <DropdownItem key='view-repository' textValue='View repository'>
+          <ViewOnRepositoryButton context={context} />
+        </DropdownItem>
+      </DropdownSection>
+    </DropdownMenu>
+  </Dropdown>
+}

--- a/frontend/src/pages/tasks/gitActions/ReUpGitButton.tsx
+++ b/frontend/src/pages/tasks/gitActions/ReUpGitButton.tsx
@@ -1,0 +1,48 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { TaskGitActionContext } from './types'
+
+// Core
+import { useState } from 'react'
+
+// User interface
+import { Button } from '@heroui/react'
+
+// Misc
+import { reUpTaskGit } from '@frontend/lib/routes/taskRoutes'
+
+type Props = {
+  context: TaskGitActionContext
+}
+
+export function ReUpGitButton(props: Props) {
+  const { context } = props
+  const [ isLoading, setIsLoading ] = useState<boolean>(false)
+
+  async function handleClick() {
+    console.debug('ReUpGitButton clicked', context)
+    setIsLoading(true)
+
+    try {
+      const response = await reUpTaskGit(context.task.id)
+      console.debug('ReUpGitButton response', response)
+    }
+    catch (error) {
+      console.debug('ReUpGitButton request failed', {
+        error,
+        context,
+      })
+    }
+    finally {
+      setIsLoading(false)
+    }
+  }
+
+  return <Button
+    size='sm'
+    onPress={handleClick}
+    isLoading={isLoading}
+  >
+    <span>Re-up git</span>
+  </Button>
+}

--- a/frontend/src/pages/tasks/gitActions/RefreshGitButton.tsx
+++ b/frontend/src/pages/tasks/gitActions/RefreshGitButton.tsx
@@ -1,0 +1,48 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { TaskGitActionContext } from './types'
+
+// Core
+import { useState } from 'react'
+
+// User interface
+import { Button } from '@heroui/react'
+
+// Misc
+import { refreshTaskGit } from '@frontend/lib/routes/taskRoutes'
+
+type Props = {
+  context: TaskGitActionContext
+}
+
+export function RefreshGitButton(props: Props) {
+  const { context } = props
+  const [ isLoading, setIsLoading ] = useState<boolean>(false)
+
+  async function handleClick() {
+    console.debug('RefreshGitButton clicked', context)
+    setIsLoading(true)
+
+    try {
+      const response = await refreshTaskGit(context.task.id)
+      console.debug('RefreshGitButton response', response)
+    }
+    catch (error) {
+      console.debug('RefreshGitButton request failed', {
+        error,
+        context,
+      })
+    }
+    finally {
+      setIsLoading(false)
+    }
+  }
+
+  return <Button
+    size='sm'
+    onPress={handleClick}
+    isLoading={isLoading}
+  >
+    <span>Refresh git</span>
+  </Button>
+}

--- a/frontend/src/pages/tasks/gitActions/ViewOnRepositoryButton.tsx
+++ b/frontend/src/pages/tasks/gitActions/ViewOnRepositoryButton.tsx
@@ -1,0 +1,69 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { TaskGitActionContext } from './types'
+
+// Core
+import { useState } from 'react'
+
+// User interface
+import { Button } from '@heroui/react'
+
+// Misc
+import { viewTaskRepository } from '@frontend/lib/routes/taskRoutes'
+
+type Props = {
+  context: TaskGitActionContext
+}
+
+function getViewOnRepositoryLabel(provider: string) {
+  const normalizedProvider = provider.toLowerCase()
+
+  if (normalizedProvider === 'github') {
+    return 'View on GitHub'
+  }
+
+  if (normalizedProvider === 'gitlab') {
+    return 'View on GitLab'
+  }
+
+  if (normalizedProvider === 'bitbucket') {
+    return 'View on Bitbucket'
+  }
+
+  console.debug('ViewOnRepositoryButton received an unknown provider', {
+    provider,
+  })
+  return 'View repository'
+}
+
+export function ViewOnRepositoryButton(props: Props) {
+  const { context } = props
+  const [ isLoading, setIsLoading ] = useState<boolean>(false)
+
+  async function handleClick() {
+    console.debug('ViewOnRepositoryButton clicked', context)
+    setIsLoading(true)
+
+    try {
+      const response = await viewTaskRepository(context.task.id)
+      console.debug('ViewOnRepositoryButton response', response)
+    }
+    catch (error) {
+      console.debug('ViewOnRepositoryButton request failed', {
+        error,
+        context,
+      })
+    }
+    finally {
+      setIsLoading(false)
+    }
+  }
+
+  return <Button
+    size='sm'
+    onPress={handleClick}
+    isLoading={isLoading}
+  >
+    <span>{getViewOnRepositoryLabel(context.provider)}</span>
+  </Button>
+}

--- a/frontend/src/pages/tasks/gitActions/types.ts
+++ b/frontend/src/pages/tasks/gitActions/types.ts
@@ -1,0 +1,8 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Task } from '@prisma/client'
+
+export type TaskGitActionContext = {
+  task: Task
+  provider: string
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,14 @@ model Task {
 
   name      String
   branch    String
+
+  // Git
+  gitBranch             String?  @map("git_branch")
+  pullRequestLink       String?  @map("pull_request_link")
+  isPullRequestUpToDate Boolean  @default(false) @map("is_pull_request_up_to_date")
+  isMerged              Boolean  @default(false) @map("is_merged")
+  isBehind              Boolean  @default(false) @map("is_behind")
+
   container String    @map("container")
   containerName String? @map("container_name")
   archived  Boolean   @default(false)


### PR DESCRIPTION
### Motivation
- Provide a Git action entrypoint on the Task view so users can run repository-related actions (refresh, re-up, create/update PR, and view on provider) and wire the UI to backend placeholders for future implementation.
- Persist basic Git/PR state on the Task model so the UI can reflect PR presence and status moving forward.

### Description
- Added a HeroUI `Dropdown` in the task header and wired it to task context in `TaskView` so the menu only appears when a task is available (`frontend/src/pages/tasks/TaskView.tsx`).
- Implemented dedicated button components for each action with context logging and placeholder calls: `RefreshGitButton`, `ReUpGitButton`, `CreateOrUpdatePullRequestButton`, `ViewOnRepositoryButton`, and a shared `GitTaskDropdown` and `types` file (`frontend/src/pages/tasks/gitActions/*`).
- Added frontend API helpers in `frontend/src/lib/routes/taskRoutes.ts` to call the placeholder endpoints (`refresh`, `re-up`, `pull-request`, `view-repository`).
- Added backend placeholder routes under `/api/v1/protected/tasks/:taskId/git/*` that validate params and return `{ "message": "Not implemented yet" }` (`electron/src/api/routes/v1/protected/tasks/*.ts`) and registered them in the tasks router.
- Extended the Prisma `Task` model with Git/PR fields: `gitBranch`, `pullRequestLink`, `isPullRequestUpToDate` (default `false`), `isMerged` (default `false`), and `isBehind` (default `false`) (`prisma/schema.prisma`).

### Testing
- Ran `yarn prisma generate` which completed successfully and generated the Prisma client.
- Ran `yarn typecheck` which completed successfully after generating the Prisma client.
- Ran `yarn eslint` against changed files which completed with only a noted warning that the Prisma schema file is ignored by ESLint rules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698564ce500083229bf6f76c864b1e36)