### PR TITLE
Add optional issueLink field to task creation flow

### DIFF
--- a/common/src/schema.ts
+++ b/common/src/schema.ts
@@ -64,6 +64,7 @@ export const taskCreateSchema = z.object({
   llmId: z.string().trim().min(1),
   message: z.string().trim().min(1),
   branch: z.string().trim().min(1),
+  issueLink: z.string().optional(),
   archived: z.boolean().optional().default(false),
 }).strict()
 

--- a/electron/src/tasks/taskManager.ts
+++ b/electron/src/tasks/taskManager.ts
@@ -160,6 +160,7 @@ class TaskManager {
         name: taskName,
         sourceGitBranch: request.branch,
         workGitBranch: gitWorkBranchName,
+        issueLink: request.issueLink?.trim() || null,
         container: 'pending',
         containerName: resolvedContainerName,
         archived: request.archived,

--- a/frontend/src/pages/tasks/EmptyTaskView.tsx
+++ b/frontend/src/pages/tasks/EmptyTaskView.tsx
@@ -26,6 +26,7 @@ import {
   Card,
   Select,
   SelectItem,
+  Input,
   Textarea,
 } from '@heroui/react'
 
@@ -41,6 +42,7 @@ type TaskDraft = {
   authAccountId: string
   llmId: string
   branch: string
+  issueLink: string
 }
 
 type Props = {
@@ -66,6 +68,7 @@ export function EmptyTaskView(props: Props) {
   const [ authAccountId, setAuthAccountId ] = useState<string>('')
   const [ llmId, setLlmId ] = useState<string>('')
   const [ branch, setBranch ] = useState<string>('')
+  const [ issueLink, setIssueLink ] = useState<string>('')
   const [ branchSearchQuery, setBranchSearchQuery ] = useState<string>('')
 
   const debouncedBranchSearchQuery = useDebouncedState(branchSearchQuery, 250)
@@ -272,6 +275,7 @@ export function EmptyTaskView(props: Props) {
       authAccountId,
       llmId,
       branch,
+      issueLink: issueLink.trim(),
     })
   }
 
@@ -332,6 +336,15 @@ export function EmptyTaskView(props: Props) {
           autoFocus
           value={message}
           onValueChange={setMessage}
+          isDisabled={isSubmitting}
+        />
+      </div>
+      <div className='relaxed'>
+        <Input
+          label='Issue link (optional)'
+          placeholder='https://github.com/org/repo/issues/123'
+          value={issueLink}
+          onValueChange={setIssueLink}
           isDisabled={isSubmitting}
         />
       </div>

--- a/frontend/src/pages/tasks/Tasks.tsx
+++ b/frontend/src/pages/tasks/Tasks.tsx
@@ -31,6 +31,7 @@ type TaskDraft = {
   authAccountId: string
   llmId: string
   branch: string
+  issueLink: string
 }
 
 export function Tasks() {
@@ -90,6 +91,7 @@ export function Tasks() {
         llmId: draft.llmId,
         message: draft.message,
         branch: draft.branch,
+        issueLink: draft.issueLink || undefined,
         archived: false,
       })
 


### PR DESCRIPTION
### Motivation
- Allow users to optionally attach an external issue link when creating a task so it can be persisted and referenced with the task.
- Ensure the API accepts the new optional field and the frontend collects and forwards it from the empty task creation UI.

### Description
- Added `issueLink` as an optional string to the shared request validator `taskCreateSchema` in `common/src/schema.ts` so create requests are accepted by validation.
- Updated the empty task UI `EmptyTaskView` (`frontend/src/pages/tasks/EmptyTaskView.tsx`) to include an `Issue link (optional)` `Input`, state handling, and include `issueLink` in the submitted draft.
- Forwarded `issueLink` through the tasks flow in `Tasks` (`frontend/src/pages/tasks/Tasks.tsx`) so the create API receives the field.
- Persisted `issueLink` when creating tasks in `TaskManager.createTask` (`electron/src/tasks/taskManager.ts`) by setting `issueLink: request.issueLink?.trim() || null` in the `databaseClient.task.create` call.
- No Prisma model change was required because the `Task` model already contains `issueLink` mapped to `issue_link` in `prisma/schema.prisma`.

### Testing
- Ran `yarn typecheck`, which failed in this environment due to missing generated `@electron/vendor/codex-protocol` modules and not related to the changes introduced here.
- Started the frontend with `yarn --cwd frontend dev` and visually verified the new `Issue link` input in `EmptyTaskView` (screenshot captured successfully).
- No additional automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7878bef88322a94c00406f54e91d)