### PR TITLE
Use Workspace.sourceRepoUrl; remove Task.sourceRepoUrl and repositoryId/fullName fields

### DIFF
--- a/common/src/schema.ts
+++ b/common/src/schema.ts
@@ -36,8 +36,7 @@ export const workspaceEnvEntrySchema = z.object({
 export const workspaceCreateSchema = z.object({
   authAccountId: z.string().trim().min(1),
   name: z.string().trim().min(1),
-  repositoryId: z.coerce.number().int().positive(),
-  repositoryFullName: z.string().trim().min(1),
+  sourceRepoUrl: z.string().trim().min(1),
   customDockerfileCommands: z.string().trim().optional().default(''),
   description: z.string().trim().optional().default(''),
   setupScript: z.string().trim().optional().default(''),
@@ -49,8 +48,7 @@ export const workspaceCreateSchema = z.object({
 export const workspaceUpdateSchema = z.object({
   authAccountId: z.string().trim().min(1).optional(),
   name: z.string().trim().min(1).optional(),
-  repositoryId: z.coerce.number().int().positive().optional(),
-  repositoryFullName: z.string().trim().min(1).optional(),
+  sourceRepoUrl: z.string().trim().min(1).optional(),
   customDockerfileCommands: z.string().trim().optional(),
   description: z.string().trim().optional(),
   setupScript: z.string().trim().optional(),
@@ -66,7 +64,6 @@ export const taskCreateSchema = z.object({
   workspaceId: z.string().trim().min(1),
   llmId: z.string().trim().min(1),
   authAccountId: z.string().trim().min(1),
-  repoUrl: z.string().trim().min(1),
   message: z.string().trim().min(1),
   branch: z.string().trim().min(1),
   archived: z.boolean().optional().default(false),

--- a/electron/src/api/routes/v1/protected/workspaces/createWorkspaceRoute.ts
+++ b/electron/src/api/routes/v1/protected/workspaces/createWorkspaceRoute.ts
@@ -36,8 +36,7 @@ export async function handleCreateWorkspaceRequest(
   const {
     authAccountId,
     name,
-    repositoryId,
-    repositoryFullName,
+    sourceRepoUrl,
     customDockerfileCommands,
     description,
     setupScript,
@@ -49,8 +48,7 @@ export async function handleCreateWorkspaceRequest(
   try {
     const baseWorkspaceData = {
       name,
-      repositoryId,
-      repositoryFullName,
+      sourceRepoUrl,
       customDockerfileCommands,
       description,
       setupScript,

--- a/electron/src/docker/buildImage.ts
+++ b/electron/src/docker/buildImage.ts
@@ -54,7 +54,7 @@ export async function buildImage(
     if (!cloner && task?.authAccount) {
       const cloner = getCloner(
         task.authAccount.provider,
-        task.sourceRepoUrl,
+        workspace.sourceRepoUrl || '',
         task.authAccount.accessToken,
       )
       cloneUrl = cloner.getCloneUrl()

--- a/electron/src/tasks/taskInstance.ts
+++ b/electron/src/tasks/taskInstance.ts
@@ -111,8 +111,16 @@ export class TaskInstance extends EventEmitter<EventMap> {
       authAccount,
       // messages,
       // user,
-      sourceRepoUrl,
     } = this.task
+
+    const sourceRepoUrl = workspace.sourceRepoUrl?.trim()
+    if (!sourceRepoUrl) {
+      console.debug('TaskInstance missing workspace source repo URL', {
+        taskId: this.task.id,
+        workspaceId: workspace.id,
+      })
+      throw new Error('Workspace source repository is required')
+    }
 
     const cloner = getCloner(
       authAccount.provider,
@@ -124,7 +132,7 @@ export class TaskInstance extends EventEmitter<EventMap> {
 
     if (!canClone) {
       console.error('Cannot clone repository with provided URL and credentials', {
-        repository: sourceRepoUrl,
+        repository: workspace.sourceRepoUrl,
         authProvider: authAccount.provider,
       })
       throw new Error('Cannot clone repository with provided URL and credentials')

--- a/electron/src/tasks/taskManager.ts
+++ b/electron/src/tasks/taskManager.ts
@@ -102,14 +102,13 @@ class TaskManager {
       }
     }
 
-    const repository = workspace.repositoryId
-    if (!repository) {
-      console.debug('Task creation failed, workspace missing repository', {
+    if (!workspace.sourceRepoUrl?.trim()) {
+      console.debug('Task creation failed, workspace missing source repo URL', {
         workspaceId: request.workspaceId,
       })
       return {
         status: 'error',
-        error: 'Workspace repository is required',
+        error: 'Workspace source repository is required',
         httpStatus: 400,
       }
     }
@@ -137,7 +136,6 @@ class TaskManager {
         authAccountId: request.authAccountId,
         name: codexTaskName,
         sourceGitBranch: request.branch,
-        sourceRepoUrl: request.repoUrl,
         container: 'pending',
         containerName: resolvedContainerName,
         archived: request.archived,

--- a/frontend/src/pages/workspaces/CreateWorkspace.tsx
+++ b/frontend/src/pages/workspaces/CreateWorkspace.tsx
@@ -26,8 +26,7 @@ const zodResolved = zodResolver(createWorkspaceSchema)
 const defaultValues: CreateWorkspaceFormValues = {
   authAccountId: '',
   name: '',
-  repositoryId: 0,
-  repositoryFullName: '',
+  sourceRepoUrl: '',
   customDockerfileCommands: '',
   description: '',
   setupScript: 'yarn install',

--- a/frontend/src/pages/workspaces/EditWorkspace.tsx
+++ b/frontend/src/pages/workspaces/EditWorkspace.tsx
@@ -70,8 +70,7 @@ export function EditWorkspace() {
     defaultValues: {
       authAccountId: '',
       name: '',
-      repositoryId: 0,
-      repositoryFullName: '',
+      sourceRepoUrl: '',
       customDockerfileCommands: '',
       description: '',
       setupScript: '',
@@ -94,8 +93,7 @@ export function EditWorkspace() {
     const workspace = workspaceQuery.data.workspace
     form.reset({
       name: workspace.name,
-      repositoryId: workspace.repositoryId,
-      repositoryFullName: workspace.repositoryFullName,
+      sourceRepoUrl: workspace.sourceRepoUrl || '',
       customDockerfileCommands: workspace.customDockerfileCommands || '',
       description: workspace.description || '',
       setupScript: workspace.setupScript || '',

--- a/frontend/src/pages/workspaces/ListWorkspaces.tsx
+++ b/frontend/src/pages/workspaces/ListWorkspaces.tsx
@@ -81,7 +81,7 @@ export function ListWorkspaces() {
             >
               <div className='text-lg'>{workspace.name || 'Untitled workspace'}</div>
               <div className='opacity-60 text-sm'>
-                {workspace.repositoryFullName || 'Repository not selected'}
+                {workspace.sourceRepoUrl || 'Repository not selected'}
               </div>
             </Link>
             <Link

--- a/frontend/src/pages/workspaces/WorkspaceEditorForm.tsx
+++ b/frontend/src/pages/workspaces/WorkspaceEditorForm.tsx
@@ -43,9 +43,9 @@ export function WorkspaceEditorForm(props: Props) {
           <input type='hidden' {...form.register('authAccountId')} />
           <input
             type='hidden'
-            {...form.register('repositoryId', { valueAsNumber: true })}
+            {...form.register('sourceRepoUrl')}
           />
-          <input type='hidden' {...form.register('repositoryFullName')} />
+
           <div className='relaxed w-full'>
             <Controller
               control={form.control}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,8 +11,7 @@ model Workspace {
 
   name                     String
   description              String   @default("")
-  repositoryId             Int      @map("repository_id")
-  repositoryFullName       String   @map("repository_full_name")
+  sourceRepoUrl            String?  @map("source_repo_url")
   customDockerfileCommands String   @default("") @map("custom_dockerfile_commands")
   setupScript              String   @default("") @map("setup_script")
   postScript               String   @default("") @map("post_script")
@@ -56,7 +55,6 @@ model Task {
   issueLink String? @map("issue_link")
 
   // Git source
-  sourceRepoUrl   String? @map("source_repo_url")
   sourceGitBranch String? @map("source_git_branch")
 
   // Git push


### PR DESCRIPTION
### Motivation
- Align the data model so a Workspace stores its source repository URL as `sourceRepoUrl` rather than keeping `repositoryId` / `repositoryFullName`. 
- Ensure tasks do not persist a repository URL on the Task record and instead use the workspace's `sourceRepoUrl` at runtime.

### Description
- Updated the Prisma schema to add `Workspace.sourceRepoUrl` (@map("source_repo_url")) and removed `Workspace.repositoryId`, `Workspace.repositoryFullName` and `Task.sourceRepoUrl` from the schema. 
- Switched shared Zod request schemas to accept `sourceRepoUrl` for workspace create/update and removed `repoUrl` from the task create schema. 
- Adjusted Electron API workspace creation to persist `sourceRepoUrl` into the database and include it in created workspace payloads. 
- Stopped persisting a repository URL on task creation and changed Task runtime code to read the repo URL from `workspace.sourceRepoUrl` with defensive logging/guards in `TaskManager` and `TaskInstance`, and updated Docker build logic to use the workspace field. 
- Updated frontend workspace forms and picker to bind to `sourceRepoUrl` (hidden input wiring, defaults, reset behavior and list display) and adjusted the repository picker to map selection into `sourceRepoUrl`.

### Testing
- Ran `yarn prisma generate` successfully to regenerate the client after schema changes. 
- Ran `yarn typecheck` across workspaces and the top-level monorepo and it completed successfully. 
- Ran `yarn lint --fix` and applied automatic fixes with no remaining reported errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b91f27cd48322905b61cf2b6c7dd4)