### PR TITLE
Add `gitBranchTemplate` to Workspace model, validators, API, and editor form

### DIFF
--- a/common/src/schema.ts
+++ b/common/src/schema.ts
@@ -34,6 +34,7 @@ export const workspaceEnvEntrySchema = z.object({
 export const workspaceCreateSchema = z.object({
   name: z.string().trim().min(1),
   sourceRepoUrl: z.string().trim().min(1),
+  gitBranchTemplate: z.string().trim().optional().default(''),
   customDockerfileCommands: z.string().trim().optional().default(''),
   description: z.string().trim().optional().default(''),
   setupScript: z.string().trim().optional().default(''),
@@ -45,6 +46,7 @@ export const workspaceCreateSchema = z.object({
 export const workspaceUpdateSchema = z.object({
   name: z.string().trim().min(1).optional(),
   sourceRepoUrl: z.string().trim().min(1).optional(),
+  gitBranchTemplate: z.string().trim().optional(),
   customDockerfileCommands: z.string().trim().optional(),
   description: z.string().trim().optional(),
   setupScript: z.string().trim().optional(),

--- a/electron/src/api/routes/v1/protected/workspaces/createWorkspaceRoute.ts
+++ b/electron/src/api/routes/v1/protected/workspaces/createWorkspaceRoute.ts
@@ -37,6 +37,7 @@ export async function handleCreateWorkspaceRequest(
   const {
     name,
     sourceRepoUrl,
+    gitBranchTemplate,
     customDockerfileCommands,
     description,
     setupScript,
@@ -49,6 +50,7 @@ export async function handleCreateWorkspaceRequest(
     const baseWorkspaceData = {
       name,
       sourceRepoUrl,
+      gitBranchTemplate,
       customDockerfileCommands,
       description,
       setupScript,

--- a/frontend/src/pages/workspaces/CreateWorkspace.tsx
+++ b/frontend/src/pages/workspaces/CreateWorkspace.tsx
@@ -26,6 +26,7 @@ const zodResolved = zodResolver(createWorkspaceSchema)
 const defaultValues: CreateWorkspaceFormValues = {
   name: '',
   sourceRepoUrl: '',
+  gitBranchTemplate: '',
   customDockerfileCommands: '',
   description: '',
   setupScript: 'yarn install',

--- a/frontend/src/pages/workspaces/EditWorkspace.tsx
+++ b/frontend/src/pages/workspaces/EditWorkspace.tsx
@@ -33,6 +33,7 @@ const zodResolved = zodResolver(createWorkspaceSchema)
 const defaultValues: EditWorkspaceFormValues = {
   name: '',
   sourceRepoUrl: '',
+  gitBranchTemplate: '',
   customDockerfileCommands: '',
   description: '',
   setupScript: '',
@@ -89,6 +90,7 @@ export function EditWorkspace() {
     form.reset({
       name: workspace.name,
       sourceRepoUrl: workspace.sourceRepoUrl || '',
+      gitBranchTemplate: workspace.gitBranchTemplate || '',
       customDockerfileCommands: workspace.customDockerfileCommands || '',
       description: workspace.description || '',
       setupScript: workspace.setupScript || '',

--- a/frontend/src/pages/workspaces/WorkspaceEditorForm.tsx
+++ b/frontend/src/pages/workspaces/WorkspaceEditorForm.tsx
@@ -90,6 +90,24 @@ export function WorkspaceEditorForm(props: Props) {
               )}
             />
           </div>
+          <div className='relaxed w-full'>
+            <Controller
+              control={form.control}
+              name='gitBranchTemplate'
+              render={({ field }) => (
+                <Input
+                  label='Git branch template'
+                  placeholder='anakin.skywalker-fix-#{issue-number}-3-to-5-word-task-description'
+                  className='w-full'
+                  isDisabled={isFormLocked}
+                  value={field.value}
+                  name={field.name}
+                  onValueChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+              )}
+            />
+          </div>
         </div>
         <div className='w-full'>
           <div>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Workspace {
   name                     String
   description              String   @default("")
   sourceRepoUrl            String?  @map("source_repo_url")
+  gitBranchTemplate        String   @default("") @map("git_branch_template")
   customDockerfileCommands String   @default("") @map("custom_dockerfile_commands")
   setupScript              String   @default("") @map("setup_script")
   postScript               String   @default("") @map("post_script")


### PR DESCRIPTION
### Motivation
- Provide a configurable branch naming template for workspaces so tasks and Git operations can use a consistent branch naming convention.
- Surface the template in the workspace editor so users can set a per-workspace default branch naming pattern with the requested placeholder.

### Description
- Add `gitBranchTemplate` to the Prisma `Workspace` model mapped to `git_branch_template` and regenerate the client so the DB model stores the field.
- Extend the shared Zod schemas `workspaceCreateSchema` and `workspaceUpdateSchema` to accept `gitBranchTemplate` for create and update payloads.
- Read and persist `gitBranchTemplate` in the create workspace API route payload so new workspaces store the value server-side.
- Add a `Git branch template` input to the frontend `WorkspaceEditorForm` with the placeholder `anakin.skywalker-fix-#{issue-number}-3-to-5-word-task-description` and wire default/hydration in `CreateWorkspace` and `EditWorkspace`.

### Testing
- Ran `yarn generate` to update generated artifacts (Prisma client) and it completed successfully.
- Ran `yarn typecheck` across the workspace and TypeScript type checking passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfe9731ec8322a27b5b5e2ce5ccb0)