### PR TITLE
Add Redux-driven tasks list page with task item components

### DIFF
--- a/frontend/src/pages/tasks/ListTasksPage.tsx
+++ b/frontend/src/pages/tasks/ListTasksPage.tsx
@@ -1,5 +1,47 @@
 // Copyright © 2026 Jalapeno Labs
 
+import type { Task } from '@common/types'
+
+// Core
+import { Navigate, useNavigate } from 'react-router'
+
+// Redux
+import { useSelector } from '@frontend/framework/store'
+
+// User Interface
+import { TaskItemsList } from './TaskItemsList'
+
+// Misc
+import { UrlTree } from '@common/urls'
+
+function getTaskViewUrl(taskId: string) {
+  return UrlTree.viewTask.replace(':taskId', taskId)
+}
+
 export function ListTasksPage() {
-  return <></>
+  const navigate = useNavigate()
+  const tasks = useSelector((state) => state.tasks.items)
+
+  if (!tasks?.length) {
+    console.debug('ListTasksPage has no tasks in redux, redirecting to new task page')
+    return <Navigate to={UrlTree.newTasks} replace />
+  }
+
+  function handleSelectTask(task: Task) {
+    navigate(
+      getTaskViewUrl(task.id),
+    )
+  }
+
+  return <article className='relaxed'>
+    <header className='compact level'>
+      <div className='level-left'>
+        <h1 className='text-2xl font-bold'>Tasks</h1>
+      </div>
+    </header>
+    <TaskItemsList
+      tasks={tasks}
+      onSelectTask={handleSelectTask}
+    />
+  </article>
 }

--- a/frontend/src/pages/tasks/TaskItemsList.tsx
+++ b/frontend/src/pages/tasks/TaskItemsList.tsx
@@ -1,0 +1,26 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Task } from '@common/types'
+
+// User Interface
+import { Card } from '@frontend/elements/Card'
+import { TaskListItem } from './TaskListItem'
+
+type Props = {
+  tasks: Task[]
+  onSelectTask: (task: Task) => void
+}
+
+export function TaskItemsList(props: Props) {
+  return <Card>
+    <ul className='w-full'>{
+      props.tasks.map((task) => (
+        <TaskListItem
+          key={task.id}
+          task={task}
+          onSelect={props.onSelectTask}
+        />
+      ))
+    }</ul>
+  </Card>
+}

--- a/frontend/src/pages/tasks/TaskListItem.tsx
+++ b/frontend/src/pages/tasks/TaskListItem.tsx
@@ -1,0 +1,29 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Task } from '@common/types'
+
+// User Interface
+import { ListItem } from '../data/ListItem'
+
+type Props = {
+  task: Task
+  onSelect: (task: Task) => void
+}
+
+function getTaskDescription(task: Task) {
+  const status = task.state
+  const workspaceId = task.workspaceId
+
+  return `Status: ${status} • Workspace: ${workspaceId}`
+}
+
+export function TaskListItem(props: Props) {
+  const title = props.task.name?.trim() || `Untitled task ${props.task.id.slice(0, 8)}`
+
+  return <ListItem
+    id={props.task.id}
+    title={title}
+    description={getTaskDescription(props.task)}
+    onSelect={() => props.onSelect(props.task)}
+  />
+}


### PR DESCRIPTION
### Motivation
- Provide a frontend entry point for viewing tasks that reads the latest task list from the centralized Redux store via `useSelector`.
- Break the UI into small, testable components so each task row can be reused and styled consistently.
- Redirect users to a template "new task" page when there are no tasks to show so the app surfaces a clear next step.

### Description
- Implement `ListTasksPage` to read `state.tasks.items` from Redux with `useSelector` and redirect to `UrlTree.newTasks` when the list is empty, and navigate to the task view using `navigate` and `UrlTree.viewTask` when an item is selected (`frontend/src/pages/tasks/ListTasksPage.tsx`).
- Add `TaskItemsList` as a simple container that renders the whole collection inside a `Card` without pagination (`frontend/src/pages/tasks/TaskItemsList.tsx`).
- Add `TaskListItem` which adapts a `Task` into the existing `ListItem` UI, providing a readable fallback title and a short description with status/workspace (`frontend/src/pages/tasks/TaskListItem.tsx`).
- Keep the components focused and small: no pagination/limit logic was added and all navigation uses `UrlTree` helper functions.

### Testing
- Ran `yarn --cwd frontend typecheck`, which failed due to pre-existing unrelated issues (missing generated `@common/vendor/codex-protocol` types and existing LLM page type errors). (failed)
- Started the frontend dev server with `yarn --cwd frontend dev`, which launched but surfaced existing Tailwind/PostCSS configuration errors about a missing `./public/brand/theme.json` unrelated to this change. (server started with unrelated errors)
- Captured a browser screenshot of the `/tasks` page with a Playwright script, which successfully produced `browser:/tmp/codex_browser_invocations/9fabcd595017f2bd/artifacts/artifacts/tasks-list-page.png`. (successful)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa288f55b883228eb642689cafc974)