### PR TITLE
Remove .js extensions from common imports and stabilize workspace typecheck

### DIFF
--- a/common/src/cloning/cloner.test.ts
+++ b/common/src/cloning/cloner.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Lib to test
-import { Cloner } from './cloner.js'
+import { Cloner } from './cloner'
 
 class TestCloner extends Cloner {
   public getOrgName() {

--- a/common/src/cloning/cloner.ts
+++ b/common/src/cloning/cloner.ts
@@ -1,7 +1,7 @@
 // Copyright © 2026 Jalapeno Labs
 
 // Core
-import { execFileAsync } from '../node/execFileAsync.js'
+import { execFileAsync } from '../node/execFileAsync'
 
 // Polymorophism!
 // Github and other types can get their own extensions of this class

--- a/common/src/cloning/getCloner.ts
+++ b/common/src/cloning/getCloner.ts
@@ -2,8 +2,8 @@
 
 import type { AuthProvider } from '@prisma/client'
 
-import { Cloner } from './cloner.js'
-import { GithubCloner } from './github.js'
+import { Cloner } from './cloner'
+import { GithubCloner } from './github'
 
 export function getCloner(authProvider: AuthProvider, sourceRepoUrl: string, token?: string): Cloner {
   if (authProvider === 'GITHUB') {

--- a/common/src/cloning/github.test.ts
+++ b/common/src/cloning/github.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Lib to test
-import { GithubCloner } from './github.js'
+import { GithubCloner } from './github'
 
 describe('GithubCloner', () => {
   let debugSpy: ReturnType<typeof vi.spyOn>

--- a/common/src/cloning/github.ts
+++ b/common/src/cloning/github.ts
@@ -1,6 +1,6 @@
 // Copyright © 2026 Jalapeno Labs
 
-import { Cloner } from './cloner.js'
+import { Cloner } from './cloner'
 
 export class GithubCloner extends Cloner {
   public getCloneUrl(): string {

--- a/common/src/envKit.test.ts
+++ b/common/src/envKit.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
 // Misc
-import { parseEnvBool, parseEnvInt, parseEnvNumber } from './envKit.js'
+import { parseEnvBool, parseEnvInt, parseEnvNumber } from './envKit'
 
 describe('parseEnvInt', () => {
   it('returns the default when the value is missing', () => {

--- a/common/src/envKit.ts
+++ b/common/src/envKit.ts
@@ -1,6 +1,6 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { Environment } from './schema.js'
+import type { Environment } from './schema'
 
 export function parseEnvInt(value: string | undefined, defaultValue: number): number {
   if (!value) {

--- a/common/src/node/searchFileListForExisting.ts
+++ b/common/src/node/searchFileListForExisting.ts
@@ -1,6 +1,6 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { StandardFilePointer } from '../types.js'
+import type { StandardFilePointer } from '../types'
 
 // Core
 import { existsSync } from 'node:fs'

--- a/common/src/node/superResolve.test.ts
+++ b/common/src/node/superResolve.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { resolve } from 'node:path'
 
 // Lib to test
-import { superResolve, expandEnvString } from './superResolve.js'
+import { superResolve, expandEnvString } from './superResolve'
 
 const fakeHomedir = '/home/testuser'
 

--- a/common/src/node/superResolve.ts
+++ b/common/src/node/superResolve.ts
@@ -1,11 +1,11 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { StandardFilePointer } from '../types.js'
+import type { StandardFilePointer } from '../types'
 
 import { homedir } from 'node:os'
 import { resolve, join } from 'node:path'
 import { sync as globglobgabgolabSync } from 'glob'
-import { validAbsoluteLinuxFilePathRegex } from '../regex.js'
+import { validAbsoluteLinuxFilePathRegex } from '../regex'
 import chalk from 'chalk'
 
 export function superResolvePath(filePointer: StandardFilePointer): string {

--- a/common/src/regex.test.ts
+++ b/common/src/regex.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from 'vitest'
 
 // Lib to test
-import { validAbsoluteLinuxFilePathRegex } from './regex.js'
+import { validAbsoluteLinuxFilePathRegex } from './regex'
 
 // We list these statically so if one of them fails we can see the exact line that failed.
 

--- a/common/src/schema.ts
+++ b/common/src/schema.ts
@@ -7,7 +7,7 @@ import {
   DONE_SOUND_MIME_TYPES,
   USER_LANGUAGE_OPTIONS,
   USER_THEME_OPTIONS,
-} from './constants.js'
+} from './constants'
 
 export const environmentSchema = z.object({
   key: z

--- a/common/src/stringify.test.ts
+++ b/common/src/stringify.test.ts
@@ -4,7 +4,7 @@
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 // Utility
-import { stringify } from './stringify.js'
+import { stringify } from './stringify'
 
 describe('stringify', () => {
   let consoleErrorMock: ReturnType<typeof vi.spyOn>

--- a/common/src/writeScriptFile.ts
+++ b/common/src/writeScriptFile.ts
@@ -5,7 +5,7 @@ import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 // Misc
-import { DOCKER_WORKDIR } from './constants.js'
+import { DOCKER_WORKDIR } from './constants'
 
 export async function writeScriptFile(
   contextDir: string,

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -6,8 +6,8 @@
       "src",
       "../common/src"
     ],
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": [
       "ESNext",
       "DOM"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "concurrently --kill-others \"yarn --cwd frontend dev\" \"yarn --cwd electron dev\"",
     "setup": "yarn prisma generate && yarn prisma db push",
     "build": "yarn workspaces foreach -Apt run build",
-    "typecheck": "yarn prisma generate && yarn workspaces foreach -Apt run typecheck",
+    "typecheck": "yarn workspaces foreach -Apt run typecheck",
     "smoketest": "cross-env SMOKETEST=true vitest run",
     "test": "vitest run",
     "test:dev": "vitest watch --coverage.enabled=false --reporter verbose",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "concurrently --kill-others \"yarn --cwd frontend dev\" \"yarn --cwd electron dev\"",
     "setup": "yarn prisma generate && yarn prisma db push",
     "build": "yarn workspaces foreach -Apt run build",
-    "typecheck": "yarn workspaces foreach -Apt run typecheck",
+    "typecheck": "yarn prisma generate && yarn workspaces foreach -Apt run typecheck",
     "smoketest": "cross-env SMOKETEST=true vitest run",
     "test": "vitest run",
     "test:dev": "vitest watch --coverage.enabled=false --reporter verbose",


### PR DESCRIPTION
### Motivation
- TypeScript was requiring `.js` extensions for relative imports under `common/src/**` and `yarn typecheck` failed due to missing Prisma client types and inconsistent module resolution across workspaces.
- Make the monorepo type-check reliably and let `common` use normal extensionless TypeScript imports.

### Description
- Removed explicit `.js` suffixes from relative imports throughout `common/src/**` (examples: `envKit`, `cloning/*`, `node/*`, `schema`, `stringify` tests) so source files import other TS modules without `.js` endings.
- Switched the Electron workspace TS config to bundler-style resolution by setting `module` to `esnext` and `moduleResolution` to `bundler` in `electron/tsconfig.json` so shared `common/src` files resolve consistently.
- Updated the root `typecheck` script in `package.json` to run `prisma generate` before running workspace typechecks (`yarn prisma generate && yarn workspaces foreach -Apt run typecheck`) so Prisma client types exist during typechecking.

### Testing
- Ran `yarn prisma generate` which produced the Prisma client into `./node_modules/@prisma/client` (it logs a warning when DB credentials are missing but client generation completed). 
- Ran `yarn typecheck` from the repo root and confirmed the TypeScript typecheck now completes successfully across workspaces.
- Verified that common package tests and imports no longer require `.js` extensions by ensuring `tsc` in the `common` workspace lists files without module-resolution import errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b922bb6648322ae9b90d202111685)