### PR TITLE
Add task archive endpoint and archive action in tasks sidebar

### DIFF
--- a/electron/src/api/routes/v1/protected/tasks/archiveTaskRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/archiveTaskRoute.ts
@@ -1,0 +1,54 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Request, Response } from 'express'
+
+// Lib
+import { z } from 'zod'
+
+// Utility
+import { parseRequestParams } from '../../validation'
+
+// Misc
+import { getTaskManager } from '@electron/tasks/taskManager'
+
+type RouteParams = {
+  taskId: string
+}
+
+const taskParamsSchema = z.object({
+  taskId: z.string().trim().min(1),
+})
+
+export async function handleArchiveTaskRequest(
+  request: Request<RouteParams>,
+  response: Response,
+): Promise<void> {
+  const params = parseRequestParams(
+    taskParamsSchema,
+    request,
+    response,
+    {
+      context: 'Archive task API',
+      errorMessage: 'Task ID is required',
+    },
+  )
+  if (!params) {
+    return
+  }
+
+  try {
+    const taskManager = getTaskManager()
+    const result = await taskManager.archiveTask(params.taskId)
+
+    if (result.status === 'error') {
+      response.status(result.httpStatus).json({ error: result.error })
+      return
+    }
+
+    response.status(200).json({ archived: true, taskId: result.taskId })
+  }
+  catch (error) {
+    console.error('Failed to archive task', error)
+    response.status(500).json({ error: 'Failed to archive task' })
+  }
+}

--- a/electron/src/api/routes/v1/protected/tasks/listTasksRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/listTasksRoute.ts
@@ -13,6 +13,7 @@ export async function handleListTasksRequest(
 
   try {
     const tasks = await databaseClient.task.findMany({
+      where: { archived: false },
       orderBy: { createdAt: 'desc' },
     })
     response.status(200).json({ tasks })

--- a/electron/src/api/routes/v1/protected/tasksRouter.ts
+++ b/electron/src/api/routes/v1/protected/tasksRouter.ts
@@ -6,6 +6,7 @@ import type { Router } from 'express'
 import { Router as createRouter } from 'express'
 
 // Misc
+import { handleArchiveTaskRequest } from './tasks/archiveTaskRoute'
 import { handleCreateTaskRequest } from './tasks/createTaskRoute'
 import { handleDeleteTaskRequest } from './tasks/deleteTaskRoute'
 import { handleGetTaskRequest } from './tasks/getTaskRoute'
@@ -32,6 +33,8 @@ export function createTasksRouter(): Router {
   tasksRouter.patch('/:taskId', handleUpdateTaskRequest)
   // /api/v1/protected/tasks/:taskId
   tasksRouter.delete('/:taskId', handleDeleteTaskRequest)
+  // /api/v1/protected/tasks/:taskId/archive
+  tasksRouter.delete('/:taskId/archive', handleArchiveTaskRequest)
   // /api/v1/protected/tasks/:taskId/git/refresh
   tasksRouter.post('/:taskId/git/refresh', handleRefreshTaskGitRequest)
   // /api/v1/protected/tasks/:taskId/git/re-up

--- a/electron/src/tasks/types.ts
+++ b/electron/src/tasks/types.ts
@@ -23,3 +23,14 @@ export type DeleteTaskResult =
     status: 'deleted'
     taskId: string
   }
+
+export type ArchiveTaskResult =
+  | {
+    status: 'error'
+    error: string
+    httpStatus: number
+  }
+  | {
+    status: 'archived'
+    taskId: string
+  }

--- a/frontend/src/common/IconNexus.tsx
+++ b/frontend/src/common/IconNexus.tsx
@@ -1,7 +1,7 @@
 // Copyright © 2026 Jalapeno Labs
 
 import { GoPlusCircle } from 'react-icons/go'
-import { MdEditDocument, MdOutlineSettings, MdLogout } from 'react-icons/md'
+import { MdArchive, MdEditDocument, MdOutlineSettings, MdLogout } from 'react-icons/md'
 import { FaRegTrashAlt, FaRegUserCircle } from 'react-icons/fa'
 import { IoWarningOutline } from 'react-icons/io5'
 
@@ -9,6 +9,7 @@ export const WarningIcon = IoWarningOutline
 export const EditBulkIcon = MdEditDocument
 export const PlusIcon = GoPlusCircle
 export const DeleteIcon = FaRegTrashAlt
+export const ArchiveIcon = MdArchive
 export const UserIcon = FaRegUserCircle
 export const SettingsIcon = MdOutlineSettings
 export const ExitIcon = MdLogout

--- a/frontend/src/lib/routes/taskRoutes.ts
+++ b/frontend/src/lib/routes/taskRoutes.ts
@@ -60,6 +60,12 @@ export function deleteTask(taskId: string) {
     .delete(`v1/protected/tasks/${taskId}`)
 }
 
+
+export function archiveTask(taskId: string) {
+  return apiClient
+    .delete(`v1/protected/tasks/${taskId}/archive`)
+}
+
 type TaskGitActionResponse = {
   message: string
 }


### PR DESCRIPTION
### Motivation

- Tasks need an "archive" flow so users can hide tasks without deleting them and the backend can retain records for auditing or restoration.
- The UI should provide a safe, confirmable way to archive a task that mirrors the existing delete flow so users have consistent UX.

### Description

- Added a new protected API route `DELETE /api/v1/protected/tasks/:taskId/archive` with request validation and structured success/error responses (`electron/src/api/routes/v1/protected/tasks/archiveTaskRoute.ts`).
- Implemented `TaskManager.archiveTask` and `ArchiveTaskResult` to validate input, mark the task `archived: true` in the database, teardown any running container, remove in-memory instances, and broadcast an SSE update (`electron/src/tasks/taskManager.ts`, `electron/src/tasks/types.ts`).
- Excluded archived tasks from startup initialization and the tasks listing so archived items no longer appear in active lists (`electron/src/tasks/taskManager.ts`, `electron/src/api/routes/v1/protected/tasks/listTasksRoute.ts`).
- Added frontend support: `archiveTask` Ky helper (`frontend/src/lib/routes/taskRoutes.ts`), an archive icon export (`frontend/src/common/IconNexus.tsx`), and an archive button placed next to delete in the Tasks sidebar that uses `useConfirm` and updates Redux on success (`frontend/src/pages/tasks/TasksSidebar.tsx`).

### Testing

- Ran type checking with `yarn typecheck` and it succeeded.
- Ran linting with `yarn lint` and it succeeded.
- Launched the frontend with `yarn --cwd frontend dev` and visually verified the archive button and confirmation flow via a screenshot (used for visual verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be48132308322856ea76c8cf086a2)