### PR TITLE
feat(tasks): show task state chips in tasks sidebar

### DIFF
--- a/frontend/src/pages/tasks/TasksSidebar.tsx
+++ b/frontend/src/pages/tasks/TasksSidebar.tsx
@@ -13,7 +13,7 @@ import { dispatch, useSelector } from '@frontend/framework/store'
 import { taskActions } from '@frontend/framework/redux/stores/tasks'
 
 // User interface
-import { Button, Card, Tooltip } from '@heroui/react'
+import { Button, Card, Chip, Tooltip } from '@heroui/react'
 
 // Misc
 import { getTaskViewUrl, UrlTree } from '@common/urls'
@@ -36,6 +36,43 @@ function getSelectedTaskId(pathname: string) {
 
   const pathParts = pathname.split('/')
   return pathParts[2]
+}
+
+function getTaskStateColor(taskState: Task['state']) {
+  if (taskState === 'Working') {
+    return 'primary'
+  }
+
+  if (taskState === 'Validating') {
+    return 'warning'
+  }
+
+  if (taskState === 'Reviewing' || taskState === 'AwaitingReview') {
+    return 'secondary'
+  }
+
+  if (taskState === 'Failed') {
+    return 'danger'
+  }
+
+  if (taskState === 'SettingUp') {
+    return 'default'
+  }
+
+  console.debug('TasksSidebar received unknown task state, using default chip color', { taskState })
+  return 'default'
+}
+
+function getTaskStateLabel(taskState: Task['state']) {
+  if (taskState === 'AwaitingReview') {
+    return 'Awaiting Review'
+  }
+
+  if (taskState === 'SettingUp') {
+    return 'Setting Up'
+  }
+
+  return taskState
 }
 
 export function TasksSidebar() {
@@ -110,8 +147,18 @@ export function TasksSidebar() {
               <div className='level'>
                 <Link to={getTaskViewUrl(task.id)} className='block min-w-0 flex-1'>
                   <div className='text-sm font-semibold truncate'>{task.name || 'Untitled task'}</div>
-                  <div className='text-xs opacity-60 truncate'>
-                    {getWorkspaceLabel(workspaces, task.workspaceId)}
+                  <div className='compact flex items-center gap-2'>
+                    <Chip
+                      size='sm'
+                      variant='flat'
+                      color={getTaskStateColor(task.state)}
+                      className='max-w-full'
+                    >
+                      <span className='truncate'>{getTaskStateLabel(task.state)}</span>
+                    </Chip>
+                    <div className='min-w-0 text-xs opacity-60 truncate'>
+                      {getWorkspaceLabel(workspaces, task.workspaceId)}
+                    </div>
                   </div>
                 </Link>
                 <Tooltip content='Delete Task'>


### PR DESCRIPTION
### Motivation

- Surface each task's `state` in the sidebar so users can quickly scan progress without opening a task. 
- Use a compact, styled HeroUI `Chip` with color semantics to make task states visually distinct and pleasant.

### Description

- Imported `Chip` from `@heroui/react` and rendered a small metadata row for each task showing a state `Chip` and the workspace label. 
- Added `getTaskStateColor` helper to map `Task.state` values to HeroUI color variants and `getTaskStateLabel` to produce readable labels for special cases. 
- Kept the existing layout and delete action, and added a defensive `console.debug` fallback for unknown states so unexpected values are logged instead of failing silently. 

### Testing

- Ran `yarn typecheck` which failed in this environment due to pre-existing Prisma client type export issues unrelated to this UI change. 
- Ran `yarn --cwd frontend typecheck` which failed for the same pre-existing Prisma typing problems. 
- Attempted a Playwright script to capture a screenshot of `/tasks`, but the dev server was not serving on port `5173` and the navigation failed with `net::ERR_EMPTY_RESPONSE` so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b986a55dc8322ab1cfde2dd3fa8e7)