### PR TITLE
Add AuthAccount selector to Empty Task form and include `authAccountId` in task creation

### DIFF
--- a/frontend/src/pages/tasks/Tasks.tsx
+++ b/frontend/src/pages/tasks/Tasks.tsx
@@ -30,6 +30,7 @@ type TaskRouteParams = {
 type TaskDraft = {
   message: string
   workspaceId: string
+  authAccountId: string
   llmId: string
 }
 
@@ -40,6 +41,7 @@ export function Tasks() {
   const tasks = useSelector((state) => state.tasks.items)
   const workspaces = useSelector((state) => state.workspaces.items)
   const llms = useSelector((state) => state.llms.items)
+  const authAccounts = useSelector((state) => state.accounts.items)
 
   const selectedTask = taskId
     ? tasks.find((task) => task.id === taskId)
@@ -73,12 +75,19 @@ export function Tasks() {
       return
     }
 
+    const authAccount = authAccounts.find((entry) => entry.id === draft.authAccountId)
+    if (!authAccount) {
+      console.debug('Tasks cannot create a task without an auth account', { draft })
+      return
+    }
+
     setIsSubmitting(true)
 
     try {
       const response = await createTask({
         userId: user.id,
         workspaceId: workspace.id,
+        authAccountId: authAccount.id,
         llmId: draft.llmId,
         message: draft.message,
         branch: DEFAULT_TASK_BRANCH,


### PR DESCRIPTION
### Motivation

- The backend and validators expect an `authAccountId` on task creation, so the empty-task UI needs a picker for users to choose which connected auth account to use.

### Description

- Added `authAccountId` to the `TaskDraft` type and component state in `frontend/src/pages/tasks/EmptyTaskView.tsx` and default-selected the first connected account from Redux (`state.accounts.items`).
- Introduced an `Auth account` dropdown (`Select`) with selection handler `handleAuthAccountSelection` and a `getAuthAccountLabel` helper to render readable account labels.\
- Wired `authAccountId` into the submit flow in `EmptyTaskView` with validation and explicit debug logs for missing/invalid selection to avoid silent failures.\
- Updated `frontend/src/pages/tasks/Tasks.tsx` to read `accounts` from Redux, validate the picked `authAccount`, and include `authAccountId` in the payload sent to `createTask`.

### Testing

- Ran TypeScript typecheck with `yarn --cwd frontend typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bac14f4088322aefbfa8768021976)