### PR TITLE
Environment variables with secret scrubbing (closes #59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,13 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   (= environment setup), `config_repo_url`, `default_branch_template`,
   `current_session_id` (the one shared Claude session), and the secret columns
   `claude_oauth_token` / `github_token` (the API only ever exposes
-  `*_token_set` booleans, never the raw values; write via `POST /settings/tokens`).
+  `*_token_set` booleans plus a masked `*_token_preview`, never the raw values;
+  write via `POST /settings/tokens`).
+- **`environment_variables`** — user-defined `key` / `value` / `is_secret` rows,
+  injected into the agent's turn and setup execs at runtime. A secret value is
+  scrubbed out of Claude's output before anything is persisted or streamed
+  (`secrets::Scrubber`), and the API only ever returns it masked. CRUD via
+  `GET`/`PUT /settings/env`.
 - **`repositories`** — `full_name`, `clone_url`, `default_branch`,
   `branch_template`, `setup_script` (per-repo setup), `instructions`,
   `review_policy` (NULL = inherit default), `enabled`, `sync_issues` (poll this

--- a/api/migrations/0006_env_vars.sql
+++ b/api/migrations/0006_env_vars.sql
@@ -1,0 +1,13 @@
+-- User-defined environment variables, injected into the agent's execs at runtime
+-- (the same way the Claude/GitHub tokens are). A row flagged `is_secret` is also
+-- scrubbed out of Claude's output before anything is persisted or streamed, and
+-- the API only ever returns a masked preview of its value.
+
+CREATE TABLE environment_variables (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key        TEXT NOT NULL UNIQUE,
+    value      TEXT NOT NULL DEFAULT '',
+    is_secret  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/api/src/claude/exec.rs
+++ b/api/src/claude/exec.rs
@@ -30,6 +30,21 @@ pub struct TurnArgs {
     pub oauth_token: String,
     /// GitHub token, so the agent's `gh`/`git` are authed for this turn.
     pub github_token: String,
+    /// User-defined environment variables (`key`, `value`) for this exec.
+    pub env: Vec<(String, String)>,
+}
+
+/// Builds the exec environment: the auth tokens plus any user-defined variables.
+/// User variables come last so they cannot shadow the tokens we control.
+fn build_env(args: &TurnArgs) -> Vec<String> {
+    let mut env = vec![
+        format!("CLAUDE_CODE_OAUTH_TOKEN={}", args.oauth_token),
+        format!("GH_TOKEN={}", args.github_token),
+    ];
+    for (key, value) in &args.env {
+        env.push(format!("{key}={value}"));
+    }
+    env
 }
 
 /// Builds the `claude` argv for a headless, fully-autonomous turn.
@@ -71,10 +86,7 @@ pub fn run_turn(docker: &Docker, args: TurnArgs) -> impl Stream<Item = Result<Ag
                     working_dir: Some(args.working_dir.clone()),
                     // Secrets are injected per-exec from the database, never baked
                     // into the container's environment.
-                    env: Some(vec![
-                        format!("CLAUDE_CODE_OAUTH_TOKEN={}", args.oauth_token),
-                        format!("GH_TOKEN={}", args.github_token),
-                    ]),
+                    env: Some(build_env(&args)),
                     // Claude must not run as root with bypassPermissions.
                     user: Some("node".to_string()),
                     attach_stdout: Some(true),
@@ -136,6 +148,7 @@ mod tests {
             model: "claude-opus-4-8[1m]".to_string(),
             oauth_token: "tok".to_string(),
             github_token: "gh".to_string(),
+            env: vec![],
         };
         let command = build_command(&args);
         assert!(command.contains(&"--resume".to_string()));
@@ -154,6 +167,7 @@ mod tests {
             model: "claude-opus-4-8[1m]".to_string(),
             oauth_token: "tok".to_string(),
             github_token: "gh".to_string(),
+            env: vec![],
         };
         let command = build_command(&args);
         assert!(!command.contains(&"--resume".to_string()));

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -78,6 +78,39 @@ pub struct Settings {
     pub claude_token_set: bool,
     /// Whether a GitHub token is stored (the token itself is never sent).
     pub github_token_set: bool,
+    /// Masked preview of the stored Claude token, e.g. `sk-ant-****abcd`. Not a
+    /// DB column; the settings handler fills it from the raw token so an operator
+    /// can recognize what is stored without it being revealed.
+    #[sqlx(default)]
+    pub claude_token_preview: Option<String>,
+    /// Masked preview of the stored GitHub token. Filled like
+    /// [`Self::claude_token_preview`].
+    #[sqlx(default)]
+    pub github_token_preview: Option<String>,
+}
+
+/// A user-defined environment variable injected into the agent's execs.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct EnvVar {
+    pub id: Uuid,
+    pub key: String,
+    pub value: String,
+    /// When true, the value is scrubbed from output and only ever returned masked.
+    pub is_secret: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// One environment variable as submitted by the settings UI.
+///
+/// `value` is optional so a secret can be left unchanged: `None` means "keep the
+/// stored value" (the UI never receives raw secrets to send back), while `Some`
+/// sets a new value.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EnvVarWrite {
+    pub key: String,
+    pub value: Option<String>,
+    pub is_secret: bool,
 }
 
 /// A repository the agent is allowed to clone and work in.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -3,13 +3,16 @@
 //! Functions take a `&PgPool` and return [`sqlx::Result`]; callers lift errors
 //! into the application's `eyre` result with `?`.
 
+use std::collections::HashMap;
+
 use serde_json::Value;
 use sqlx::types::Json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    Repository, ReviewPolicy, Settings, SourceKind, Task, TaskColumn, TaskStatus, Turn,
+    EnvVar, EnvVarWrite, Repository, ReviewPolicy, Settings, SourceKind, Task, TaskColumn,
+    TaskStatus, Turn,
 };
 
 // --- Settings ----------------------------------------------------------------
@@ -116,6 +119,85 @@ pub async fn set_tokens(
     .execute(pool)
     .await?;
     Ok(())
+}
+
+// --- Environment variables ---------------------------------------------------
+
+/// All environment variables, ordered by key, with their raw values. Internal
+/// use only (injection + secret scrubbing); the HTTP layer masks secrets.
+pub async fn list_environment_variables(pool: &PgPool) -> sqlx::Result<Vec<EnvVar>> {
+    sqlx::query_as::<_, EnvVar>("SELECT * FROM environment_variables ORDER BY key")
+        .fetch_all(pool)
+        .await
+}
+
+/// Every secret value that should be scrubbed from agent output: the secret
+/// environment variables plus the stored Claude and GitHub tokens. Empty values
+/// are omitted.
+pub async fn list_secret_values(pool: &PgPool) -> sqlx::Result<Vec<String>> {
+    let values: Vec<String> = sqlx::query_scalar(
+        "SELECT value FROM environment_variables WHERE is_secret = TRUE AND value <> '' \
+         UNION ALL \
+         SELECT claude_oauth_token FROM settings WHERE id = 1 AND claude_oauth_token <> '' \
+         UNION ALL \
+         SELECT github_token FROM settings WHERE id = 1 AND github_token <> ''",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(values)
+}
+
+/// Replaces the whole set of environment variables in one transaction.
+///
+/// Keys absent from `variables` are deleted. For each entry, a `Some` value is
+/// written verbatim; a `None` value keeps the currently-stored value (used for
+/// secrets the UI never received and so cannot resend). Returns the resulting
+/// rows, ordered by key.
+pub async fn replace_environment_variables(
+    pool: &PgPool,
+    variables: &[EnvVarWrite],
+) -> sqlx::Result<Vec<EnvVar>> {
+    let mut tx = pool.begin().await?;
+
+    // Existing values, so a `None` (unchanged secret) can be preserved.
+    let existing: HashMap<String, String> =
+        sqlx::query_as::<_, (String, String)>("SELECT key, value FROM environment_variables")
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .collect();
+
+    let mut keys: Vec<String> = Vec::with_capacity(variables.len());
+    for variable in variables {
+        let key = variable.key.trim();
+        if key.is_empty() {
+            continue; // Skip blank rows the UI may leave behind.
+        }
+        let value = match &variable.value {
+            Some(value) => value.clone(),
+            None => existing.get(key).cloned().unwrap_or_default(),
+        };
+        sqlx::query(
+            "INSERT INTO environment_variables (key, value, is_secret) VALUES ($1, $2, $3) \
+             ON CONFLICT (key) DO UPDATE SET \
+             value = EXCLUDED.value, is_secret = EXCLUDED.is_secret, updated_at = now()",
+        )
+        .bind(key)
+        .bind(&value)
+        .bind(variable.is_secret)
+        .execute(&mut *tx)
+        .await?;
+        keys.push(key.to_string());
+    }
+
+    // Drop any variable the UI removed.
+    sqlx::query("DELETE FROM environment_variables WHERE key <> ALL($1)")
+        .bind(&keys)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+    list_environment_variables(pool).await
 }
 
 // --- Repositories ------------------------------------------------------------

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -65,6 +65,10 @@ pub fn router(state: AppState) -> Router {
         .route("/settings", get(settings::get).patch(settings::update))
         .route("/settings/pause", post(settings::set_pause))
         .route("/settings/tokens", post(settings::set_tokens))
+        .route(
+            "/settings/env",
+            get(settings::list_env).put(settings::set_env),
+        )
         .route("/workspace/restart", post(workspace::restart))
         .route("/workspace/recreate", post(workspace::recreate))
         .route("/workspace/provision", post(workspace::provision))

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -1,17 +1,30 @@
-//! Org/environment settings endpoints, including the agent pause switch.
+//! Org/environment settings endpoints, including the agent pause switch and the
+//! user-defined environment variables.
 
 use axum::extract::State;
 use axum::Json;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::ApiResult;
-use crate::db::models::{ReviewPolicy, Settings};
+use crate::db::models::{EnvVarWrite, ReviewPolicy, Settings};
 use crate::db::queries;
+use crate::secrets::mask;
 use crate::state::AppState;
+
+/// Loads the settings and fills in the masked token previews, so the UI can show
+/// a recognizable hint of each stored secret without ever receiving the raw value.
+async fn settings_view(state: &AppState) -> ApiResult<Settings> {
+    let mut settings = queries::get_settings(&state.db).await?;
+    let claude = queries::get_claude_token(&state.db).await?;
+    let github = queries::get_github_token(&state.db).await?;
+    settings.claude_token_preview = (!claude.is_empty()).then(|| mask(&claude));
+    settings.github_token_preview = (!github.is_empty()).then(|| mask(&github));
+    Ok(settings)
+}
 
 /// `GET /api/v1/settings`
 pub async fn get(State(state): State<AppState>) -> ApiResult<Json<Settings>> {
-    Ok(Json(queries::get_settings(&state.db).await?))
+    Ok(Json(settings_view(&state).await?))
 }
 
 #[derive(Debug, Deserialize)]
@@ -30,7 +43,7 @@ pub async fn update(
     State(state): State<AppState>,
     Json(body): Json<UpdateSettingsRequest>,
 ) -> ApiResult<Json<Settings>> {
-    let settings = queries::update_settings(
+    queries::update_settings(
         &state.db,
         body.org_name,
         body.global_instructions,
@@ -42,7 +55,7 @@ pub async fn update(
     )
     .await?;
     state.notify_board();
-    Ok(Json(settings))
+    Ok(Json(settings_view(&state).await?))
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,7 +77,7 @@ pub async fn set_tokens(
         body.github_token.filter(|token| !token.is_empty()),
     )
     .await?;
-    Ok(Json(queries::get_settings(&state.db).await?))
+    Ok(Json(settings_view(&state).await?))
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,5 +92,63 @@ pub async fn set_pause(
 ) -> ApiResult<Json<Settings>> {
     queries::set_paused(&state.db, body.paused).await?;
     state.notify_board();
-    Ok(Json(queries::get_settings(&state.db).await?))
+    Ok(Json(settings_view(&state).await?))
+}
+
+// --- Environment variables ---------------------------------------------------
+
+/// One environment variable as the UI sees it. A secret's `value` is the masked
+/// preview, never the raw secret.
+#[derive(Debug, Serialize)]
+pub struct EnvVarView {
+    pub key: String,
+    pub value: String,
+    pub is_secret: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnvVarsResponse {
+    pub variables: Vec<EnvVarView>,
+}
+
+/// Builds the masked, UI-facing view of the stored environment variables.
+async fn env_vars_view(state: &AppState) -> ApiResult<EnvVarsResponse> {
+    let variables = queries::list_environment_variables(&state.db)
+        .await?
+        .into_iter()
+        .map(|variable| EnvVarView {
+            key: variable.key,
+            // Secrets are only ever exposed masked, so the operator can identify
+            // a value without it being revealed.
+            value: if variable.is_secret {
+                mask(&variable.value)
+            } else {
+                variable.value
+            },
+            is_secret: variable.is_secret,
+        })
+        .collect();
+    Ok(EnvVarsResponse { variables })
+}
+
+/// `GET /api/v1/settings/env` - list environment variables (secrets masked).
+pub async fn list_env(State(state): State<AppState>) -> ApiResult<Json<EnvVarsResponse>> {
+    Ok(Json(env_vars_view(&state).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetEnvRequest {
+    pub variables: Vec<EnvVarWrite>,
+}
+
+/// `PUT /api/v1/settings/env` - replace the whole set of environment variables.
+///
+/// A secret whose `value` is omitted keeps its stored value (the UI never holds
+/// the raw secret to resend). Responds with the refreshed, masked list.
+pub async fn set_env(
+    State(state): State<AppState>,
+    Json(body): Json<SetEnvRequest>,
+) -> ApiResult<Json<EnvVarsResponse>> {
+    queries::replace_environment_variables(&state.db, &body.variables).await?;
+    Ok(Json(env_vars_view(&state).await?))
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -11,6 +11,7 @@ mod docker;
 mod git;
 mod http;
 mod orchestrator;
+mod secrets;
 mod state;
 
 use eyre::{Context, Result};

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -25,6 +25,7 @@ use crate::claude::{run_turn, AgentEventKind, TurnArgs};
 use crate::db::models::{Repository, ReviewPolicy, SourceKind, Task, TaskColumn, TaskStatus};
 use crate::db::queries;
 use crate::git;
+use crate::secrets::Scrubber;
 use crate::state::AppState;
 
 /// How often the agent loop checks for work when idle.
@@ -238,6 +239,16 @@ async fn run_agent_turn(
     )
     .await?;
 
+    // User-defined environment variables are injected into the agent's exec.
+    let env = queries::list_environment_variables(&state.db)
+        .await?
+        .into_iter()
+        .map(|variable| (variable.key, variable.value))
+        .collect();
+    // Every secret (env vars + tokens) is scrubbed from output before it is
+    // persisted or streamed, so a secret the agent echoes never leaks.
+    let scrubber = Scrubber::new(queries::list_secret_values(&state.db).await?);
+
     let args = TurnArgs {
         container: state.workspace.container().to_string(),
         working_dir,
@@ -246,6 +257,7 @@ async fn run_agent_turn(
         model: settings.claude_model.clone(),
         oauth_token: queries::get_claude_token(&state.db).await?,
         github_token: queries::get_github_token(&state.db).await?,
+        env,
     };
 
     let mut stream = Box::pin(run_turn(state.workspace.docker(), args));
@@ -275,20 +287,23 @@ async fn run_agent_turn(
         } = &event.kind
         {
             total_cost = *total_cost_usd;
-            result_text.clone_from(text);
+            result_text = text.as_deref().map(|text| scrubber.scrub_text(text));
             if *is_error {
-                error_message = Some(
-                    text.clone()
-                        .unwrap_or_else(|| "the agent reported an error".to_string()),
-                );
+                let message = text
+                    .clone()
+                    .unwrap_or_else(|| "the agent reported an error".to_string());
+                error_message = Some(scrubber.scrub_text(&message));
             }
         }
 
         let label = event.type_label();
-        queries::append_event(&state.db, turn.id, seq, label, event.raw.clone()).await?;
+        // Scrub secrets out of the payload before it touches the DB or the stream.
+        let mut payload = event.raw.clone();
+        scrubber.scrub_value(&mut payload);
+        queries::append_event(&state.db, turn.id, seq, label, payload.clone()).await?;
         state.notify_task(
             task.id,
-            serde_json::json!({ "type": label, "payload": event.raw }),
+            serde_json::json!({ "type": label, "payload": payload }),
         );
         queries::set_task_status(&state.db, task.id, TaskStatus::Working)
             .await

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -163,7 +163,11 @@ async fn run(state: &AppState, script: &str) -> Result<()> {
     // Wire git's credential helper for HTTPS remotes (GH_TOKEN is in this exec's
     // env); SSH remotes use the mounted key instead.
     let full_script = format!("gh auth setup-git >/dev/null 2>&1 || true\n{script}");
-    let env = vec![format!("GH_TOKEN={github_token}")];
+    // User-defined env vars are available to setup scripts (e.g. registry tokens).
+    let mut env = vec![format!("GH_TOKEN={github_token}")];
+    for variable in queries::list_environment_variables(&state.db).await? {
+        env.push(format!("{}={}", variable.key, variable.value));
+    }
     let output = state
         .workspace
         .exec_capture(

--- a/api/src/secrets.rs
+++ b/api/src/secrets.rs
@@ -1,0 +1,217 @@
+//! Masking and scrubbing of secret values.
+//!
+//! Two related jobs live here:
+//!
+//! - [`mask`] turns a raw secret into a human-identifiable preview, e.g.
+//!   `sk_live_123456789` becomes `sk_live_*****6789`. It is used both for the
+//!   settings page (so an operator can recognize a stored token without it being
+//!   fully revealed) and as the replacement text when scrubbing.
+//! - [`Scrubber`] removes a known set of secret values from arbitrary text and
+//!   JSON, so a secret the agent happens to echo never reaches the database, the
+//!   live event stream, or the logs.
+//!
+//! Both are pure and unit-tested; the orchestrator builds a [`Scrubber`] from the
+//! configured secrets once per turn and runs every event through it.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+/// Recognized secret prefixes whose identifying lead-in is kept when masking.
+///
+/// Keeping the prefix (plus the last few characters) lets an operator tell two
+/// tokens apart at a glance without exposing the secret itself.
+const KNOWN_PREFIXES: &[&str] = &[
+    "sk-ant-",
+    "github_pat_",
+    "ghp_",
+    "gho_",
+    "ghs_",
+    "sk_live_",
+    "sk_test_",
+];
+
+/// How many trailing characters stay visible when a known prefix is recognized.
+const REVEALED_TAIL: usize = 4;
+
+/// Shortest secret length we will scrub from output.
+///
+/// Scrubbing replaces every occurrence of a secret, so a very short value (say
+/// `"1"`) would corrupt unrelated text. Real tokens are long; we refuse to scrub
+/// anything shorter than this to stay safe. Masking, by contrast, applies to any
+/// length.
+const MIN_SCRUB_LEN: usize = 4;
+
+/// Masks a secret into an identifiable preview, preserving its length.
+///
+/// A value beginning with a [`KNOWN_PREFIXES`] entry keeps that prefix and its
+/// last [`REVEALED_TAIL`] characters, with the middle replaced by `*`. Any other
+/// value is fully masked. An empty input returns an empty string.
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(mask("sk_live_123456789"), "sk_live_*****6789");
+/// assert_eq!(mask("12345"), "*****");
+/// ```
+pub fn mask(secret: &str) -> String {
+    let total = secret.chars().count();
+    if total == 0 {
+        return String::new();
+    }
+
+    let Some(prefix) = KNOWN_PREFIXES
+        .iter()
+        .copied()
+        .find(|prefix| secret.starts_with(prefix))
+    else {
+        // No recognized prefix: fully mask, honoring length.
+        return "*".repeat(total);
+    };
+
+    let prefix_len = prefix.chars().count();
+    // Only reveal the tail when doing so still hides a meaningful middle section;
+    // otherwise keep just the prefix so we never expose most of a short secret.
+    if total > prefix_len + REVEALED_TAIL {
+        let masked = total - prefix_len - REVEALED_TAIL;
+        let tail: String = secret.chars().skip(total - REVEALED_TAIL).collect();
+        format!("{prefix}{}{tail}", "*".repeat(masked))
+    } else {
+        format!("{prefix}{}", "*".repeat(total - prefix_len))
+    }
+}
+
+/// Replaces known secret values with their masked form wherever they appear.
+///
+/// Built once from the configured secrets, then applied to every persisted or
+/// streamed event. Replacements run longest-secret-first so that one secret
+/// containing another is masked before its shorter substring.
+#[derive(Debug, Clone, Default)]
+pub struct Scrubber {
+    /// `(secret, mask)` pairs, sorted by descending secret length.
+    replacements: Vec<(String, String)>,
+}
+
+impl Scrubber {
+    /// Builds a scrubber from raw secret values, ignoring empties, duplicates,
+    /// and values too short to scrub safely (see [`MIN_SCRUB_LEN`]).
+    pub fn new<I: IntoIterator<Item = String>>(secrets: I) -> Self {
+        let mut seen = HashSet::new();
+        let mut replacements: Vec<(String, String)> = secrets
+            .into_iter()
+            .filter(|secret| secret.chars().count() >= MIN_SCRUB_LEN)
+            .filter(|secret| seen.insert(secret.clone()))
+            .map(|secret| {
+                let masked = mask(&secret);
+                (secret, masked)
+            })
+            .collect();
+        // Longest first so a secret that contains another is replaced before it.
+        replacements.sort_by(|left, right| right.0.len().cmp(&left.0.len()));
+        Self { replacements }
+    }
+
+    /// Returns `text` with every known secret replaced by its masked form.
+    pub fn scrub_text(&self, text: &str) -> String {
+        let mut scrubbed = text.to_string();
+        for (secret, masked) in &self.replacements {
+            if scrubbed.contains(secret.as_str()) {
+                scrubbed = scrubbed.replace(secret.as_str(), masked);
+            }
+        }
+        scrubbed
+    }
+
+    /// Scrubs every string contained in a JSON value, in place.
+    ///
+    /// Object keys are left untouched (they are field names, not secrets); only
+    /// string values, including those nested in arrays and objects, are masked.
+    pub fn scrub_value(&self, value: &mut Value) {
+        match value {
+            Value::String(text) => {
+                if self
+                    .replacements
+                    .iter()
+                    .any(|(secret, _)| text.contains(secret.as_str()))
+                {
+                    *text = self.scrub_text(text);
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    self.scrub_value(item);
+                }
+            }
+            Value::Object(map) => {
+                for nested in map.values_mut() {
+                    self.scrub_value(nested);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn masks_unknown_secret_fully_preserving_length() {
+        assert_eq!(mask("12345"), "*****");
+        assert_eq!(mask(""), "");
+        assert_eq!(mask("abcdefghij"), "**********");
+    }
+
+    #[test]
+    fn keeps_known_prefix_and_last_four() {
+        assert_eq!(mask("sk_live_123456789"), "sk_live_*****6789");
+        assert_eq!(mask("sk-ant-abcdefghhijk"), "sk-ant-********hijk");
+    }
+
+    #[test]
+    fn short_known_prefix_keeps_only_the_prefix() {
+        // Not long enough to also reveal a tail without exposing most of it.
+        assert_eq!(mask("ghp_ab"), "ghp_**");
+        assert_eq!(mask("github_pat_12"), "github_pat_**");
+    }
+
+    #[test]
+    fn scrubber_replaces_secret_in_text() {
+        let scrubber = Scrubber::new(["github_pat_ABCDEFGH1234".to_string()]);
+        let result = scrubber.scrub_text("the token is github_pat_ABCDEFGH1234 ok");
+        assert_eq!(result, "the token is github_pat_********1234 ok");
+    }
+
+    #[test]
+    fn scrubber_ignores_empty_and_too_short_values() {
+        // Empty and sub-threshold values are dropped, so nothing is replaced.
+        let scrubber = Scrubber::new([String::new(), "ab".to_string()]);
+        assert_eq!(scrubber.scrub_text("ab cd"), "ab cd");
+    }
+
+    #[test]
+    fn scrubber_walks_nested_json_values_but_not_keys() {
+        let scrubber = Scrubber::new(["sk_live_123456789".to_string()]);
+        let mut value = json!({
+            "text": "key=sk_live_123456789",
+            "nested": ["sk_live_123456789", 42],
+            "sk_live_123456789": "untouched-key"
+        });
+        scrubber.scrub_value(&mut value);
+
+        assert_eq!(value["text"], "key=sk_live_*****6789");
+        assert_eq!(value["nested"][0], "sk_live_*****6789");
+        assert_eq!(value["nested"][1], 42);
+        // The key itself is a field name, not a value, so it is left as-is.
+        assert_eq!(value["sk_live_123456789"], "untouched-key");
+    }
+
+    #[test]
+    fn longer_secrets_are_scrubbed_before_shorter_substrings() {
+        let scrubber = Scrubber::new(["abcdef".to_string(), "abcdef1234567890".to_string()]);
+        let result = scrubber.scrub_text("abcdef1234567890");
+        // The full-length secret wins, so we get its mask, not a partial one.
+        assert_eq!(result, mask("abcdef1234567890"));
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "node build",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.2.0",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ import ky from 'ky'
 import type {
   BoardResponse,
   ConfigBundle,
+  EnvVar,
   Repository,
   ReviewPolicy,
   Settings,
@@ -103,6 +104,26 @@ export type TokensRequest = {
 
 export function setTokens(body: TokensRequest) {
   return apiClient.post('settings/tokens', { json: body }).json<Settings>()
+}
+
+type EnvVarsResponse = {
+  variables: EnvVar[]
+}
+
+export function listEnvVars() {
+  return apiClient.get('settings/env').json<EnvVarsResponse>()
+}
+
+// One variable to write. `value` is omitted for a secret left unchanged, so the
+// server keeps its stored value (the UI never holds the raw secret to resend).
+export type EnvVarWrite = {
+  key: string
+  value?: string
+  is_secret: boolean
+}
+
+export function setEnvVars(variables: EnvVarWrite[]) {
+  return apiClient.put('settings/env', { json: { variables } }).json<EnvVarsResponse>()
 }
 
 export function restartWorkspace() {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -53,6 +53,18 @@ export type Settings = {
   updated_at: string
   claude_token_set: boolean
   github_token_set: boolean
+  // Masked previews of the stored tokens (e.g. "sk-ant-****abcd"), or null when
+  // unset. The raw tokens are never sent.
+  claude_token_preview: string | null
+  github_token_preview: string | null
+}
+
+// A user-defined environment variable as the UI sees it. For a secret, `value`
+// is the masked preview returned by the API, never the raw secret.
+export type EnvVar = {
+  key: string
+  value: string
+  is_secret: boolean
 }
 
 export type Repository = {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { ReviewPolicy, Settings } from '$lib/types'
+  import type { EnvVar, ReviewPolicy, Settings } from '$lib/types'
+  import type { EnvVarWrite } from '$lib/api'
 
   import { onMount } from 'svelte'
 
@@ -8,13 +9,25 @@
     exportConfig,
     getSettings,
     importConfig,
+    listEnvVars,
     recreateWorkspace,
     restartWorkspace,
+    setEnvVars,
     setTokens,
     updateSettings
   } from '$lib/api'
 
   const CUSTOM_MODEL = '__custom__'
+
+  // One editable row in the environment-variables table. For a secret loaded from
+  // the server, `value` starts blank and `preview` holds the masked stored value;
+  // leaving it blank on save keeps the stored secret unchanged.
+  type EnvRow = {
+    key: string
+    value: string
+    is_secret: boolean
+    preview: string | null
+  }
 
   let settings = $state<Settings | null>(null)
   let savedAt = $state<string | null>(null)
@@ -29,7 +42,22 @@
   // Model picker: a dropdown of known ids plus a custom free-text fallback.
   let modelChoice = $state<string>(KNOWN_MODELS[0].value)
 
+  // Environment variables (DigitalOcean-style rows).
+  let envRows = $state<EnvRow[]>([])
+  let envMessage = $state<string | null>(null)
+
   const policies: ReviewPolicy[] = ['auto_squash_merge', 'human_review', 'none']
+
+  function toEnvRow(variable: EnvVar): EnvRow {
+    return {
+      key: variable.key,
+      // Secrets arrive masked; show that as a placeholder and keep the input
+      // blank so an unedited secret is preserved on save.
+      value: variable.is_secret ? '' : variable.value,
+      is_secret: variable.is_secret,
+      preview: variable.is_secret ? variable.value : null
+    }
+  }
 
   async function load() {
     const loaded = await getSettings()
@@ -37,6 +65,36 @@
     modelChoice = KNOWN_MODELS.some((model) => model.value === loaded.claude_model)
       ? loaded.claude_model
       : CUSTOM_MODEL
+    const env = await listEnvVars()
+    envRows = env.variables.map(toEnvRow)
+  }
+
+  function addEnvRow() {
+    envRows = [...envRows, { key: '', value: '', is_secret: false, preview: null }]
+  }
+
+  function removeEnvRow(index: number) {
+    envRows = envRows.filter((_, position) => position !== index)
+  }
+
+  async function saveEnv() {
+    const variables: EnvVarWrite[] = envRows
+      .filter((row) => row.key.trim())
+      .map((row) => {
+        const key = row.key.trim()
+        if (!row.is_secret) {
+          return { key, value: row.value, is_secret: false }
+        }
+        // A blank secret input keeps the stored value, so omit it; otherwise the
+        // typed value becomes the new secret.
+        if (row.value) {
+          return { key, value: row.value, is_secret: true }
+        }
+        return { key, is_secret: true }
+      })
+    const saved = await setEnvVars(variables)
+    envRows = saved.variables.map(toEnvRow)
+    envMessage = 'Saved.'
   }
 
   function onModelChange() {
@@ -206,6 +264,9 @@
           placeholder="from `claude setup-token`"
           bind:value={claudeTokenInput}
         />
+        {#if settings.claude_token_preview}
+          <p class="hint">Stored: <code>{settings.claude_token_preview}</code></p>
+        {/if}
       </div>
       <div class="field">
         <label for="gh-token">
@@ -221,10 +282,54 @@
           placeholder="PAT with repo + issues scope"
           bind:value={githubTokenInput}
         />
+        {#if settings.github_token_preview}
+          <p class="hint">Stored: <code>{settings.github_token_preview}</code></p>
+        {/if}
       </div>
       <div class="actions">
         <button class="primary" onclick={saveTokens}>Save secrets</button>
         {#if tokensMessage}<span class="muted">{tokensMessage}</span>{/if}
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Environment variables</h2>
+      <p class="hint">
+        Injected into the agent's environment at runtime (alongside its tokens) and available to
+        setup scripts. Mark a row <strong>secret</strong> to have its value scrubbed from the
+        agent's output before it reaches the logs or database, and only ever shown here masked.
+      </p>
+
+      {#if envRows.length}
+        <div class="env-table">
+          {#each envRows as row, index}
+            <div class="env-row">
+              <input class="env-key" placeholder="KEY" bind:value={row.key} />
+              <input
+                class="env-value"
+                type={row.is_secret ? 'password' : 'text'}
+                placeholder={row.is_secret && row.preview ? `${row.preview} (leave blank to keep)` : 'value'}
+                autocomplete="off"
+                bind:value={row.value}
+              />
+              <label class="env-secret" title="Scrub this value from all output">
+                <input type="checkbox" bind:checked={row.is_secret} />
+                <span>secret</span>
+              </label>
+              <button class="env-delete" title="Remove" onclick={() => removeEnvRow(index)}>
+                ✕
+              </button>
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <p class="muted">No environment variables yet.</p>
+      {/if}
+
+      <div class="actions">
+        <button onclick={addEnvRow}>+ Add another</button>
+        <button class="primary" onclick={saveEnv}>Save variables</button>
+        {#if envMessage}<span class="muted">{envMessage}</span>{/if}
       </div>
     </section>
 
@@ -330,6 +435,46 @@
 
   .custom-model {
     margin-top: 0.4rem;
+  }
+
+  .env-table {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0.6rem 0 0.9rem;
+  }
+
+  .env-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .env-key {
+    flex: 0 0 30%;
+    font-family: monospace;
+  }
+
+  .env-value {
+    flex: 1;
+  }
+
+  .env-secret {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--muted);
+    font-size: 0.8rem;
+    white-space: nowrap;
+  }
+
+  .env-secret input {
+    width: auto;
+  }
+
+  .env-delete {
+    flex: 0 0 auto;
+    padding: 0.4rem 0.6rem;
   }
 
   .import-button {


### PR DESCRIPTION
See commit 31a450d. Adds DigitalOcean-style env var rows, a secret scrubbing/masking module (secrets.rs) applied to Claude output before it is persisted or streamed, and masked token previews restored to the settings page. Closes #59.