### PR TITLE
Mark tasks with missing containers as ContainerBroken during startup

### DIFF
--- a/frontend/src/pages/tasks/TasksSidebar.tsx
+++ b/frontend/src/pages/tasks/TasksSidebar.tsx
@@ -34,6 +34,7 @@ import {
 const TASK_STATE_COLOR_BY_STATE: Record<TaskState, ChipProps['color']> = {
   Creating: 'default',
   SettingUp: 'default',
+  ContainerBroken: 'danger',
   Working: 'primary',
   Validating: 'warning',
   Halting: 'warning',

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ enum AuthProvider {
 enum TaskState {
   Creating
   SettingUp
+  ContainerBroken
   Working
   Validating
   Reviewing


### PR DESCRIPTION
### Motivation
- Ensure tasks loaded from the database that reference a persisted container id but whose Docker container no longer exists are represented with an explicit state instead of silently keeping an invalid container reference.
- Prevent UI/state confusion and make it easier to surface and handle broken container references programmatically.

### Description
- Added a new `TaskState.ContainerBroken` enum value in `prisma/schema.prisma` to represent tasks with missing persisted containers.
- Updated `electron/src/tasks/taskManager.ts` initialization so that after `TaskInstance.refreshContainerStatus()` returns false, tasks that have a persisted `container` (and are not `'pending'`) are logged and transitioned to `ContainerBroken` using `updateTaskState(...)` to persist and broadcast the change.
- Kept existing behavior for tasks with no persisted container id or with `container === 'pending'` by logging and skipping state changes.
- Updated `frontend/src/pages/tasks/TasksSidebar.tsx` to include `ContainerBroken` in the task state color map so the frontend renders the new state explicitly.

### Testing
- Ran `yarn tsc --noEmit` to typecheck the codebase, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0475c6588322aac3f326639494fe)