### PR TITLE
Disable Prisma Studio browser auto-open in container

### DIFF
--- a/services/prisma_studio/Dockerfile
+++ b/services/prisma_studio/Dockerfile
@@ -17,4 +17,4 @@ RUN corepack enable && yarn install --immutable
 
 EXPOSE 5555
 
-CMD [ "yarn", "prisma", "studio", "--config", "./prisma.config.ts", "--port", "5555" ]
+CMD [ "yarn", "prisma", "studio", "--config", "./prisma.config.ts", "--port", "5555", "--browser", "none" ]


### PR DESCRIPTION
### Motivation
- Prisma Studio inside the container was crashing with `spawn xdg-open ENOENT` because the image lacks desktop/browser tooling, so auto-opening a browser must be disabled.

### Description
- Update `services/prisma_studio/Dockerfile` to add `--browser none` to the `CMD` that runs `yarn prisma studio --config ./prisma.config.ts --port 5555`, preventing Prisma from attempting to launch `xdg-open` inside the container.

### Testing
- Verified the Prisma CLI supports the option by running `yarn prisma studio --help`; attempted `docker compose config` but `docker` is not available in this environment so compose validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9075627883228be4ec7fb7032f70)