### PR TITLE
CreateWorkspace: switch from Form submit to direct onPress handler

### DIFF
--- a/frontend/src/pages/workspaces/CreateWorkspace.tsx
+++ b/frontend/src/pages/workspaces/CreateWorkspace.tsx
@@ -10,7 +10,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 // UI
-import { Button, Form } from '@heroui/react'
+import { Button } from '@heroui/react'
 import { WorkspaceEditorForm } from './WorkspaceEditorForm'
 
 // Misc
@@ -61,18 +61,21 @@ export function CreateWorkspace() {
     })
   }, [])
 
-  const onSubmit = useCallback(() => form.handleSubmit(
-    async (data) => {
-      try {
-        console.log(data)
-        await createWorkspace(data)
-        navigate(UrlTree.tasksList)
-      }
-      catch (error) {
-        console.debug('CreateWorkspace failed to submit form', { error })
-      }
-    },
-    ), [])
+  const handleSubmit = useCallback(async function handleSubmit() {
+    const submitWithValidation = form.handleSubmit(
+      async function submitWithValidation(data) {
+        try {
+          await createWorkspace(data)
+          navigate(UrlTree.tasksList)
+        }
+        catch (error) {
+          console.debug('CreateWorkspace failed to submit form', { error })
+        }
+      },
+    )
+
+    await submitWithValidation()
+  }, [ form, navigate ])
 
   return <section className='container p-6'>
     <div className='relaxed'>
@@ -83,23 +86,22 @@ export function CreateWorkspace() {
         Define a workspace with its repository, scripts, and environment values.
       </p>
     </div>
-    <Form onSubmit={onSubmit} className='relaxed'>
+    <div className='relaxed'>
       <WorkspaceEditorForm
         form={form}
         isFormLocked={isFormLocked}
         autoFocusWorkspaceName
         onBuildStateChange={handleBuildStateChange}
         footer={<Button
-          type='submit'
           color='primary'
           className='mx-auto'
           isLoading={form.formState.isSubmitting}
           isDisabled={isFormLocked}
-          onPress={() => onSubmit()}
+          onPress={handleSubmit}
         >
           <span>Create Workspace</span>
         </Button>}
       />
-    </Form>
+    </div>
   </section>
 }


### PR DESCRIPTION
### Motivation
- Prefer a direct button `onPress` submission flow instead of relying on a `<Form>`/`type='submit'` behavior so the page matches the Edit flow and the requested UX pattern.

### Description
- Removed the `Form` import and wrapper in `frontend/src/pages/workspaces/CreateWorkspace.tsx` and replaced it with a simple container `div` and an explicit `handleSubmit` that invokes `form.handleSubmit(...)` for validation and submission. 
- Replaced the footer button's `type='submit'` behavior with `onPress={handleSubmit}` and removed a stray `console.log` left in the create flow. 
- Preserved the existing validation and API call to `createWorkspace` and the navigation to `UrlTree.tasksList`.

### Testing
- Ran the frontend typecheck with `yarn typecheck`, which failed due to existing repository-wide `@prisma/client` type export issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9935b17883228b5d1dead18bef95)