### PR TITLE
Add shared time util and show Created/Updated columns with tooltips in settings lists

### DIFF
--- a/common/src/time.ts
+++ b/common/src/time.ts
@@ -1,0 +1,8 @@
+// Copyright © 2026 Jalapeno Labs
+
+import moment from 'moment'
+
+export { moment }
+
+export const STANDARD_TIME_FORMAT_FULL = 'MMMM Do YYYY [at] h:mm:ssa'
+export const STANDARD_TIME_FORMAT_SHORT = 'MMM Do [at] h:mma'

--- a/electron/src/api/routes/v1/protected/accounts/accountSanitizer.ts
+++ b/electron/src/api/routes/v1/protected/accounts/accountSanitizer.ts
@@ -15,6 +15,7 @@ export type AccountSummary = {
   scope: string
   lastUsedAt: Date | null
   createdAt: Date
+  updatedAt: Date
 }
 
 export function sanitizeAccount(account: AuthAccount): AccountSummary {
@@ -28,5 +29,6 @@ export function sanitizeAccount(account: AuthAccount): AccountSummary {
     scope: account.scope,
     lastUsedAt: account.lastUsedAt,
     createdAt: account.createdAt,
+    updatedAt: account.updatedAt,
   }
 }

--- a/frontend/src/lib/routes/accountsRoutes.ts
+++ b/frontend/src/lib/routes/accountsRoutes.ts
@@ -19,6 +19,7 @@ export type ConnectedAccount = {
   scope: string
   lastUsedAt: string | null
   createdAt: string
+  updatedAt: string
 }
 
 export type GithubRepoSummary = {

--- a/frontend/src/pages/accounts/ConnectedAccounts.tsx
+++ b/frontend/src/pages/accounts/ConnectedAccounts.tsx
@@ -19,6 +19,11 @@ import { addToast } from '@heroui/toast'
 import { CreateAccountDrawer } from './CreateAccountDrawer'
 
 // Misc
+import {
+  moment,
+  STANDARD_TIME_FORMAT_FULL,
+  STANDARD_TIME_FORMAT_SHORT,
+} from '@common/time'
 import { DeleteIcon, EditBulkIcon, PlusIcon } from '@frontend/common/IconNexus'
 import {
   addAccount,
@@ -102,6 +107,26 @@ async function parseAddAccountError(error: unknown): Promise<string | null> {
   }
 
   return message
+}
+
+
+function formatTimestamp(dateIso: string | Date) {
+  const parsedDate = moment(dateIso)
+
+  if (!parsedDate.isValid()) {
+    console.debug('ConnectedAccounts received invalid timestamp for formatting', {
+      dateIso,
+    })
+    return {
+      short: 'Unknown',
+      full: 'Unknown timestamp',
+    }
+  }
+
+  return {
+    short: parsedDate.format(STANDARD_TIME_FORMAT_SHORT),
+    full: parsedDate.format(STANDARD_TIME_FORMAT_FULL),
+  }
 }
 
 function applyCreatedAccount(response: AddAccountResponse) {
@@ -253,20 +278,25 @@ export function ConnectedAccounts() {
   }
   else {
     content = <Card className='relaxed p-2'>
-      <div className='grid grid-cols-12 gap-4 px-4 py-3 text-sm opacity-70'>
-        <div className='col-span-3'>Account</div>
+      <div className='grid grid-cols-14 gap-4 px-4 py-3 text-sm opacity-70'>
+        <div className='col-span-2'>Account</div>
         <div className='col-span-2'>GitHub user</div>
         <div className='col-span-3'>Email</div>
         <div className='col-span-2'>Token</div>
-        <div className='col-span-2 text-right'>Actions</div>
+        <div className='col-span-2'>Created at</div>
+        <div className='col-span-2'>Updated at</div>
+        <div className='col-span-1 text-right'>Actions</div>
       </div>
       <div className='divide-y'>
-        {accounts.map((account) =>
-          <div
+        {accounts.map((account) => {
+          const createdAt = formatTimestamp(account.createdAt)
+          const updatedAt = formatTimestamp(account.updatedAt)
+
+          return <div
             key={account.id}
-            className='grid grid-cols-12 items-center gap-4 px-4 py-4'
+            className='grid grid-cols-14 items-center gap-4 px-4 py-4'
           >
-            <div className='col-span-3'>
+            <div className='col-span-2'>
               <div className='text-lg'>{account.name}</div>
             </div>
             <div className='col-span-2'>
@@ -278,7 +308,17 @@ export function ConnectedAccounts() {
             <div className='col-span-2'>
               <div className='text-sm opacity-80'>{account.tokenPreview}</div>
             </div>
-            <div className='col-span-2 text-right'>
+            <div className='col-span-2'>
+              <Tooltip content={createdAt.full}>
+                <div className='text-sm opacity-80 w-fit'>{createdAt.short}</div>
+              </Tooltip>
+            </div>
+            <div className='col-span-2'>
+              <Tooltip content={updatedAt.full}>
+                <div className='text-sm opacity-80 w-fit'>{updatedAt.short}</div>
+              </Tooltip>
+            </div>
+            <div className='col-span-1 text-right'>
               <div className='level-right gap-2'>
                 <Tooltip content='Edit account'>
                   <Button
@@ -305,8 +345,8 @@ export function ConnectedAccounts() {
                 </Tooltip>
               </div>
             </div>
-          </div>,
-        )}
+          </div>
+        })}
       </div>
     </Card>
   }

--- a/frontend/src/pages/llms/Llms.tsx
+++ b/frontend/src/pages/llms/Llms.tsx
@@ -17,6 +17,11 @@ import { dispatch, useSelector } from '@frontend/framework/store'
 import { Button, Card, Chip, Tooltip } from '@heroui/react'
 
 // Misc
+import {
+  moment,
+  STANDARD_TIME_FORMAT_FULL,
+  STANDARD_TIME_FORMAT_SHORT,
+} from '@common/time'
 import { DeleteIcon, EditBulkIcon, PlusIcon } from '@frontend/common/IconNexus'
 import { deleteLlm, listLlms, updateLlm } from '@frontend/lib/routes/llmRoutes'
 import { CreateLlmDrawer } from './CreateLlmDrawer'
@@ -59,6 +64,26 @@ function getLlmName(llm: LlmRecord) {
 
   const display = getLlmDisplay(llm.type)
   return display.label
+}
+
+
+function formatTimestamp(dateIso: string | Date) {
+  const parsedDate = moment(dateIso)
+
+  if (!parsedDate.isValid()) {
+    console.debug('LLMs received invalid timestamp for formatting', {
+      dateIso,
+    })
+    return {
+      short: 'Unknown',
+      full: 'Unknown timestamp',
+    }
+  }
+
+  return {
+    short: parsedDate.format(STANDARD_TIME_FORMAT_SHORT),
+    full: parsedDate.format(STANDARD_TIME_FORMAT_FULL),
+  }
 }
 
 function getUsageLabel(llm: LlmRecord) {
@@ -178,6 +203,8 @@ export function Llms() {
     const display = getLlmDisplay(llm.type)
     const llmName = getLlmName(llm)
     const usageLabel = getUsageLabel(llm)
+    const createdAt = formatTimestamp(llm.createdAt)
+    const updatedAt = formatTimestamp(llm.updatedAt)
 
     let defaultChip = null
     if (llm.isDefault) {
@@ -193,9 +220,9 @@ export function Llms() {
 
     return <div
       key={llm.id}
-      className='group relative grid grid-cols-12 items-center gap-4 px-4 py-4'
+      className='group relative grid grid-cols-14 items-center gap-4 px-4 py-4'
     >
-      <div className='col-span-4 flex items-center gap-3'>
+      <div className='col-span-3 flex items-center gap-3'>
         <div className='h-10 w-10 overflow-hidden rounded-full border border-black/10'>
           <img
             src={display.logoUrl}
@@ -214,8 +241,18 @@ export function Llms() {
       <div className='col-span-3'>
         <div className='text-sm opacity-80'>{preferredModel}</div>
       </div>
-      <div className='col-span-3'>
+      <div className='col-span-2'>
         <div className='text-sm opacity-80'>{usageLabel}</div>
+      </div>
+      <div className='col-span-2'>
+        <Tooltip content={createdAt.full}>
+          <div className='text-sm opacity-80 w-fit'>{createdAt.short}</div>
+        </Tooltip>
+      </div>
+      <div className='col-span-2'>
+        <Tooltip content={updatedAt.full}>
+          <div className='text-sm opacity-80 w-fit'>{updatedAt.short}</div>
+        </Tooltip>
       </div>
       <div className='col-span-2'>
         <div className='flex items-center justify-end gap-2'>
@@ -307,10 +344,12 @@ export function Llms() {
       </Button>
     </div>
     <Card className='relaxed p-2'>
-      <div className='grid grid-cols-12 gap-4 px-4 py-3 text-sm opacity-70'>
-        <div className='col-span-4'>LLM</div>
+      <div className='grid grid-cols-14 gap-4 px-4 py-3 text-sm opacity-70'>
+        <div className='col-span-3'>LLM</div>
         <div className='col-span-3'>Preferred Model</div>
-        <div className='col-span-3'>Usage</div>
+        <div className='col-span-2'>Usage</div>
+        <div className='col-span-2'>Created at</div>
+        <div className='col-span-2'>Updated at</div>
         <div className='col-span-2 text-right'>Actions</div>
       </div>
       <div className='divide-y'>{

--- a/frontend/src/pages/workspaces/ListWorkspaces.tsx
+++ b/frontend/src/pages/workspaces/ListWorkspaces.tsx
@@ -11,9 +11,34 @@ import { dispatch, useSelector } from '@frontend/framework/store'
 import { workspaceActions } from '@frontend/framework/redux/stores/workspaces'
 
 // Misc
+import {
+  moment,
+  STANDARD_TIME_FORMAT_FULL,
+  STANDARD_TIME_FORMAT_SHORT,
+} from '@common/time'
 import { getWorkspaceEditUrl, UrlTree } from '@common/urls'
 import { DeleteIcon, EditBulkIcon } from '@frontend/common/IconNexus'
 import { deleteWorkspace } from '@frontend/lib/routes/workspaceRoutes'
+
+
+function formatTimestamp(dateIso: string | Date) {
+  const parsedDate = moment(dateIso)
+
+  if (!parsedDate.isValid()) {
+    console.debug('ListWorkspaces received invalid timestamp for formatting', {
+      dateIso,
+    })
+    return {
+      short: 'Unknown',
+      full: 'Unknown timestamp',
+    }
+  }
+
+  return {
+    short: parsedDate.format(STANDARD_TIME_FORMAT_SHORT),
+    full: parsedDate.format(STANDARD_TIME_FORMAT_FULL),
+  }
+}
 
 export function ListWorkspaces() {
   const workspaces = useSelector((state) => state.workspaces.items)
@@ -66,17 +91,23 @@ export function ListWorkspaces() {
     </div>
     <Card className='relaxed p-2'>
       <div className='grid grid-cols-12 gap-4 px-4 py-3 text-sm opacity-70'>
-        <div className='col-span-6'>Workspace</div>
-        <div className='col-span-6'>Description</div>
+        <div className='col-span-3'>Workspace</div>
+        <div className='col-span-3'>Description</div>
+        <div className='col-span-2'>Created at</div>
+        <div className='col-span-2'>Updated at</div>
+        <div className='col-span-2 text-right'>Actions</div>
       </div>
       <div className='divide-y'>
-        {workspaces.map((workspace) =>
-          <div
+        {workspaces.map((workspace) => {
+          const createdAt = formatTimestamp(workspace.createdAt)
+          const updatedAt = formatTimestamp(workspace.updatedAt)
+
+          return <div
             key={workspace.id}
             className='group relative grid grid-cols-12 gap-4 px-4 py-4 items-center hover:bg-content2/30'
           >
             <Link
-              className='col-span-6'
+              className='col-span-3'
               to={getWorkspaceEditUrl(workspace.id)}
             >
               <div className='text-lg'>{workspace.name || 'Untitled workspace'}</div>
@@ -85,14 +116,24 @@ export function ListWorkspaces() {
               </div>
             </Link>
             <Link
-              className='col-span-6'
+              className='col-span-3'
               to={getWorkspaceEditUrl(workspace.id)}
             >
               <div className='opacity-80 text-sm'>{
                 workspace.description || 'No description added yet.'
               }</div>
             </Link>
-            <div className='absolute right-4 top-1/2 -translate-y-1/2'>
+            <div className='col-span-2'>
+              <Tooltip content={createdAt.full}>
+                <div className='text-sm opacity-80 w-fit'>{createdAt.short}</div>
+              </Tooltip>
+            </div>
+            <div className='col-span-2'>
+              <Tooltip content={updatedAt.full}>
+                <div className='text-sm opacity-80 w-fit'>{updatedAt.short}</div>
+              </Tooltip>
+            </div>
+            <div className='col-span-2'>
               <div className='flex items-center justify-end gap-2 opacity-0 transition-opacity group-hover:opacity-100'>
                 <Tooltip content='Edit workspace'>
                   <Button
@@ -121,8 +162,8 @@ export function ListWorkspaces() {
                 </Tooltip>
               </div>
             </div>
-          </div>,
-        )}
+          </div>
+        })}
       </div>
     </Card>
   </section>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "hjson": "^3.2.2",
     "humanize-duration": "^3.33.0",
     "lodash-es": "^4.17.21",
+    "moment": "^2.30.1",
     "node-global-key-listener": "^0.3.0",
     "openai": "^5.7.0",
     "prisma": "7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12083,6 +12083,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moment@npm:^2.30.1":
+  version: 2.30.1
+  resolution: "moment@npm:2.30.1"
+  checksum: 10c0/865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a
+  languageName: node
+  linkType: hard
+
 "monaco-editor@npm:^0.55.1":
   version: 0.55.1
   resolution: "monaco-editor@npm:0.55.1"
@@ -14198,6 +14205,7 @@ __metadata:
     hjson: "npm:^3.2.2"
     humanize-duration: "npm:^3.33.0"
     lodash-es: "npm:^4.17.21"
+    moment: "npm:^2.30.1"
     node-global-key-listener: "npm:^0.3.0"
     openai: "npm:^5.7.0"
     prisma: "npm:7"


### PR DESCRIPTION
### Motivation
- Provide a single, shared time formatter and canonical formats so all settings pages render timestamps consistently. 
- Surface created/updated timestamps for LLMs, Workspaces and Connected Accounts so users can see when records were created/modified.

### Description
- Added `common/src/time.ts` which re-exports `moment` and exports `STANDARD_TIME_FORMAT_FULL` and `STANDARD_TIME_FORMAT_SHORT` for shared formatting.  
- Added `moment` to workspace dependencies and updated `yarn.lock` so frontend and common can import it.  
- Extended connected-account shapes end-to-end by including `updatedAt` in the backend sanitizer (`electron/.../accountSanitizer.ts`) and the frontend route type (`frontend/src/lib/routes/accountsRoutes.ts`).  
- Updated UI lists to add `Created at` and `Updated at` columns that render the short format in the table and show the full timestamp in a HeroUI `Tooltip` on LLMs (`frontend/src/pages/llms/Llms.tsx`), Workspaces (`frontend/src/pages/workspaces/ListWorkspaces.tsx`) and Connected Accounts (`frontend/src/pages/accounts/ConnectedAccounts.tsx`), using a local `formatTimestamp` helper that logs invalid timestamps defensively.

### Testing
- Ran `yarn eslint` against the modified files which completed without lint errors.  
- Installed `moment` via `yarn add moment` successfully and updated `yarn.lock`.  
- Ran workspace type checking with `yarn typecheck` and `yarn --cwd frontend typecheck`, both of which failed due to an existing Prisma client type-generation mismatch in the environment and not caused by these changes.  
- Launched the frontend dev server and captured a screenshot of the updated settings page to validate the UI change (`browser:/tmp/codex_browser_invocations/.../settings-timestamps.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba68d31d08322a551139bbd9c2b2b)