### PR TITLE
Add SSE endpoint and frontend hook to stream task messages

### DIFF
--- a/electron/src/api/express.ts
+++ b/electron/src/api/express.ts
@@ -18,7 +18,6 @@ import { notFoundMiddleware } from './middleware/notFoundMiddleware'
 import { errorMiddleware } from './middleware/errorMiddleware'
 import { createPublicRouter } from './routes/public/publicRouter'
 import { createProtectedRouter } from './routes/v1/protected/protectedRouter'
-import { handleStreamTaskMessagesRequest } from './routes/v1/protected/tasks/streamTaskMessagesRoute'
 
 // Misc
 import { API_BASE_PATH } from '../constants'
@@ -45,11 +44,6 @@ export function createApiApp(): Application {
   const publicRouter = createPublicRouter()
   const protectedRouter = createProtectedRouter()
   apiApplication.use(publicRouter)
-  apiApplication.get(
-    `${API_BASE_PATH}/tasks/:taskId/messages`,
-    protectedApiMiddleware,
-    handleStreamTaskMessagesRequest,
-  )
   apiApplication.use(
     `${API_BASE_PATH}/protected`,
     protectedApiMiddleware,

--- a/electron/src/api/express.ts
+++ b/electron/src/api/express.ts
@@ -18,6 +18,7 @@ import { notFoundMiddleware } from './middleware/notFoundMiddleware'
 import { errorMiddleware } from './middleware/errorMiddleware'
 import { createPublicRouter } from './routes/public/publicRouter'
 import { createProtectedRouter } from './routes/v1/protected/protectedRouter'
+import { handleStreamTaskMessagesRequest } from './routes/v1/protected/tasks/streamTaskMessagesRoute'
 
 // Misc
 import { API_BASE_PATH } from '../constants'
@@ -43,8 +44,12 @@ export function createApiApp(): Application {
 
   const publicRouter = createPublicRouter()
   const protectedRouter = createProtectedRouter()
-
   apiApplication.use(publicRouter)
+  apiApplication.get(
+    `${API_BASE_PATH}/tasks/:taskId/messages`,
+    protectedApiMiddleware,
+    handleStreamTaskMessagesRequest,
+  )
   apiApplication.use(
     `${API_BASE_PATH}/protected`,
     protectedApiMiddleware,

--- a/electron/src/api/routes/v1/protected/tasks/streamTaskMessagesRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/streamTaskMessagesRoute.ts
@@ -6,9 +6,6 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 // Utility
-import { parseRequestParams } from '../../validation'
-
-// Misc
 import {
   formatSseEvent,
   initializeSseResponse,
@@ -23,47 +20,123 @@ const taskParamsSchema = z.object({
   taskId: z.string().trim().min(1),
 })
 
+type TaskMessagesStreamErrorCode =
+  | 'INVALID_TASK_ID'
+  | 'TASK_NOT_FOUND'
+  | 'TASK_MESSAGES_UNAVAILABLE'
+
+type TaskMessagesStreamError = {
+  code: TaskMessagesStreamErrorCode
+  message: string
+  terminal: boolean
+}
+
+function writeTaskMessagesStreamErrorEvent(
+  response: Response,
+  taskError: TaskMessagesStreamError,
+  retryAfterMilliseconds: number,
+) {
+  if (response.writableEnded) {
+    console.debug('Task messages stream error event skipped because response is already closed', {
+      taskError,
+    })
+    return
+  }
+
+  if (!response.headersSent) {
+    initializeSseResponse(response)
+  }
+
+  response.write(`retry: ${retryAfterMilliseconds}\n`)
+  response.write(formatSseEvent('task-error', JSON.stringify(taskError)))
+  response.end()
+}
+
 export async function handleStreamTaskMessagesRequest(
   request: Request<RouteParams>,
   response: Response,
 ): Promise<void> {
   const databaseClient = requireDatabaseClient('Stream task messages SSE')
+  const parsedTaskParams = taskParamsSchema.safeParse(request.params)
 
-  const params = parseRequestParams(
-    taskParamsSchema,
-    request,
-    response,
-    {
-      context: 'Stream task messages SSE',
-      errorMessage: 'Task ID is required',
-    },
-  )
-  if (!params) {
+  if (!parsedTaskParams.success) {
+    console.debug('Task message stream requested with invalid task id', {
+      taskId: request.params.taskId,
+      issues: parsedTaskParams.error.issues,
+    })
+    writeTaskMessagesStreamErrorEvent(
+      response,
+      {
+        code: 'INVALID_TASK_ID',
+        message: 'Task ID is required',
+        terminal: true,
+      },
+      0,
+    )
     return
   }
 
-  const { taskId } = params
+  const { taskId } = parsedTaskParams.data
 
-  const task = await databaseClient.task.findUnique({
-    where: { id: taskId },
-  })
-  if (!task) {
-    console.debug('Task message stream requested for missing task', { taskId })
-    response.status(404).json({ error: 'Task not found' })
-    return
+  try {
+    const task = await databaseClient.task.findUnique({
+      where: { id: taskId },
+    })
+
+    if (!task) {
+      console.debug('Task message stream requested for missing task', { taskId })
+      writeTaskMessagesStreamErrorEvent(
+        response,
+        {
+          code: 'TASK_NOT_FOUND',
+          message: 'Task not found',
+          terminal: true,
+        },
+        0,
+      )
+      return
+    }
+
+    const messages = await databaseClient.message.findMany({
+      where: { taskId },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    if (!response.headersSent) {
+      initializeSseResponse(response)
+    }
+
+    if (!response.writableEnded) {
+      response.write(formatSseEvent('message', JSON.stringify(messages)))
+    }
+
+    function handleClose() {
+      response.end()
+    }
+
+    request.on('close', handleClose)
   }
+  catch (error) {
+    console.debug('Task message stream query failed', {
+      taskId,
+      error,
+    })
 
-  const messages = await databaseClient.message.findMany({
-    where: { taskId },
-    orderBy: { createdAt: 'asc' },
-  })
+    if (response.headersSent || response.writableEnded) {
+      console.debug('Task message stream error response skipped because headers were already sent', {
+        taskId,
+      })
+      return
+    }
 
-  initializeSseResponse(response)
-  response.write(formatSseEvent('message', JSON.stringify(messages)))
-
-  function handleClose() {
-    response.end()
+    writeTaskMessagesStreamErrorEvent(
+      response,
+      {
+        code: 'TASK_MESSAGES_UNAVAILABLE',
+        message: 'Task messages are temporarily unavailable',
+        terminal: false,
+      },
+      5_000,
+    )
   }
-
-  request.on('close', handleClose)
 }

--- a/electron/src/api/routes/v1/protected/tasks/streamTaskMessagesRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/streamTaskMessagesRoute.ts
@@ -1,16 +1,14 @@
 // Copyright © 2026 Jalapeno Labs
 
 import type { Request, Response } from 'express'
+import type { Message, TurnWithMessages } from '@common/types'
+import type { SetOptional } from 'type-fest'
 
-// Lib
-import { z } from 'zod'
-
-// Utility
-import {
-  formatSseEvent,
-  initializeSseResponse,
-} from '@electron/api/sse/sseManager'
+// Core
 import { requireDatabaseClient } from '@electron/database'
+import { formatSseEvent, initializeSseResponse } from '@electron/api/sse/sseManager'
+import { v7 as uuid } from 'uuid'
+import { z } from 'zod'
 
 type RouteParams = {
   taskId: string
@@ -20,101 +18,119 @@ const taskParamsSchema = z.object({
   taskId: z.string().trim().min(1),
 })
 
-type TaskMessagesStreamErrorCode =
-  | 'INVALID_TASK_ID'
-  | 'TASK_NOT_FOUND'
-  | 'TASK_MESSAGES_UNAVAILABLE'
-
-type TaskMessagesStreamError = {
-  code: TaskMessagesStreamErrorCode
-  message: string
-  terminal: boolean
+type EventPayloadMap = {
+  'turns': TurnWithMessages[]
+  'new-message': Message
+  'upsert-turn': TurnWithMessages
+  'task-error': { message: string }
+}
+type Events = keyof EventPayloadMap
+type EventData<Event extends Events> = EventPayloadMap[Event]
+type Writer = <Event extends Events>(event: Event, data: EventData<Event>) => void
+type WriterDef = {
+  id: string
+  writer: Writer
 }
 
-function writeTaskMessagesStreamErrorEvent(
-  response: Response,
-  taskError: TaskMessagesStreamError,
-  retryAfterMilliseconds: number,
-) {
-  if (response.writableEnded) {
-    console.debug('Task messages stream error event skipped because response is already closed', {
-      taskError,
-    })
-    return
-  }
-
-  if (!response.headersSent) {
-    initializeSseResponse(response)
-  }
-
-  response.write(`retry: ${retryAfterMilliseconds}\n`)
-  response.write(formatSseEvent('task-error', JSON.stringify(taskError)))
-  response.end()
-}
+const writersByTaskId: Record<string, WriterDef[]> = {}
 
 export async function handleStreamTaskMessagesRequest(
   request: Request<RouteParams>,
   response: Response,
 ): Promise<void> {
-  const databaseClient = requireDatabaseClient('Stream task messages SSE')
+  const prisma = requireDatabaseClient('Stream task messages SSE')
   const parsedTaskParams = taskParamsSchema.safeParse(request.params)
+
+  initializeSseResponse(response)
+
+  function write<Event extends Events>(
+    event: Event,
+    data: EventData<Event>,
+  ) {
+    if (response.writableEnded) {
+      console.debug('Attempted to write to task messages SSE after response ended', {
+        event,
+        data,
+      })
+      return
+    }
+
+    response.write(
+      formatSseEvent(event,
+        JSON.stringify(data),
+      ),
+    )
+  }
 
   if (!parsedTaskParams.success) {
     console.debug('Task message stream requested with invalid task id', {
       taskId: request.params.taskId,
       issues: parsedTaskParams.error.issues,
     })
-    writeTaskMessagesStreamErrorEvent(
-      response,
-      {
-        code: 'INVALID_TASK_ID',
-        message: 'Task ID is required',
-        terminal: true,
-      },
-      0,
-    )
+    write('task-error', {
+      message: 'Task ID is required',
+    })
+    response.end()
     return
   }
 
   const { taskId } = parsedTaskParams.data
 
   try {
-    const task = await databaseClient.task.findUnique({
+    const task = await prisma.task.findUnique({
       where: { id: taskId },
     })
 
     if (!task) {
       console.debug('Task message stream requested for missing task', { taskId })
-      writeTaskMessagesStreamErrorEvent(
-        response,
-        {
-          code: 'TASK_NOT_FOUND',
-          message: 'Task not found',
-          terminal: true,
-        },
-        0,
-      )
+      write('task-error', {
+        message: 'Task not found',
+      })
+      response.end()
       return
     }
 
-    const messages = await databaseClient.message.findMany({
-      where: { taskId },
-      orderBy: { createdAt: 'asc' },
+    const sessionId = uuid()
+    const allTurns = await prisma.turn.findMany({
+      where: {
+        taskId,
+      },
+      include: {
+        messages: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
     })
 
-    if (!response.headersSent) {
-      initializeSseResponse(response)
-    }
+    write('turns', allTurns)
 
-    if (!response.writableEnded) {
-      response.write(formatSseEvent('message', JSON.stringify(messages)))
+    if (writersByTaskId[taskId]) {
+      writersByTaskId[taskId].push({
+        id: sessionId,
+        writer: write,
+      })
+    }
+    else {
+      writersByTaskId[taskId] = [{
+        id: sessionId,
+        writer: write,
+      }]
     }
 
     function handleClose() {
-      response.end()
+      writersByTaskId[taskId] = writersByTaskId[taskId]?.filter((writer) => writer.id !== sessionId)
+
+      if (!writersByTaskId[taskId]?.length) {
+        delete writersByTaskId[taskId]
+      }
     }
 
-    request.on('close', handleClose)
+    request.once('close', handleClose)
   }
   catch (error) {
     console.debug('Task message stream query failed', {
@@ -123,20 +139,71 @@ export async function handleStreamTaskMessagesRequest(
     })
 
     if (response.headersSent || response.writableEnded) {
-      console.debug('Task message stream error response skipped because headers were already sent', {
-        taskId,
+      return
+    }
+
+    write('task-error', {
+      message: 'Something went wrong trying to stream task messages',
+    })
+    response.end()
+  }
+}
+
+export async function broadcastTurnUpsert(
+  taskId: string,
+  turn: SetOptional<TurnWithMessages, 'messages'>,
+) {
+  const writers = writersByTaskId[taskId]
+  if (!writers) {
+    return
+  }
+
+  const prisma = requireDatabaseClient('Stream task messages SSE - broadcastTurnUpsert')
+
+  try {
+    const fullTurnWithMessages = await prisma.turn.findUnique({
+      where: {
+        id: turn.id,
+      },
+      include: {
+        messages: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    })
+
+    if (!fullTurnWithMessages) {
+      console.debug('Failed to find turn for upsert broadcast', {
+        turnId: turn.id,
       })
       return
     }
 
-    writeTaskMessagesStreamErrorEvent(
-      response,
-      {
-        code: 'TASK_MESSAGES_UNAVAILABLE',
-        message: 'Task messages are temporarily unavailable',
-        terminal: false,
-      },
-      5_000,
-    )
+    for (const { writer } of writers) {
+      writer('upsert-turn', fullTurnWithMessages)
+    }
+  }
+  catch (error) {
+    console.error('Failed to load turn for upsert broadcast', {
+      taskId,
+      turnId: turn.id,
+      error,
+    })
+  }
+}
+
+export async function broadcastMessageUpsert(
+  taskId: string,
+  message: Message,
+) {
+  const writers = writersByTaskId[taskId]
+  if (!writers) {
+    return
+  }
+
+  for (const { writer } of writers) {
+    writer('new-message', message)
   }
 }

--- a/electron/src/api/routes/v1/protected/tasks/streamTaskMessagesRoute.ts
+++ b/electron/src/api/routes/v1/protected/tasks/streamTaskMessagesRoute.ts
@@ -1,0 +1,69 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Request, Response } from 'express'
+
+// Lib
+import { z } from 'zod'
+
+// Utility
+import { parseRequestParams } from '../../validation'
+
+// Misc
+import {
+  formatSseEvent,
+  initializeSseResponse,
+} from '@electron/api/sse/sseManager'
+import { requireDatabaseClient } from '@electron/database'
+
+type RouteParams = {
+  taskId: string
+}
+
+const taskParamsSchema = z.object({
+  taskId: z.string().trim().min(1),
+})
+
+export async function handleStreamTaskMessagesRequest(
+  request: Request<RouteParams>,
+  response: Response,
+): Promise<void> {
+  const databaseClient = requireDatabaseClient('Stream task messages SSE')
+
+  const params = parseRequestParams(
+    taskParamsSchema,
+    request,
+    response,
+    {
+      context: 'Stream task messages SSE',
+      errorMessage: 'Task ID is required',
+    },
+  )
+  if (!params) {
+    return
+  }
+
+  const { taskId } = params
+
+  const task = await databaseClient.task.findUnique({
+    where: { id: taskId },
+  })
+  if (!task) {
+    console.debug('Task message stream requested for missing task', { taskId })
+    response.status(404).json({ error: 'Task not found' })
+    return
+  }
+
+  const messages = await databaseClient.message.findMany({
+    where: { taskId },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  initializeSseResponse(response)
+  response.write(formatSseEvent('message', JSON.stringify(messages)))
+
+  function handleClose() {
+    response.end()
+  }
+
+  request.on('close', handleClose)
+}

--- a/electron/src/api/routes/v1/protected/tasksRouter.ts
+++ b/electron/src/api/routes/v1/protected/tasksRouter.ts
@@ -15,6 +15,7 @@ import { handleRefreshTaskGitRequest } from './tasks/postRefreshTaskGitRoute'
 import { handleTaskPullRequestRequest } from './tasks/postTaskPullRequestRoute'
 import { handleViewTaskRepositoryRequest } from './tasks/postViewTaskRepositoryRoute'
 import { handleStreamTaskLogsRequest } from './tasks/streamTaskLogsRoute'
+import { handleStreamTaskMessagesRequest } from './tasks/streamTaskMessagesRoute'
 import { handleUpdateTaskRequest } from './tasks/updateTaskRoute'
 
 export function createTasksRouter(): Router {
@@ -24,6 +25,8 @@ export function createTasksRouter(): Router {
   tasksRouter.get('/', handleListTasksRequest)
   // /api/v1/protected/tasks/:taskId/logs/stream
   tasksRouter.get('/:taskId/logs/stream', handleStreamTaskLogsRequest)
+  // /api/v1/protected/tasks/:taskId/messages/stream
+  tasksRouter.get('/:taskId/messages/stream', handleStreamTaskMessagesRequest)
   // /api/v1/protected/tasks/:taskId
   tasksRouter.get('/:taskId', handleGetTaskRequest)
   // /api/v1/protected/tasks

--- a/frontend/src/elements/SearchIssueTrackers.tsx
+++ b/frontend/src/elements/SearchIssueTrackers.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Jalapeno Labs
+// Copyright © 2026 Jalapeno Labs
 
 import type { IssueTracking } from '@common/types'
 

--- a/frontend/src/hooks/useTaskMessages.ts
+++ b/frontend/src/hooks/useTaskMessages.ts
@@ -1,46 +1,129 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { Message } from '@common/types'
+import type { Message, TurnWithMessages } from '@common/types'
 
 // Core
 import { useEffect, useState } from 'react'
-
-// Utility
 import { safeParseJson } from '@common/json'
-
-// Misc
 import { getTaskMessagesSseUrl } from '@frontend/routes/taskRoutes'
 
 export function useTaskMessages(taskId: string) {
-  const [ messages, setMessages ] = useState<Message[]>([])
+  const [ turns, setTurns ] = useState<TurnWithMessages[]>([])
 
-  function noopCleanup() {
-    return undefined
-  }
-
-  useEffect(function manageTaskMessagesSseConnection() {
+  useEffect(() => {
     if (!taskId?.trim()) {
       console.debug('useTaskMessages received empty taskId, skipping SSE connection', {
         taskId,
       })
-      setMessages([])
-      return noopCleanup
+      if (turns.length) {
+        setTurns([])
+      }
+      return null
     }
 
-    const taskMessagesUrl = getTaskMessagesSseUrl(taskId)
-    const eventSource = new EventSource(taskMessagesUrl)
+    const eventSource = new EventSource(
+      getTaskMessagesSseUrl(taskId),
+    )
 
-    function handleMessage(event: MessageEvent) {
-      const payload = safeParseJson<unknown>(event.data)
-      if (!Array.isArray(payload)) {
-        console.debug('Task messages SSE payload is not an array', {
-          taskId,
-          payload,
-        })
+    function handleInitialTurns(event: MessageEvent) {
+      const data = safeParseJson<TurnWithMessages[]>(event.data)
+      setTurns(data)
+    }
+
+    function handleNewMessage(event: MessageEvent) {
+      const newMessage = safeParseJson<Message>(event.data)
+
+      if (!newMessage?.id) {
+        console.debug('Received new message SSE with invalid data', event)
         return
       }
 
-      setMessages(payload)
+      // Needs to handle:
+      // - Create message on existing turn
+      // - Create message on new turn where we receive the message before the turn due to race conditions
+      setTurns((previousTurns) => {
+        const existingTurn = previousTurns.find((turn) => turn.id === newMessage.turnId)
+
+        // We can guess the turn if there's a race condition...
+        if (!existingTurn) {
+          console.debug('Received new message SSE for missing turn, creating new in-memory turn', {
+            turnId: newMessage.turnId,
+            messageId: newMessage.id,
+          })
+
+          return [
+            ...previousTurns,
+            {
+              id: newMessage.turnId,
+              taskId,
+              createdAt: Date.now(),
+              timeTaken: null,
+              finishedAt: null,
+              messages: [ newMessage ],
+            },
+          ] as TurnWithMessages[]
+        }
+
+        // Otherwise, we know exactly which turn to put the message in
+        return previousTurns
+          .map((turn) => {
+            if (turn.id !== newMessage.turnId) {
+              return turn
+            }
+
+            return {
+              ...turn,
+              messages: [ ...turn.messages, newMessage ],
+            }
+          })
+      })
+    }
+
+    function handleNewTurn(event: MessageEvent) {
+      const newTurn = safeParseJson<TurnWithMessages>(event.data)
+
+      if (!newTurn?.id) {
+        console.debug('Received new turn SSE with invalid data', event)
+        return
+      }
+
+      // Needs to handle:
+      // - Turn Creations
+      // - Turn Updates
+      // - Message race conditions where we receive a message with a new turn id before the new turn is received
+      setTurns((previousTurns) => {
+        const existingTurn = previousTurns.find((turn) => turn.id === newTurn.id)
+        if (!existingTurn) {
+          return [ ...previousTurns, newTurn ]
+        }
+
+        console.debug('Received new turn SSE for existing turn, merging messages', {
+          turnId: newTurn.id,
+          previousMessagesCount: existingTurn.messages.length,
+          newMessagesCount: newTurn.messages.length,
+        })
+
+        return previousTurns
+          .map((turn) => {
+            if (turn.id !== newTurn.id) {
+              return turn
+            }
+
+            const mergedMessages = [
+              ...turn.messages || [],
+              ...newTurn.messages || [],
+            ]
+
+            return {
+              ...newTurn,
+              messages: mergedMessages
+                .filter((message, index) =>
+                  index === mergedMessages.findIndex((m) => m.id === message.id),
+                )
+                .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
+            }
+          })
+      })
     }
 
     function handleError(event: Event) {
@@ -51,17 +134,23 @@ export function useTaskMessages(taskId: string) {
       })
     }
 
-    eventSource.addEventListener('message', handleMessage)
+    eventSource.addEventListener('turns', handleInitialTurns)
+    eventSource.addEventListener('new-message', handleNewMessage)
+    eventSource.addEventListener('upsert-turn', handleNewTurn)
+    eventSource.addEventListener('task-error', handleError)
     eventSource.addEventListener('error', handleError)
 
-    return function cleanupTaskMessagesSseConnection() {
-      eventSource.removeEventListener('message', handleMessage)
+    return () => {
+      eventSource.removeEventListener('turns', handleInitialTurns)
+      eventSource.removeEventListener('new-message', handleNewMessage)
+      eventSource.removeEventListener('upsert-turns', handleNewTurn)
+      eventSource.removeEventListener('task-error', handleError)
       eventSource.removeEventListener('error', handleError)
       eventSource.close()
     }
   }, [ taskId ])
 
   return {
-    messages,
-  }
+    turns,
+  } as const
 }

--- a/frontend/src/hooks/useTaskMessages.ts
+++ b/frontend/src/hooks/useTaskMessages.ts
@@ -14,13 +14,17 @@ import { getTaskMessagesSseUrl } from '@frontend/routes/taskRoutes'
 export function useTaskMessages(taskId: string) {
   const [ messages, setMessages ] = useState<Message[]>([])
 
+  function noopCleanup() {
+    return undefined
+  }
+
   useEffect(function manageTaskMessagesSseConnection() {
     if (!taskId?.trim()) {
       console.debug('useTaskMessages received empty taskId, skipping SSE connection', {
         taskId,
       })
       setMessages([])
-      return
+      return noopCleanup
     }
 
     const taskMessagesUrl = getTaskMessagesSseUrl(taskId)

--- a/frontend/src/hooks/useTaskMessages.ts
+++ b/frontend/src/hooks/useTaskMessages.ts
@@ -1,0 +1,63 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { Message } from '@common/types'
+
+// Core
+import { useEffect, useState } from 'react'
+
+// Utility
+import { safeParseJson } from '@common/json'
+
+// Misc
+import { getTaskMessagesSseUrl } from '@frontend/routes/taskRoutes'
+
+export function useTaskMessages(taskId: string) {
+  const [ messages, setMessages ] = useState<Message[]>([])
+
+  useEffect(function manageTaskMessagesSseConnection() {
+    if (!taskId?.trim()) {
+      console.debug('useTaskMessages received empty taskId, skipping SSE connection', {
+        taskId,
+      })
+      setMessages([])
+      return
+    }
+
+    const taskMessagesUrl = getTaskMessagesSseUrl(taskId)
+    const eventSource = new EventSource(taskMessagesUrl)
+
+    function handleMessage(event: MessageEvent) {
+      const payload = safeParseJson<unknown>(event.data)
+      if (!Array.isArray(payload)) {
+        console.debug('Task messages SSE payload is not an array', {
+          taskId,
+          payload,
+        })
+        return
+      }
+
+      setMessages(payload)
+    }
+
+    function handleError(event: Event) {
+      console.debug('Task messages SSE error received', {
+        taskId,
+        event,
+        readyState: eventSource.readyState,
+      })
+    }
+
+    eventSource.addEventListener('message', handleMessage)
+    eventSource.addEventListener('error', handleError)
+
+    return function cleanupTaskMessagesSseConnection() {
+      eventSource.removeEventListener('message', handleMessage)
+      eventSource.removeEventListener('error', handleError)
+      eventSource.close()
+    }
+  }, [ taskId ])
+
+  return {
+    messages,
+  }
+}

--- a/frontend/src/routes/taskRoutes.ts
+++ b/frontend/src/routes/taskRoutes.ts
@@ -49,7 +49,7 @@ export function getTask(taskId: string) {
 }
 
 export function getTaskMessagesSseUrl(taskId: string) {
-  return `${ApiRoot}/api/v1/tasks/${taskId}/messages`
+  return `${ApiRoot}/api/v1/protected/tasks/${taskId}/messages/stream`
 }
 
 // /////////////////////////////// //

--- a/frontend/src/routes/taskRoutes.ts
+++ b/frontend/src/routes/taskRoutes.ts
@@ -4,7 +4,7 @@ import type { Message, Task } from '@common/types'
 import type { TaskCreateRequest, TaskUpdateRequest } from '@common/schema/task'
 
 // Core
-import { parseRequestBeforeSend } from '@common/api'
+import { ApiRoot, parseRequestBeforeSend } from '@common/api'
 import { frontendClient } from '@frontend/framework/api'
 
 // Redux
@@ -46,6 +46,10 @@ export function getTask(taskId: string) {
   return frontendClient
     .get(`v1/protected/tasks/${taskId}`)
     .json<GetTaskResponse>()
+}
+
+export function getTaskMessagesSseUrl(taskId: string) {
+  return `${ApiRoot}/api/v1/tasks/${taskId}/messages`
 }
 
 // /////////////////////////////// //


### PR DESCRIPTION
### Motivation
- Provide real-time streaming of a task's messages so the UI can stay synchronized using Server-Sent Events (SSE).

### Description
- Add `handleStreamTaskMessagesRequest` in `routes/v1/protected/tasks/streamTaskMessagesRoute.ts` that validates `taskId`, fetches the task and its messages, initializes an SSE response, writes the initial messages, and closes the stream on disconnect.
- Register the SSE route in `createApiApp` as `GET /api/v1/tasks/:taskId/messages` and protect it with `protectedApiMiddleware`.
- Add a frontend hook `useTaskMessages` in `frontend/src/hooks/useTaskMessages.ts` that connects to the SSE via `EventSource`, parses array payloads, updates `messages` state, and cleans up listeners on unmount, and add `getTaskMessagesSseUrl` in `frontend/src/routes/taskRoutes.ts` while importing `ApiRoot`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9903defc8322a5aec477fa5977d4)