### PR TITLE
Add TaskInstance.executeCmd to run bash commands inside task container

### DIFF
--- a/electron/src/tasks/taskInstance.ts
+++ b/electron/src/tasks/taskInstance.ts
@@ -34,6 +34,13 @@ type EventMap = {
   'message': [ unknown ]
 }
 
+type ExecuteCommandResult = {
+  command: string
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
 export class TaskInstance extends EventEmitter<EventMap> {
   private task: TaskWithFullContext
   private containerExists: boolean
@@ -364,5 +371,91 @@ export class TaskInstance extends EventEmitter<EventMap> {
 
     const payload = `${JSON.stringify(message)}\n`
     this.ioStream.write(payload)
+  }
+
+  public async executeCmd(command: string): Promise<ExecuteCommandResult> {
+    const containerId = this.containerId
+    if (!containerId) {
+      console.debug('TaskInstance executeCmd requested without container id', {
+        taskId: this.task.id,
+        command,
+      })
+      throw new Error('Cannot execute command without a container id')
+    }
+
+    const dockerClient = getDockerClient()
+    if (!dockerClient) {
+      console.debug('TaskInstance executeCmd requested without docker client', {
+        taskId: this.task.id,
+        containerId,
+        command,
+      })
+      throw new Error('Docker client is not available')
+    }
+
+    const container = dockerClient.getContainer(containerId)
+    const execInstance = await container.exec({
+      AttachStdout: true,
+      AttachStderr: true,
+      Cmd: [ 'bash', '-lc', command ],
+    })
+
+    const stdoutStream = new PassThrough()
+    const stderrStream = new PassThrough()
+    const stdoutChunks: Buffer[] = []
+    const stderrChunks: Buffer[] = []
+
+    function handleStdoutData(chunk: Buffer) {
+      stdoutChunks.push(chunk)
+    }
+
+    function handleStderrData(chunk: Buffer) {
+      stderrChunks.push(chunk)
+    }
+
+    function handleStreamError(this: TaskInstance, error: Error) {
+      console.debug('TaskInstance executeCmd stream error', {
+        taskId: this.task.id,
+        containerId,
+        command,
+        error,
+      })
+    }
+
+    stdoutStream.on('data', handleStdoutData)
+    stderrStream.on('data', handleStderrData)
+
+    const executionStream = await execInstance.start({
+      hijack: true,
+      stdin: false,
+    })
+
+    executionStream.on('error', handleStreamError.bind(this))
+    dockerClient.modem.demuxStream(executionStream, stdoutStream, stderrStream)
+
+    await new Promise<void>((resolve, reject) => {
+      function handleEnd() {
+        resolve()
+      }
+
+      function handleError(error: Error) {
+        reject(error)
+      }
+
+      executionStream.once('end', handleEnd)
+      executionStream.once('error', handleError)
+    })
+
+    const inspectionResult = await execInstance.inspect()
+    const exitCode = inspectionResult.ExitCode ?? -1
+    const stdout = Buffer.concat(stdoutChunks).toString('utf8')
+    const stderr = Buffer.concat(stderrChunks).toString('utf8')
+
+    return {
+      command,
+      stdout,
+      stderr,
+      exitCode,
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a helper on `TaskInstance` to run arbitrary shell commands inside the task's Docker container (so pipelines like `ls -lah -R | grep node_modules` can be executed from code). 

### Description
- Added a new `ExecuteCommandResult` type and implemented `public async executeCmd(command: string)` on `TaskInstance` which runs the command via Docker exec with `bash -lc` and returns `{ command, stdout, stderr, exitCode }`.
- The method demuxes stdout/stderr into buffers, inspects the exec instance for the exit code, and includes guard rails that log and throw if the container id or Docker client are missing.

### Testing
- Ran `yarn --cwd electron typecheck` which reported pre-existing `@prisma/client` export issues unrelated to this change so the workspace typecheck failed overall.
- Ran top-level `yarn typecheck` which also failed for the same pre-existing Prisma-related errors and is not caused by this PR.
- Verified there are no TypeScript errors emitted for `electron/src/tasks/taskInstance.ts` by filtering the typecheck output for `taskInstance.ts` (no errors reported for this file).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9fb2d1d08322a3c91e4e942988a8)