### PR TITLE
Add GitHub issue tracker provider support

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -13,6 +13,8 @@
     "build": "echo"
   },
   "dependencies": {
+    "@octokit/core": "^7.0.6",
+    "@octokit/request-error": "^7.0.2",
     "@openai/codex-sdk": "^0.98.0",
     "glob": "^13.0.0",
     "jira.js": "^5.3.0",

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -97,6 +97,7 @@ export const GITHUB_AUTH_PROVIDER_REQUIRED_SCOPES = [
 
 // Issue tracking
 export const DEFAULT_JIRA_CLOUD_BASE_URL = 'https://api.atlassian.com' as const
+export const DEFAULT_GITHUB_API_BASE_URL = 'https://api.github.com' as const
 export const JIRA_CLOUD_REQUIRED_SCOPES = [
   'read:jira-work',
   'write:jira-work',

--- a/common/src/issueTracking/getIssueTracker.ts
+++ b/common/src/issueTracking/getIssueTracker.ts
@@ -5,12 +5,14 @@ import type { IssueTracking, IssueTrackingProvider } from '@prisma/client'
 // Core
 import { IssueTracker } from './polymorphism/issueTracker'
 import { JiraIssueTracker } from './polymorphism/jira'
+import { GithubIssueTracker } from './polymorphism/github'
 
 const IssueTrackingProviderToTrackerMap: Record<
   IssueTrackingProvider,
   new (issueTracking: IssueTracking) => IssueTracker
 > = {
   Jira: JiraIssueTracker,
+  Github: GithubIssueTracker,
 }
 
 export function getIssueTracker(issueTracking: IssueTracking): IssueTracker {

--- a/common/src/issueTracking/polymorphism/github.test.ts
+++ b/common/src/issueTracking/polymorphism/github.test.ts
@@ -1,0 +1,137 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { IssueTracking } from '@prisma/client'
+
+// Core
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Misc
+import { IssueTrackingProvider } from '@prisma/client'
+import { GithubIssueTracker } from './github'
+
+function buildIssueTracking(
+  overrides: Partial<IssueTracking> = {},
+): IssueTracking {
+  return {
+    id: 'github-test',
+    userId: 'user-test',
+    provider: IssueTrackingProvider.Github,
+    accessToken: 'test-token',
+    baseUrl: 'https://api.github.com',
+    name: 'GitHub Test Account',
+    email: 'jalapenolabs',
+    targetBoard: 'seraphim',
+    lastUsedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+type RequestMock = ReturnType<typeof vi.fn>
+
+function setOctokitRequestMock(
+  tracker: GithubIssueTracker,
+  requestMock: RequestMock,
+) {
+  Reflect.set(tracker, 'octokit', {
+    request: requestMock,
+  })
+}
+
+describe('GithubIssueTracker', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('check fails when owner is missing', async () => {
+    const tracker = new GithubIssueTracker(
+      buildIssueTracking({
+        email: '',
+      }),
+    )
+
+    const [ success, error ] = await tracker.check()
+
+    expect(success).toBe(false)
+    expect(error).toContain('owner')
+  })
+
+  it('check validates repository access', async () => {
+    const tracker = new GithubIssueTracker(buildIssueTracking())
+
+    const requestMock = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        id: 1,
+      },
+    })
+
+    setOctokitRequestMock(tracker, requestMock)
+
+    const [ success, error ] = await tracker.check()
+
+    expect(success, error).toBe(true)
+    expect(requestMock).toHaveBeenCalledWith('GET /repos/{owner}/{repo}', {
+      owner: 'jalapenolabs',
+      repo: 'seraphim',
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    })
+  })
+
+  it('listIssues maps issue payloads and excludes pull requests', async () => {
+    const tracker = new GithubIssueTracker(buildIssueTracking())
+
+    const requestMock = vi.fn().mockResolvedValue({
+      data: {
+        total_count: 2,
+        items: [
+          {
+            number: 10,
+            title: 'Fix bug',
+            state: 'open',
+            labels: [
+              {
+                id: 99,
+                name: 'bug',
+              },
+            ],
+          },
+          {
+            number: 11,
+            title: 'PR item',
+            state: 'open',
+            pull_request: {
+              url: 'https://example.com',
+            },
+          },
+        ],
+      },
+    })
+
+    setOctokitRequestMock(tracker, requestMock)
+
+    const response = await tracker.listIssues({
+      q: 'is:open',
+      page: 1,
+      limit: 20,
+    })
+
+    expect(response.totalCount).toBe(2)
+    expect(response.items).toEqual([
+      {
+        id: '10',
+        key: '#10',
+        summary: 'Fix bug',
+        statusId: 'open',
+        labels: [ 'bug' ],
+      },
+    ])
+  })
+})

--- a/common/src/issueTracking/polymorphism/github.ts
+++ b/common/src/issueTracking/polymorphism/github.ts
@@ -1,0 +1,554 @@
+// Copyright © 2026 Jalapeno Labs
+
+import type { IssueTracking } from '@prisma/client'
+import type {
+  IssueTrackingIssue,
+  IssueTrackingIssueList,
+  IssueTrackingIssueUpdate,
+  IssueTrackingLabel,
+  IssueTrackingListIssuesParams,
+  IssueTrackingStatusType,
+} from '../types'
+
+// Core
+import { IssueTracker } from './issueTracker'
+import { Octokit } from '@octokit/core'
+import { RequestError } from '@octokit/request-error'
+
+export class GithubIssueTracker extends IssueTracker {
+  private readonly octokit: Octokit
+
+  constructor(issueTracking: IssueTracking) {
+    super(issueTracking)
+
+    this.octokit = new Octokit({
+      auth: this.issueTracking.accessToken,
+      baseUrl: IssueTracker.resolveIssueTrackingBaseUrl(
+        this.issueTracking.baseUrl,
+        this.issueTracking.provider,
+      ),
+    })
+  }
+
+  public async check(): Promise<[ boolean, string ]> {
+    if (!this.issueTracking.accessToken?.trim()) {
+      console.debug('GitHub issue tracker check failed because access token is missing', {
+        issueTrackingId: this.issueTracking.id,
+      })
+      return [ false, 'GitHub access token is required' ]
+    }
+
+    const owner = this.getOwner()
+    if (!owner) {
+      return [ false, 'GitHub organization or owner is required' ]
+    }
+
+    const repo = this.getRepo()
+    if (!repo) {
+      return [ false, 'GitHub repository is required' ]
+    }
+
+    try {
+      await this.octokit.request('GET /repos/{owner}/{repo}', {
+        owner,
+        repo,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      return [ true, '' ]
+    }
+    catch (error) {
+      return this.resolveGithubError(error, 'Unable to validate GitHub repository access')
+    }
+  }
+
+  public async listIssues(
+    params: IssueTrackingListIssuesParams = {},
+  ): Promise<IssueTrackingIssueList> {
+    const owner = this.getOwner()
+    const repo = this.getRepo()
+    const page = params.page ?? 1
+    const limit = params.limit ?? 50
+
+    if (!owner || !repo) {
+      console.debug('GitHub listIssues cannot run without owner and repo', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+      })
+      return super.listIssues(params)
+    }
+
+    try {
+      const searchQuery = this.buildSearchQuery(owner, repo, params.q)
+
+      const response = await this.octokit.request('GET /search/issues', {
+        q: searchQuery,
+        page,
+        per_page: limit,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      const issues = this.mapIssueListPayload(response.data.items)
+      const totalCount = Number.isFinite(response.data.total_count)
+        ? Number(response.data.total_count)
+        : issues.length
+
+      return {
+        items: issues,
+        page,
+        limit,
+        totalCount,
+      }
+    }
+    catch (error) {
+      console.debug('GitHub listIssues failed', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+        search: params.q ?? null,
+        page,
+        limit,
+        error,
+      })
+      return super.listIssues(params)
+    }
+  }
+
+  public async getIssueById(issueId: string): Promise<IssueTrackingIssue | null> {
+    if (!issueId?.trim()) {
+      console.debug('GitHub getIssueById received invalid issueId', {
+        issueId,
+      })
+      return super.getIssueById(issueId)
+    }
+
+    const owner = this.getOwner()
+    const repo = this.getRepo()
+
+    if (!owner || !repo) {
+      console.debug('GitHub getIssueById cannot run without owner and repo', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+      })
+      return super.getIssueById(issueId)
+    }
+
+    const issueNumber = Number(issueId)
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      console.debug('GitHub getIssueById received non-numeric issue id', {
+        issueTrackingId: this.issueTracking.id,
+        issueId,
+      })
+      return super.getIssueById(issueId)
+    }
+
+    try {
+      const response = await this.octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      return this.mapIssuePayload(response.data)
+    }
+    catch (error) {
+      console.debug('GitHub getIssueById failed', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+        issueId,
+        error,
+      })
+
+      return super.getIssueById(issueId)
+    }
+  }
+
+  public async listLabels(): Promise<IssueTrackingLabel[]> {
+    const owner = this.getOwner()
+    const repo = this.getRepo()
+
+    if (!owner || !repo) {
+      console.debug('GitHub listLabels cannot run without owner and repo', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+      })
+      return super.listLabels()
+    }
+
+    try {
+      const response = await this.octokit.request('GET /repos/{owner}/{repo}/labels', {
+        owner,
+        repo,
+        per_page: 100,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      return this.mapLabelsPayload(response.data)
+    }
+    catch (error) {
+      console.debug('GitHub listLabels failed', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+        error,
+      })
+      return super.listLabels()
+    }
+  }
+
+  public async listStatusTypes(): Promise<IssueTrackingStatusType[]> {
+    return [
+      {
+        id: 'open',
+        name: 'Open',
+        category: 'To Do',
+      },
+      {
+        id: 'closed',
+        name: 'Closed',
+        category: 'Done',
+      },
+    ]
+  }
+
+  public async updateIssueById(
+    issueId: string,
+    update: IssueTrackingIssueUpdate,
+  ): Promise<IssueTrackingIssue | null> {
+    if (!issueId?.trim()) {
+      console.debug('GitHub updateIssueById received invalid issueId', {
+        issueId,
+      })
+      return super.updateIssueById(issueId, update)
+    }
+
+    if (!update || Object.keys(update).length === 0) {
+      console.debug('GitHub updateIssueById received empty update payload', {
+        issueId,
+        update,
+      })
+      return super.updateIssueById(issueId, update)
+    }
+
+    const owner = this.getOwner()
+    const repo = this.getRepo()
+    if (!owner || !repo) {
+      console.debug('GitHub updateIssueById cannot run without owner and repo', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+      })
+      return super.updateIssueById(issueId, update)
+    }
+
+    const issueNumber = Number(issueId)
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      console.debug('GitHub updateIssueById received non-numeric issue id', {
+        issueTrackingId: this.issueTracking.id,
+        issueId,
+      })
+      return super.updateIssueById(issueId, update)
+    }
+
+    const requestBody = this.buildUpdateRequest(update)
+    if (!requestBody) {
+      console.debug('GitHub updateIssueById did not receive any supported update fields', {
+        issueTrackingId: this.issueTracking.id,
+        issueId,
+        update,
+      })
+      return super.updateIssueById(issueId, update)
+    }
+
+    try {
+      const response = await this.octokit.request('PATCH /repos/{owner}/{repo}/issues/{issue_number}', {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        ...requestBody,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      return this.mapIssuePayload(response.data)
+    }
+    catch (error) {
+      console.debug('GitHub updateIssueById failed', {
+        issueTrackingId: this.issueTracking.id,
+        owner,
+        repo,
+        issueId,
+        update,
+        error,
+      })
+
+      return super.updateIssueById(issueId, update)
+    }
+  }
+
+  private getOwner(): string {
+    const owner = this.issueTracking.email?.trim() || ''
+    if (!owner) {
+      console.debug('GitHub issue tracker owner is missing', {
+        issueTrackingId: this.issueTracking.id,
+      })
+    }
+    return owner
+  }
+
+  private getRepo(): string {
+    const repo = this.issueTracking.targetBoard?.trim() || ''
+    if (!repo) {
+      console.debug('GitHub issue tracker repository is missing', {
+        issueTrackingId: this.issueTracking.id,
+      })
+    }
+    return repo
+  }
+
+  private resolveGithubError(
+    error: unknown,
+    fallbackMessage: string,
+  ): [ boolean, string ] {
+    if (error instanceof RequestError) {
+      if (error.status === 401) {
+        return [ false, 'GitHub authentication failed. Check the access token.' ]
+      }
+
+      if (error.status === 403) {
+        return [ false, 'GitHub access denied to this repository.' ]
+      }
+
+      if (error.status === 404) {
+        return [ false, 'GitHub repository was not found for the provided org/repo.' ]
+      }
+    }
+
+    console.debug('GitHub issue tracker request failed', {
+      issueTrackingId: this.issueTracking.id,
+      error,
+    })
+
+    return [ false, fallbackMessage ]
+  }
+
+  private mapIssueListPayload(payload: unknown): IssueTrackingIssue[] {
+    if (!Array.isArray(payload)) {
+      console.debug('GitHub listIssues payload was not an array', {
+        issueTrackingId: this.issueTracking.id,
+        payload,
+      })
+      return []
+    }
+
+    const issues: IssueTrackingIssue[] = []
+
+    for (const issuePayload of payload) {
+      const issue = this.mapIssuePayload(issuePayload)
+      if (!issue) {
+        continue
+      }
+
+      issues.push(issue)
+    }
+
+    return issues
+  }
+
+  private mapIssuePayload(payload: unknown): IssueTrackingIssue | null {
+    if (!payload || typeof payload !== 'object') {
+      console.debug('GitHub issue payload was not an object', {
+        issueTrackingId: this.issueTracking.id,
+        payload,
+      })
+      return null
+    }
+
+    if (!this.isRecord(payload)) {
+      console.debug('GitHub issue payload could not be parsed as object record', {
+        issueTrackingId: this.issueTracking.id,
+        payload,
+      })
+      return null
+    }
+
+    const issueRecord = payload
+
+    if (issueRecord.pull_request && typeof issueRecord.pull_request === 'object') {
+      return null
+    }
+
+    const issueNumber = issueRecord.number
+    const issueTitle = issueRecord.title
+    const issueState = issueRecord.state
+
+    if (!Number.isFinite(issueNumber) || typeof issueTitle !== 'string' || typeof issueState !== 'string') {
+      console.debug('GitHub issue payload missing required fields', {
+        issueTrackingId: this.issueTracking.id,
+        issueNumber,
+        issueTitle,
+        issueState,
+      })
+      return null
+    }
+
+    const issueLabels = this.resolveLabelNames(issueRecord.labels)
+
+    return {
+      id: String(issueNumber),
+      key: `#${issueNumber}`,
+      summary: issueTitle,
+      statusId: issueState,
+      labels: issueLabels,
+    }
+  }
+
+  private resolveLabelNames(payload: unknown): string[] {
+    if (!Array.isArray(payload)) {
+      return []
+    }
+
+    const labelNames: string[] = []
+
+    for (const label of payload) {
+      if (!label || typeof label !== 'object') {
+        continue
+      }
+
+      if (!this.isRecord(label)) {
+        continue
+      }
+
+      const labelName = label.name
+      if (typeof labelName !== 'string' || !labelName.trim()) {
+        continue
+      }
+
+      labelNames.push(labelName)
+    }
+
+    return labelNames
+  }
+
+  private mapLabelsPayload(payload: unknown): IssueTrackingLabel[] {
+    if (!Array.isArray(payload)) {
+      console.debug('GitHub listLabels payload was not an array', {
+        issueTrackingId: this.issueTracking.id,
+        payload,
+      })
+      return []
+    }
+
+    const labels: IssueTrackingLabel[] = []
+
+    for (const labelPayload of payload) {
+      if (!labelPayload || typeof labelPayload !== 'object') {
+        continue
+      }
+
+      if (!this.isRecord(labelPayload)) {
+        continue
+      }
+
+      const labelRecord = labelPayload
+      const labelName = labelRecord.name
+      const labelId = labelRecord.id
+
+      if (typeof labelName !== 'string' || !labelName.trim()) {
+        continue
+      }
+
+      const resolvedLabelId = Number.isFinite(labelId)
+        ? String(labelId)
+        : labelName
+
+      labels.push({
+        id: resolvedLabelId,
+        name: labelName,
+      })
+    }
+
+    return labels
+  }
+
+  private buildSearchQuery(owner: string, repo: string, search?: string): string {
+    const trimmedSearch = search?.trim() || ''
+    const baseQuery = `repo:${owner}/${repo} is:issue`
+
+    if (!trimmedSearch) {
+      return baseQuery
+    }
+
+    return `${baseQuery} ${trimmedSearch}`
+  }
+
+  private buildUpdateRequest(update: IssueTrackingIssueUpdate) {
+    const requestBody: {
+      title?: string
+      body?: string
+      state?: 'open' | 'closed'
+      labels?: string[]
+      assignee?: string
+      assignees?: string[]
+    } = {}
+
+    if (typeof update.summary === 'string') {
+      requestBody.title = update.summary
+    }
+
+    if (typeof update.description === 'string') {
+      requestBody.body = update.description
+    }
+
+    if (typeof update.statusId === 'string') {
+      const status = update.statusId.toLowerCase().trim()
+      if (status === 'open' || status === 'closed') {
+        requestBody.state = status
+      }
+      else {
+        console.debug('GitHub updateIssueById ignored unsupported statusId', {
+          issueTrackingId: this.issueTracking.id,
+          statusId: update.statusId,
+        })
+      }
+    }
+
+    if (Array.isArray(update.labels)) {
+      requestBody.labels = update.labels
+    }
+
+    if (typeof update.assigneeId === 'string' && update.assigneeId.trim()) {
+      requestBody.assignee = update.assigneeId
+      requestBody.assignees = [ update.assigneeId ]
+    }
+
+    if (update.assigneeId === null) {
+      requestBody.assignees = []
+      requestBody.assignee = ''
+    }
+
+    if (Object.keys(requestBody).length === 0) {
+      return null
+    }
+
+    return requestBody
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object'
+  }
+}

--- a/common/src/issueTracking/polymorphism/issueTracker.ts
+++ b/common/src/issueTracking/polymorphism/issueTracker.ts
@@ -1,6 +1,6 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { IssueTracking } from '@prisma/client'
+import type { IssueTracking, IssueTrackingProvider } from '@prisma/client'
 import type {
   IssueTrackingIssue,
   IssueTrackingIssueList,
@@ -11,20 +11,33 @@ import type {
 } from '../types'
 
 // Misc
-import { DEFAULT_JIRA_CLOUD_BASE_URL } from '@common/constants'
+import {
+  DEFAULT_GITHUB_API_BASE_URL,
+  DEFAULT_JIRA_CLOUD_BASE_URL,
+} from '@common/constants'
 
 export class IssueTracker {
   protected readonly issueTracking: IssueTracking
 
-  public static resolveIssueTrackingBaseUrl(baseUrl?: string | null) {
+  public static resolveIssueTrackingBaseUrl(
+    baseUrl?: string | null,
+    provider: IssueTrackingProvider = 'Jira',
+  ) {
     const trimmed = baseUrl?.trim()
+
+    let providerDefaultBaseUrl: string = DEFAULT_JIRA_CLOUD_BASE_URL
+    if (provider === 'Github') {
+      providerDefaultBaseUrl = DEFAULT_GITHUB_API_BASE_URL
+    }
+
     const resolvedBaseUrl = trimmed?.length
       ? trimmed
-      : DEFAULT_JIRA_CLOUD_BASE_URL
+      : providerDefaultBaseUrl
 
     if (!trimmed?.length) {
-      console.debug('Issue tracking baseUrl missing, using default Jira base URL', {
-        defaultBaseUrl: DEFAULT_JIRA_CLOUD_BASE_URL,
+      console.debug('Issue tracking baseUrl missing, using default provider base URL', {
+        provider,
+        defaultBaseUrl: providerDefaultBaseUrl,
       })
     }
 

--- a/common/src/issueTracking/polymorphism/jira.ts
+++ b/common/src/issueTracking/polymorphism/jira.ts
@@ -23,7 +23,10 @@ export class JiraIssueTracker extends IssueTracker {
     super(issueTracking)
 
     const clientConfig = {
-      host: IssueTracker.resolveIssueTrackingBaseUrl(this.issueTracking.baseUrl),
+      host: IssueTracker.resolveIssueTrackingBaseUrl(
+        this.issueTracking.baseUrl,
+        this.issueTracking.provider,
+      ),
       authentication: {
         basic: {
           email: this.issueTracking.email,

--- a/common/src/schema/issueTracking.ts
+++ b/common/src/schema/issueTracking.ts
@@ -3,14 +3,51 @@
 import { z } from 'zod'
 import { IssueTrackingProvider } from '@prisma/client'
 
+const optionalStringSchema = z.string().trim().optional()
+
+function hasValue(value?: string) {
+  return Boolean(value?.trim())
+}
+
 export const upsertIssueTrackingSchema = z
   .object({
     name: z.string().trim().min(1).optional(),
     provider: z.nativeEnum(IssueTrackingProvider),
     baseUrl: z.string().trim().url().optional(),
-    email: z.string().trim().email().optional(),
-    accessToken: z.string().trim().optional(),
+    email: optionalStringSchema,
+    accessToken: optionalStringSchema,
     targetBoard: z.string().trim().min(1).optional(),
+  })
+  .superRefine((value, context) => {
+    const ownerOrEmail = value.email?.trim()
+    const targetBoard = value.targetBoard?.trim()
+
+    if (value.provider === 'Jira') {
+      if (hasValue(ownerOrEmail) && !z.string().email().safeParse(ownerOrEmail).success) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [ 'email' ],
+          message: 'Jira account email must be a valid email address',
+        })
+      }
+      return
+    }
+
+    if (!hasValue(ownerOrEmail)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [ 'email' ],
+        message: 'GitHub organization or owner is required',
+      })
+    }
+
+    if (!hasValue(targetBoard)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [ 'targetBoard' ],
+        message: 'GitHub repository is required',
+      })
+    }
   })
 
 export type UpsertIssueTrackingRequest = z.infer<typeof upsertIssueTrackingSchema>

--- a/electron/src/api/routes/v1/protected/issueTracking/upsertIssueTrackingRoute.ts
+++ b/electron/src/api/routes/v1/protected/issueTracking/upsertIssueTrackingRoute.ts
@@ -107,6 +107,7 @@ export async function handleUpsertIssueTrackingRequest(
 
   const resolvedBaseUrl = IssueTracker.resolveIssueTrackingBaseUrl(
     payload.baseUrl ?? existingIssueTracking?.baseUrl,
+    payload.provider,
   )
   const resolvedAccessToken = payload.accessToken
     || existingIssueTracking?.accessToken

--- a/frontend/src/elements/SearchIssueLinks.tsx
+++ b/frontend/src/elements/SearchIssueLinks.tsx
@@ -39,7 +39,7 @@ export function SearchIssueLinks(props: Props) {
     <Autocomplete
       className='w-full'
       fullWidth
-      label='Jira issue link'
+      label='Issue link'
       placeholder='PROJ-123'
       allowsCustomValue
       isLoading={issueSearch.isLoading}
@@ -54,7 +54,7 @@ export function SearchIssueLinks(props: Props) {
         props.onSelection(selectedValue)
       }}
       isDisabled={props.isDisabled || !props.issueTrackingId}
-      errorMessage={issueSearch.error ? 'Unable to load Jira issues right now.' : undefined}
+      errorMessage={issueSearch.error ? 'Unable to load issues right now.' : undefined}
       isInvalid={!!issueSearch.error && Boolean(search)}
     >{ issueSearch.issues.map((issue) => (
       <AutocompleteItem
@@ -72,13 +72,13 @@ export function SearchIssueLinks(props: Props) {
       selectedKeys={[ mode ]}
       onSelectionChange={(selection: Selection) => {
         if (selection === 'all') {
-          console.debug('SearchJiraIssueLinks received invalid mode selection "all"')
+          console.debug('SearchIssueLinks received invalid mode selection "all"')
           return
         }
 
         const [ selectedKey ] = Array.from(selection)
         if (selectedKey !== 'text' && selectedKey !== 'jql') {
-          console.debug('SearchJiraIssueLinks received unknown mode selection key', {
+          console.debug('SearchIssueLinks received unknown mode selection key', {
             selectedKey,
           })
           return

--- a/frontend/src/pages/data/issueTracking/ListIssueTrackingPage.tsx
+++ b/frontend/src/pages/data/issueTracking/ListIssueTrackingPage.tsx
@@ -22,7 +22,7 @@ import {
   DropdownMenu,
   DropdownTrigger,
 } from '@heroui/react'
-import { SiJirasoftware } from 'react-icons/si'
+import { SiGithub, SiJirasoftware } from 'react-icons/si'
 import {
   PlusIcon,
   EllipsisIcon,
@@ -41,7 +41,28 @@ import { UrlTree } from '@common/urls'
 
 const IconByProvider = {
   Jira: <SiJirasoftware className='icon' size={38} />,
+  Github: <SiGithub className='icon' size={38} />,
 } as const satisfies Record<IssueTracking['provider'], ReactNode>
+
+const ProviderOptions = [
+  {
+    key: 'jira',
+    provider: 'Jira',
+    icon: <SiJirasoftware className='icon' />,
+    label: 'Jira',
+  },
+  {
+    key: 'github',
+    provider: 'Github',
+    icon: <SiGithub className='icon' />,
+    label: 'GitHub',
+  },
+] as const satisfies {
+  key: string
+  provider: IssueTracking['provider']
+  icon: ReactNode
+  label: string
+}[]
 
 export function ListIssueTrackingPage() {
   // Input
@@ -50,6 +71,7 @@ export function ListIssueTrackingPage() {
 
   // State
   const [ selectedItem, select ] = useState<'new' | IssueTracking | null>(null)
+  const [ selectedProvider, setSelectedProvider ] = useState<IssueTracking['provider']>('Jira')
 
   // State maintenance
   useEffect(() => {
@@ -84,6 +106,11 @@ export function ListIssueTrackingPage() {
     navigate(UrlTree.tasks)
   }, [ navigate, selectedItem ])
 
+  function openCreateIssueTracking(provider: IssueTracking['provider']) {
+    setSelectedProvider(provider)
+    select('new')
+  }
+
   // Hotkeys
   useHotkey([ 'Escape' ], deselectAll, {
     preventDefault: true,
@@ -105,20 +132,22 @@ export function ListIssueTrackingPage() {
               </span>
             </Button>
           </DropdownTrigger>
-          <DropdownMenu aria-label='Static Actions'>
-            <DropdownItem
-              key='jira'
-              onPress={() => {
-                select('new')
-              }}
-            >
-              <div className='level-left w-full'>
-                <span className='icon'>
-                  <SiJirasoftware className='icon' />
-                </span>
-                <span>Jira</span>
-              </div>
-            </DropdownItem>
+          <DropdownMenu aria-label='Issue tracking providers'>
+            { ProviderOptions.map((providerOption) => (
+              <DropdownItem
+                key={providerOption.key}
+                onPress={() => {
+                  openCreateIssueTracking(providerOption.provider)
+                }}
+              >
+                <div className='level-left w-full'>
+                  <span className='icon'>
+                    {providerOption.icon}
+                  </span>
+                  <span>{providerOption.label}</span>
+                </div>
+              </DropdownItem>
+            ))}
           </DropdownMenu>
         </Dropdown>
       </div>
@@ -200,7 +229,7 @@ export function ListIssueTrackingPage() {
             : undefined
           }
           provider={selectedItem === 'new'
-            ? 'Jira'
+            ? selectedProvider
             : selectedItem.provider
           }
           close={() => select(null)}

--- a/frontend/src/pages/data/issueTracking/ViewIssueTrackingPage.tsx
+++ b/frontend/src/pages/data/issueTracking/ViewIssueTrackingPage.tsx
@@ -116,6 +116,28 @@ export function ViewIssueTrackingPage(props: Props) {
     enabled: isCreateMode,
   })
 
+  const accountNamePlaceholder = provider === 'Github'
+    ? 'Team GitHub'
+    : 'Team Jira'
+  const baseUrlPlaceholder = provider === 'Github'
+    ? 'https://api.github.com'
+    : 'https://company.atlassian.net'
+  const accountIdentityLabel = provider === 'Github'
+    ? 'Organization / owner'
+    : 'Account email'
+  const accountIdentityPlaceholder = provider === 'Github'
+    ? 'jalapenolabs'
+    : 'team@company.io'
+  const targetBoardLabel = provider === 'Github'
+    ? 'Repository'
+    : 'Target board'
+  const targetBoardPlaceholder = provider === 'Github'
+    ? 'seraphim'
+    : 'SER'
+  const tokenPlaceholder = provider === 'Github'
+    ? 'github_personal_access_token'
+    : 'jira_api_token'
+
   return <Card className='w-full'>
     <header className='compact level'>
       <h1 className='text-2xl font-bold'>
@@ -135,7 +157,7 @@ export function ViewIssueTrackingPage(props: Props) {
         <Input
           fullWidth
           label='Account name'
-          placeholder='Team Jira'
+          placeholder={accountNamePlaceholder}
           isInvalid={Boolean(form.formState.errors.name)}
           errorMessage={form.formState.errors.name?.message}
           value={form.watch('name')}
@@ -149,7 +171,7 @@ export function ViewIssueTrackingPage(props: Props) {
         <Input
           fullWidth
           label='Base URL'
-          placeholder='https://company.atlassian.net'
+          placeholder={baseUrlPlaceholder}
           isInvalid={Boolean(form.formState.errors.baseUrl)}
           errorMessage={form.formState.errors.baseUrl?.message}
           value={form.watch('baseUrl')}
@@ -162,8 +184,8 @@ export function ViewIssueTrackingPage(props: Props) {
       <div className='compact'>
         <Input
           fullWidth
-          label='Account email'
-          placeholder='team@company.io'
+          label={accountIdentityLabel}
+          placeholder={accountIdentityPlaceholder}
           isInvalid={Boolean(form.formState.errors.email)}
           errorMessage={form.formState.errors.email?.message}
           value={form.watch('email')}
@@ -176,8 +198,8 @@ export function ViewIssueTrackingPage(props: Props) {
       <div className='compact'>
         <Input
           fullWidth
-          label='Target board'
-          placeholder='SER'
+          label={targetBoardLabel}
+          placeholder={targetBoardPlaceholder}
           isInvalid={Boolean(form.formState.errors.targetBoard)}
           errorMessage={form.formState.errors.targetBoard?.message}
           value={form.watch('targetBoard')}
@@ -190,7 +212,7 @@ export function ViewIssueTrackingPage(props: Props) {
       <div className='compact'>
         <Input
           label='Access token'
-          placeholder='jira_api_token'
+          placeholder={tokenPlaceholder}
           fullWidth
           type='password'
           autoComplete='off'

--- a/frontend/src/routes/issueTrackingRoutes.ts
+++ b/frontend/src/routes/issueTrackingRoutes.ts
@@ -40,7 +40,7 @@ export async function listIssueTracking(): Promise<ListIssueTrackingResponse> {
 
 
 // /////////////////////////////// //
-//        List Jira Issues         //
+//        List provider issues         //
 // /////////////////////////////// //
 
 type ListIssueTrackingIssuesResponse = IssueTrackingIssueList & {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ enum AuthProvider {
 
 enum IssueTrackingProvider {
   Jira
+  Github
 }
 
 enum Role {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8933,6 +8933,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "common@workspace:common"
   dependencies:
+    "@octokit/core": "npm:^7.0.6"
+    "@octokit/request-error": "npm:^7.0.2"
     "@openai/codex-sdk": "npm:^0.98.0"
     glob: "npm:^13.0.0"
     jira.js: "npm:^5.3.0"


### PR DESCRIPTION
### Motivation
- Provide a first-class GitHub issue-tracker implementation so users can link GitHub org/repo accounts with a personal access token and search/manage issues alongside existing Jira support.
- Reuse the existing polymorphic issue-tracker architecture so the new provider plugs into the same server routes and UI flows as Jira.

### Description
- Added `GithubIssueTracker` implementing `IssueTracker` with credential `check`, `listIssues` (via GitHub search API), `getIssueById`, `listLabels`, `listStatusTypes`, and `updateIssueById` logic in `common/src/issueTracking/polymorphism/github.ts` and accompanying unit tests `common/src/issueTracking/polymorphism/github.test.ts`.
- Wired provider dispatch so `getIssueTracker` resolves `IssueTrackingProvider.Github` to the new tracker and added `Github` to Prisma `IssueTrackingProvider` enum in `prisma/schema.prisma`.
- Extended base URL resolver to be provider-aware and added `DEFAULT_GITHUB_API_BASE_URL` in `common/src/constants.ts`, and updated Jira construction to reuse the provider-aware resolver.
- Made upsert validation provider-aware in `common/src/schema/issueTracking.ts` (Jira validates email, GitHub requires owner/org + repo), and forwarded the provider when resolving default base URLs in the upsert route (`electron/src/api/routes/.../upsertIssueTrackingRoute.ts`).
- Updated frontend UX to expose both Jira and GitHub in the Link New dropdown, show provider icons, render provider-specific labels/placeholders (owner/repo/token), and generalized issue-link text in `frontend/src/pages/data/issueTracking/*` and `frontend/src/elements/SearchIssueLinks.tsx`.
- Added `@octokit/core` and `@octokit/request-error` to the `common` workspace dependencies and updated frontend/common code that consumes the issue-tracker surfaces.

### Testing
- Ran `yarn install` successfully to fetch dependencies.
- Ran `yarn prisma generate` successfully to regenerate Prisma client artifacts for local validation.
- Ran unit tests with `yarn vitest common/src/issueTracking/polymorphism/github.test.ts common/src/issueTracking/polymorphism/jira.test.ts` and they completed with the GitHub tests passing and Jira tests exercised (summary: 2 test files, 5 tests passed and 4 tests skipped).
- Ran `yarn --cwd frontend typecheck` and `yarn --cwd common typecheck` and both typechecks succeeded for their workspaces.
- Note: `yarn generate` (root) was attempted to rebuild vendor assets but failed due to network connectivity when downloading BuildKit artifacts (`ENETUNREACH`), and `yarn typecheck` at the repo root still fails because those generated BuildKit vendor modules are missing; these failures are external to the GitHub tracker changes and require `yarn generate` to complete successfully in a network-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9bc47904832281e38624283d49bd)