### PR TITLE
Network access whitelist (closes #79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,19 +64,22 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
+
+      # The frontend uses Yarn Berry (see frontend/package.json `packageManager`),
+      # enabled through Corepack which ships with Node.
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install
-        run: npm ci
+        run: yarn install --immutable
 
       - name: Type-check
         if: ${{ !cancelled() }}
-        run: npm run check
+        run: yarn check
 
       - name: Build
         if: ${{ !cancelled() }}
-        run: npm run build
+        run: yarn build
 
   images:
     name: Docker images

--- a/api/migrations/0011_network_access.sql
+++ b/api/migrations/0011_network_access.sql
@@ -1,0 +1,22 @@
+-- Network access whitelist: an outbound-connectivity policy for the agent's
+-- workspace, modeled on Claude Code on the web's access levels. The selected
+-- level (and, for `custom`, the allowed domains) is translated into the agent's
+-- `~/.claude/settings.json` permissions during provisioning.
+
+CREATE TYPE network_access_level AS ENUM ('none', 'trusted', 'full', 'custom');
+
+-- Default to `full` so existing deployments keep their current, unrestricted
+-- network access; operators opt into a stricter level deliberately.
+ALTER TABLE settings
+    ADD COLUMN network_access_level network_access_level NOT NULL DEFAULT 'full';
+
+-- Custom allow-list, used only when network_access_level = 'custom'. One domain
+-- per entry, e.g. ["api.example.com", "*.internal.example.com"].
+ALTER TABLE settings
+    ADD COLUMN network_access_domains JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- For `custom`: whether to also allow the built-in package-manager/registry
+-- domains alongside the operator's list (the "Also include default list"
+-- checkbox in the UI).
+ALTER TABLE settings
+    ADD COLUMN network_access_include_defaults BOOLEAN NOT NULL DEFAULT TRUE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -31,6 +31,24 @@ pub enum ReviewPolicy {
     None,
 }
 
+/// How much of the internet the agent's workspace may reach, modeled on Claude
+/// Code on the web's network access levels. Translated into the agent's
+/// `~/.claude/settings.json` permissions during provisioning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "network_access_level", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkAccessLevel {
+    /// No outbound network access.
+    None,
+    /// The built-in allow-list of package registries, version-control hosts, and
+    /// cloud SDKs only.
+    Trusted,
+    /// Any destination (unrestricted).
+    Full,
+    /// The operator's own allow-list, optionally plus the built-in defaults.
+    Custom,
+}
+
 /// The kanban lane a card sits in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "task_column", rename_all = "snake_case")]
@@ -144,6 +162,12 @@ pub struct Settings {
     pub availability_windows: Json<Vec<AvailabilityWindow>>,
     /// Calendar dates to skip entirely (vacations, holidays).
     pub availability_skip_dates: Json<Vec<NaiveDate>>,
+    /// Outbound network access level enforced in the agent's workspace.
+    pub network_access_level: NetworkAccessLevel,
+    /// Operator-defined allow-list (used only when the level is `custom`).
+    pub network_access_domains: Json<Vec<String>>,
+    /// For `custom`: also allow the built-in package-manager/registry domains.
+    pub network_access_include_defaults: bool,
     /// Masked preview of the stored Claude token, e.g. `sk-ant-****abcd`. Not a
     /// DB column; the settings handler fills it from the raw token so an operator
     /// can recognize what is stored without it being revealed.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,9 +12,9 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnswerKind, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite, PendingQuestion, Question,
-    QuestionOption, QuestionStatus, Repository, ReviewPolicy, Settings, SourceKind, Task,
-    TaskColumn, TaskStatus, Turn,
+    AnswerKind, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite, NetworkAccessLevel,
+    PendingQuestion, Question, QuestionOption, QuestionStatus, Repository, ReviewPolicy, Settings,
+    SourceKind, Task, TaskColumn, TaskStatus, Turn,
 };
 
 // --- Settings ----------------------------------------------------------------
@@ -29,7 +29,8 @@ const SETTINGS_COLUMNS: &str =
      (claude_oauth_token <> '') AS claude_token_set, \
      (github_token <> '') AS github_token_set, \
      availability_enabled, availability_timezone, availability_windows, \
-     availability_skip_dates";
+     availability_skip_dates, network_access_level, network_access_domains, \
+     network_access_include_defaults";
 
 pub async fn get_settings(pool: &PgPool) -> sqlx::Result<Settings> {
     sqlx::query_as::<_, Settings>(&format!(
@@ -58,6 +59,9 @@ pub async fn update_settings(
     availability_timezone: Option<String>,
     availability_windows: Option<Json<Vec<AvailabilityWindow>>>,
     availability_skip_dates: Option<Json<Vec<NaiveDate>>>,
+    network_access_level: Option<NetworkAccessLevel>,
+    network_access_domains: Option<Json<Vec<String>>>,
+    network_access_include_defaults: Option<bool>,
 ) -> sqlx::Result<Settings> {
     sqlx::query_as::<_, Settings>(&format!(
         "UPDATE settings SET \
@@ -72,6 +76,10 @@ pub async fn update_settings(
          availability_timezone = COALESCE($9, availability_timezone), \
          availability_windows = COALESCE($10, availability_windows), \
          availability_skip_dates = COALESCE($11, availability_skip_dates), \
+         network_access_level = COALESCE($12, network_access_level), \
+         network_access_domains = COALESCE($13, network_access_domains), \
+         network_access_include_defaults = \
+             COALESCE($14, network_access_include_defaults), \
          updated_at = now() \
          WHERE id = 1 \
          RETURNING {SETTINGS_COLUMNS}"
@@ -87,6 +95,9 @@ pub async fn update_settings(
     .bind(availability_timezone)
     .bind(availability_windows)
     .bind(availability_skip_dates)
+    .bind(network_access_level)
+    .bind(network_access_domains)
+    .bind(network_access_include_defaults)
     .fetch_one(pool)
     .await
 }

--- a/api/src/http/data.rs
+++ b/api/src/http/data.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::types::Json as SqlxJson;
 
 use super::ApiResult;
-use crate::db::models::{AvailabilityWindow, ReviewPolicy};
+use crate::db::models::{AvailabilityWindow, NetworkAccessLevel, ReviewPolicy};
 use crate::db::queries;
 use crate::state::AppState;
 
@@ -31,11 +31,27 @@ pub struct SettingsExport {
     pub availability_windows: Vec<AvailabilityWindow>,
     #[serde(default)]
     pub availability_skip_dates: Vec<NaiveDate>,
+    // Default so bundles exported before the network-access feature still import.
+    #[serde(default = "default_network_level")]
+    pub network_access_level: NetworkAccessLevel,
+    #[serde(default)]
+    pub network_access_domains: Vec<String>,
+    #[serde(default = "default_true")]
+    pub network_access_include_defaults: bool,
 }
 
 /// Matches the database default so an older bundle imports as plain UTC.
 fn default_timezone() -> String {
     "UTC".to_string()
+}
+
+/// Matches the database default (`full`) so older bundles import unrestricted.
+fn default_network_level() -> NetworkAccessLevel {
+    NetworkAccessLevel::Full
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -76,6 +92,9 @@ pub async fn export(State(state): State<AppState>) -> ApiResult<Json<ConfigBundl
             availability_timezone: settings.availability_timezone,
             availability_windows: settings.availability_windows.0,
             availability_skip_dates: settings.availability_skip_dates.0,
+            network_access_level: settings.network_access_level,
+            network_access_domains: settings.network_access_domains.0,
+            network_access_include_defaults: settings.network_access_include_defaults,
         },
         repositories: repositories
             .into_iter()
@@ -117,6 +136,9 @@ pub async fn import(
         Some(settings.availability_timezone),
         Some(SqlxJson(settings.availability_windows)),
         Some(SqlxJson(settings.availability_skip_dates)),
+        Some(settings.network_access_level),
+        Some(SqlxJson(settings.network_access_domains)),
+        Some(settings.network_access_include_defaults),
     )
     .await?;
 

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use sqlx::types::Json as SqlxJson;
 
 use super::ApiResult;
-use crate::db::models::{AvailabilityWindow, EnvVarWrite, ReviewPolicy, Settings};
+use crate::db::models::{
+    AvailabilityWindow, EnvVarWrite, NetworkAccessLevel, ReviewPolicy, Settings,
+};
 use crate::db::queries;
 use crate::secrets::mask;
 use crate::state::AppState;
@@ -42,6 +44,9 @@ pub struct UpdateSettingsRequest {
     pub availability_timezone: Option<String>,
     pub availability_windows: Option<Vec<AvailabilityWindow>>,
     pub availability_skip_dates: Option<Vec<NaiveDate>>,
+    pub network_access_level: Option<NetworkAccessLevel>,
+    pub network_access_domains: Option<Vec<String>>,
+    pub network_access_include_defaults: Option<bool>,
 }
 
 /// `PATCH /api/v1/settings` - patch the org profile (omitted fields untouched).
@@ -62,6 +67,9 @@ pub async fn update(
         body.availability_timezone,
         body.availability_windows.map(SqlxJson),
         body.availability_skip_dates.map(SqlxJson),
+        body.network_access_level,
+        body.network_access_domains.map(SqlxJson),
+        body.network_access_include_defaults,
     )
     .await?;
     state.notify_board();

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -87,6 +87,9 @@ async fn bootstrap_settings(db: &sqlx::PgPool, config: &Config) -> Result<()> {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .await?;
     }

--- a/api/src/orchestrator/availability.rs
+++ b/api/src/orchestrator/availability.rs
@@ -73,7 +73,7 @@ pub fn is_available(settings: &Settings, now: DateTime<Utc>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::models::{AvailabilityWindow, ReviewPolicy};
+    use crate::db::models::{AvailabilityWindow, NetworkAccessLevel, ReviewPolicy};
     use chrono::TimeZone;
     use sqlx::types::Json;
 
@@ -103,6 +103,9 @@ mod tests {
             availability_timezone: timezone.to_string(),
             availability_windows: Json(windows),
             availability_skip_dates: Json(skip_dates),
+            network_access_level: NetworkAccessLevel::Full,
+            network_access_domains: Json(Vec::new()),
+            network_access_include_defaults: true,
             claude_token_preview: None,
             github_token_preview: None,
         }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -10,6 +10,7 @@
 //! completion before the next is considered, so turns never overlap.
 
 mod availability;
+mod network;
 mod prompt;
 mod provision;
 

--- a/api/src/orchestrator/network.rs
+++ b/api/src/orchestrator/network.rs
@@ -1,0 +1,342 @@
+//! Network access policy: translate the operator's chosen [`NetworkAccessLevel`]
+//! into Claude Code `~/.claude/settings.json` permission rules.
+//!
+//! Claude Code's permission system is the agent's built-in network control:
+//! `deny` rules are a hard boundary enforced in every permission mode (including
+//! `bypassPermissions`, which the orchestrator uses), while `allow` rules name
+//! the destinations the agent may reach without prompting. We express the policy
+//! the same way Claude Code on the web's access levels do:
+//!
+//! - **None**    -> deny the network-capable tools outright.
+//! - **Trusted** -> allow the built-in registry/VCS/cloud allow-list.
+//! - **Full**    -> allow the network tools unrestricted (no deny).
+//! - **Custom**  -> allow the operator's domains, optionally plus the defaults.
+//!
+//! The result is merged into any operator-provided `settings.json` during
+//! provisioning (see `provision::apply_network_policy`); this module is the pure,
+//! unit-tested core that decides *what* the permission block should contain.
+
+use serde_json::{json, Value};
+
+use crate::db::models::{NetworkAccessLevel, Settings};
+
+/// The built-in allow-list used by the **Trusted** level (and by **Custom** when
+/// "include defaults" is on). Mirrors Claude Code on the web's default allowed
+/// domains: package registries, version-control hosts, container registries,
+/// cloud SDKs, and OS package mirrors. `*.` entries match any subdomain.
+pub const DEFAULT_ALLOWED_DOMAINS: &[&str] = &[
+    // Anthropic services
+    "api.anthropic.com",
+    "statsig.anthropic.com",
+    "docs.claude.com",
+    "platform.claude.com",
+    "code.claude.com",
+    "claude.ai",
+    // Version control
+    "github.com",
+    "api.github.com",
+    "raw.githubusercontent.com",
+    "objects.githubusercontent.com",
+    "codeload.github.com",
+    "npm.pkg.github.com",
+    "ghcr.io",
+    "gist.github.com",
+    "gitlab.com",
+    "registry.gitlab.com",
+    "bitbucket.org",
+    "api.bitbucket.org",
+    // Container registries
+    "registry-1.docker.io",
+    "auth.docker.io",
+    "index.docker.io",
+    "hub.docker.com",
+    "production.cloudflare.docker.com",
+    "download.docker.com",
+    "gcr.io",
+    "*.gcr.io",
+    "mcr.microsoft.com",
+    "*.data.mcr.microsoft.com",
+    "public.ecr.aws",
+    // Cloud platforms
+    "*.googleapis.com",
+    "storage.googleapis.com",
+    "cloud.google.com",
+    "*.amazonaws.com",
+    "*.api.aws",
+    "azure.com",
+    "packages.microsoft.com",
+    "dev.azure.com",
+    "*.microsoftonline.com",
+    // JavaScript / Node
+    "registry.npmjs.org",
+    "npmjs.com",
+    "npmjs.org",
+    "yarnpkg.com",
+    "registry.yarnpkg.com",
+    "nodejs.org",
+    // Python
+    "pypi.org",
+    "files.pythonhosted.org",
+    "pythonhosted.org",
+    "test.pypi.org",
+    // Ruby
+    "rubygems.org",
+    "api.rubygems.org",
+    "index.rubygems.org",
+    // Rust
+    "crates.io",
+    "index.crates.io",
+    "static.crates.io",
+    "static.rust-lang.org",
+    "rustup.rs",
+    // Go
+    "proxy.golang.org",
+    "sum.golang.org",
+    "pkg.go.dev",
+    "goproxy.io",
+    // JVM
+    "repo.maven.org",
+    "repo1.maven.org",
+    "repo.maven.apache.org",
+    "plugins.gradle.org",
+    "services.gradle.org",
+    "repo.spring.io",
+    // Other package managers
+    "repo.packagist.org",
+    "packagist.org",
+    "api.nuget.org",
+    "nuget.org",
+    "pub.dev",
+    "hex.pm",
+    "metacpan.org",
+    "cdn.cocoapods.org",
+    "hackage.haskell.org",
+    "swift.org",
+    // Linux distributions
+    "archive.ubuntu.com",
+    "security.ubuntu.com",
+    "*.ubuntu.com",
+    "ppa.launchpad.net",
+    "launchpad.net",
+    "*.nixos.org",
+    // Development tools and platforms
+    "pkgs.k8s.io",
+    "dl.k8s.io",
+    "releases.hashicorp.com",
+    "apt.releases.hashicorp.com",
+    "repo.anaconda.com",
+    "conda.anaconda.org",
+    "downloads.apache.org",
+    "archive.apache.org",
+    "binaries.prisma.sh",
+    "developer.apple.com",
+    "developer.android.com",
+    // Cloud services and monitoring
+    "*.sentry.io",
+    "*.datadoghq.com",
+    "api.statsig.com",
+    // Content delivery and schema
+    "*.sourceforge.net",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+    "json-schema.org",
+    "json.schemastore.org",
+    // Model Context Protocol
+    "*.modelcontextprotocol.io",
+];
+
+/// The network-capable tools we gate. `Bash` reaches the network through many
+/// commands and cannot be domain-restricted by a permission pattern, so for the
+/// **None** level we additionally deny the common fetchers as a best effort; the
+/// authoritative blocks are the `WebFetch`/`WebSearch` denies.
+const BASH_FETCHERS: &[&str] = &["Bash(curl:*)", "Bash(wget:*)"];
+
+/// Builds the managed `permissions` block (an object with `allow` and `deny`
+/// arrays) for the workspace's `settings.json`, given the current settings.
+pub fn managed_permissions(settings: &Settings) -> Value {
+    let (allow, deny) = match settings.network_access_level {
+        NetworkAccessLevel::Full => (
+            vec!["WebFetch".to_string(), "WebSearch".to_string()],
+            vec![],
+        ),
+        NetworkAccessLevel::None => {
+            let mut deny = vec!["WebFetch".to_string(), "WebSearch".to_string()];
+            deny.extend(BASH_FETCHERS.iter().map(|rule| (*rule).to_string()));
+            (vec![], deny)
+        }
+        NetworkAccessLevel::Trusted => (
+            allow_for_domains(DEFAULT_ALLOWED_DOMAINS.iter().copied()),
+            vec![],
+        ),
+        NetworkAccessLevel::Custom => (allow_for_domains(custom_domains(settings)), vec![]),
+    };
+
+    json!({ "allow": allow, "deny": deny })
+}
+
+/// The effective domain list for the **Custom** level: the operator's entries
+/// (trimmed, de-duplicated, order preserved), with the built-in defaults
+/// prepended when "include defaults" is on.
+fn custom_domains(settings: &Settings) -> Vec<String> {
+    let mut domains: Vec<String> = Vec::new();
+    if settings.network_access_include_defaults {
+        domains.extend(
+            DEFAULT_ALLOWED_DOMAINS
+                .iter()
+                .map(|domain| (*domain).to_string()),
+        );
+    }
+    domains.extend(
+        settings
+            .network_access_domains
+            .0
+            .iter()
+            .map(|domain| domain.trim().to_string())
+            .filter(|domain| !domain.is_empty()),
+    );
+    dedup_preserving_order(domains)
+}
+
+/// `["WebSearch", "WebFetch(domain:a)", "WebFetch(domain:b)", ...]`. `WebSearch`
+/// is Anthropic-mediated (it never reaches the listed hosts directly), so the
+/// restricted levels keep it available alongside the per-domain `WebFetch` rules.
+fn allow_for_domains(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<String> {
+    let mut allow = vec!["WebSearch".to_string()];
+    for domain in domains {
+        let domain = domain.as_ref().trim();
+        if !domain.is_empty() {
+            allow.push(format!("WebFetch(domain:{domain})"));
+        }
+    }
+    dedup_preserving_order(allow)
+}
+
+fn dedup_preserving_order(items: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    items
+        .into_iter()
+        .filter(|item| seen.insert(item.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{NetworkAccessLevel, Settings};
+    use chrono::Utc;
+    use sqlx::types::Json;
+
+    fn settings(level: NetworkAccessLevel, domains: &[&str], include_defaults: bool) -> Settings {
+        Settings {
+            org_name: String::new(),
+            global_instructions: String::new(),
+            default_review_policy: crate::db::models::ReviewPolicy::None,
+            agent_paused: false,
+            claude_model: String::new(),
+            workspace_image_tag: String::new(),
+            base_setup_script: String::new(),
+            config_repo_url: String::new(),
+            default_branch_template: String::new(),
+            config_repo_error: None,
+            current_session_id: None,
+            updated_at: Utc::now(),
+            claude_token_set: false,
+            github_token_set: false,
+            availability_enabled: false,
+            availability_timezone: "UTC".to_string(),
+            availability_windows: Json(Vec::new()),
+            availability_skip_dates: Json(Vec::new()),
+            network_access_level: level,
+            network_access_domains: Json(domains.iter().map(|d| (*d).to_string()).collect()),
+            network_access_include_defaults: include_defaults,
+            claude_token_preview: None,
+            github_token_preview: None,
+        }
+    }
+
+    fn allow(value: &serde_json::Value) -> Vec<String> {
+        value["allow"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect()
+    }
+
+    fn deny(value: &serde_json::Value) -> Vec<String> {
+        value["deny"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn full_allows_the_network_tools_and_denies_nothing() {
+        let value = managed_permissions(&settings(NetworkAccessLevel::Full, &[], true));
+        assert_eq!(allow(&value), vec!["WebFetch", "WebSearch"]);
+        assert!(deny(&value).is_empty());
+    }
+
+    #[test]
+    fn none_denies_the_network_tools_and_common_fetchers() {
+        let value = managed_permissions(&settings(NetworkAccessLevel::None, &[], true));
+        assert!(allow(&value).is_empty());
+        let deny = deny(&value);
+        assert!(deny.contains(&"WebFetch".to_string()));
+        assert!(deny.contains(&"WebSearch".to_string()));
+        assert!(deny.contains(&"Bash(curl:*)".to_string()));
+        // None must never grant a bare WebFetch allow.
+        assert!(!deny.is_empty());
+    }
+
+    #[test]
+    fn trusted_allows_default_domains_but_not_bare_webfetch() {
+        let value = managed_permissions(&settings(NetworkAccessLevel::Trusted, &[], true));
+        let allow = allow(&value);
+        assert!(deny(&value).is_empty());
+        assert!(!allow.contains(&"WebFetch".to_string()));
+        assert!(allow.contains(&"WebFetch(domain:registry.npmjs.org)".to_string()));
+        assert!(allow.contains(&"WebFetch(domain:github.com)".to_string()));
+        assert!(allow.contains(&"WebSearch".to_string()));
+    }
+
+    #[test]
+    fn custom_with_defaults_combines_lists_without_duplicates() {
+        let value = managed_permissions(&settings(
+            NetworkAccessLevel::Custom,
+            &["api.example.com", "github.com", "  ", "api.example.com"],
+            true,
+        ));
+        let allow = allow(&value);
+        assert!(allow.contains(&"WebFetch(domain:api.example.com)".to_string()));
+        // github.com is in the defaults too, so it must appear exactly once.
+        let count = allow
+            .iter()
+            .filter(|r| *r == "WebFetch(domain:github.com)")
+            .count();
+        assert_eq!(count, 1);
+        // Blank entries are dropped.
+        assert!(!allow.iter().any(|r| r.contains("domain:)")));
+    }
+
+    #[test]
+    fn custom_without_defaults_allows_only_listed_domains() {
+        let value = managed_permissions(&settings(
+            NetworkAccessLevel::Custom,
+            &["api.example.com", "*.internal.example.com"],
+            false,
+        ));
+        let allow = allow(&value);
+        assert_eq!(
+            allow,
+            vec![
+                "WebSearch",
+                "WebFetch(domain:api.example.com)",
+                "WebFetch(domain:*.internal.example.com)",
+            ]
+        );
+        assert!(!allow.contains(&"WebFetch(domain:registry.npmjs.org)".to_string()));
+    }
+}

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -12,6 +12,7 @@
 use base64::Engine;
 use eyre::{eyre, Result};
 
+use super::network;
 use crate::db::models::{Repository, Settings};
 use crate::db::queries;
 use crate::state::AppState;
@@ -44,6 +45,7 @@ fn config_repo_snippet(config_repo_url: &str) -> String {
     }
     format!(
         "if [ -d \"$CLAUDE_CONFIG_DIR/.git\" ]; then\n\
+           git -C \"$CLAUDE_CONFIG_DIR\" checkout -- . 2>/dev/null || true\n\
            git -C \"$CLAUDE_CONFIG_DIR\" pull --ff-only\n\
          else\n\
            mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
@@ -105,12 +107,80 @@ pub async fn provision_config_repo(state: &AppState) -> Result<()> {
     }
 }
 
-/// Full provision: config repo (hard fail) + env setup + every enabled repo
-/// (clone/update, per-repo CLAUDE.md, per-repo setup).
+/// A small Python program that merges the managed network `permissions` block
+/// into the agent's `settings.json` without clobbering anything else. It reads
+/// the target path and the managed `{allow, deny}` object from the environment,
+/// drops any previously-managed network rules, keeps the operator's own rules,
+/// and appends the current policy. Python (not jq) because it ships in the
+/// workspace image and handles "file missing / not yet valid JSON" cleanly.
+const NETWORK_MERGE_PY: &str = r#"
+import json, os
+
+path = os.environ["SERAPHIM_SETTINGS_PATH"]
+managed = json.loads(os.environ["SERAPHIM_MANAGED_PERMS"])
+
+try:
+    with open(path) as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        data = {}
+except (FileNotFoundError, json.JSONDecodeError):
+    data = {}
+
+perms = data.get("permissions")
+if not isinstance(perms, dict):
+    perms = {}
+data["permissions"] = perms
+
+def is_network_rule(rule):
+    return (
+        rule == "WebFetch"
+        or rule.startswith("WebFetch(")
+        or rule == "WebSearch"
+        or rule in ("Bash(curl:*)", "Bash(wget:*)")
+    )
+
+for key in ("allow", "deny"):
+    current = perms.get(key)
+    current = [r for r in current if isinstance(r, str)] if isinstance(current, list) else []
+    kept = [r for r in current if not is_network_rule(r)]
+    added = [r for r in managed.get(key, []) if r not in kept]
+    perms[key] = kept + added
+
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+"#;
+
+/// Translates the operator's network access policy into the agent's
+/// `~/.claude/settings.json` permissions and merges it in. Runs after the config
+/// repo is (re)cloned so it patches whatever `settings.json` the operator ships,
+/// rather than being overwritten by it.
+pub async fn apply_network_policy(state: &AppState) -> Result<()> {
+    let settings = queries::get_settings(&state.db).await?;
+    let managed = encode(&serde_json::to_string(&network::managed_permissions(
+        &settings,
+    ))?);
+    let script = encode(NETWORK_MERGE_PY);
+
+    let bash = format!(
+        ": \"${{CLAUDE_CONFIG_DIR:=/workspace/.claude}}\"\n\
+         mkdir -p \"$CLAUDE_CONFIG_DIR\"\n\
+         SERAPHIM_SETTINGS_PATH=\"$CLAUDE_CONFIG_DIR/settings.json\" \\\n\
+         SERAPHIM_MANAGED_PERMS=\"$(echo {managed} | base64 -d)\" \\\n\
+         python3 -c \"$(echo {script} | base64 -d)\"\n",
+    );
+    run(state, &bash).await
+}
+
+/// Full provision: config repo (hard fail) + network policy + env setup + every
+/// enabled repo (clone/update, per-repo CLAUDE.md, per-repo setup).
 pub async fn provision_workspace(state: &AppState) -> Result<()> {
     // The config repo is the agent's brain (AGENTS.md, skills, docs); set it up
     // first and stop if it fails.
     provision_config_repo(state).await?;
+    // Then stamp the network policy onto its settings.json (or a fresh one).
+    apply_network_policy(state).await?;
 
     let settings = queries::get_settings(&state.db).await?;
     let repos = queries::list_repositories(&state.db).await?;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   IssueComment,
   IssueDetail,
   IssueThread,
+  NetworkAccessLevel,
   PendingQuestion,
   Question,
   Repository,
@@ -144,6 +145,9 @@ export type UpdateSettingsRequest = {
   availability_timezone?: string
   availability_windows?: AvailabilityWindow[]
   availability_skip_dates?: string[]
+  network_access_level?: NetworkAccessLevel
+  network_access_domains?: string[]
+  network_access_include_defaults?: boolean
 }
 
 export function updateSettings(body: UpdateSettingsRequest) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -47,6 +47,10 @@ export const STATUS_BADGE = {
 
 export type ReviewPolicy = 'auto_squash_merge' | 'human_review' | 'none'
 
+// How much of the internet the agent's workspace may reach (modeled on Claude
+// Code on the web's network access levels).
+export type NetworkAccessLevel = 'none' | 'trusted' | 'full' | 'custom'
+
 export type SourceKind = 'github' | 'jira'
 
 export type Task = {
@@ -102,6 +106,12 @@ export type Settings = {
   availability_windows: AvailabilityWindow[]
   // ISO calendar dates ("YYYY-MM-DD") to skip entirely.
   availability_skip_dates: string[]
+  // Outbound network access policy for the agent's workspace.
+  network_access_level: NetworkAccessLevel
+  // Operator-defined allow-list (used only when the level is "custom").
+  network_access_domains: string[]
+  // For "custom": also allow the built-in package-manager/registry domains.
+  network_access_include_defaults: boolean
   // Masked previews of the stored tokens (e.g. "sk-ant-****abcd"), or null when
   // unset. The raw tokens are never sent.
   claude_token_preview: string | null

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import type { AvailabilityWindow, EnvVar, ReviewPolicy, Settings } from '$lib/types'
+  import type {
+    AvailabilityWindow,
+    EnvVar,
+    NetworkAccessLevel,
+    ReviewPolicy,
+    Settings
+  } from '$lib/types'
   import type { EnvVarWrite } from '$lib/api'
 
   import { onMount } from 'svelte'
@@ -73,6 +79,33 @@
 
   const policies: ReviewPolicy[] = ['auto_squash_merge', 'human_review', 'none']
 
+  // Network access policy. Domains are edited as free text (one per line or
+  // whitespace-separated) and split on save, per the issue's spec.
+  let networkLevel = $state<NetworkAccessLevel>('full')
+  let networkDomains = $state('')
+  let networkIncludeDefaults = $state(true)
+  let networkSavedAt = $state<string | null>(null)
+
+  // Order and copy mirror the claude.ai network-access selector.
+  const NETWORK_LEVELS: { value: NetworkAccessLevel; title: string; description: string }[] = [
+    { value: 'none', title: 'None', description: 'Blocks internet access for maximum security.' },
+    {
+      value: 'trusted',
+      title: 'Trusted',
+      description: 'Downloads packages from verified sources.'
+    },
+    {
+      value: 'full',
+      title: 'Full',
+      description: 'Unrestricted internet access for maximum flexibility.'
+    },
+    { value: 'custom', title: 'Custom', description: 'Create a list of allowed domains.' }
+  ]
+
+  const networkLabel = $derived(
+    NETWORK_LEVELS.find((level) => level.value === networkLevel)?.title ?? networkLevel
+  )
+
   const modelLabel = $derived(
     modelChoice === CUSTOM_MODEL
       ? 'Custom…'
@@ -121,6 +154,9 @@
       : CUSTOM_MODEL
     days = buildDays(loaded.availability_windows)
     skipDates = [...loaded.availability_skip_dates]
+    networkLevel = loaded.network_access_level
+    networkDomains = loaded.network_access_domains.join('\n')
+    networkIncludeDefaults = loaded.network_access_include_defaults
     const env = await listEnvVars()
     envRows = env.variables.map(toEnvRow)
   }
@@ -157,6 +193,23 @@
       availability_skip_dates: skipDates
     })
     scheduleSavedAt = new Date().toLocaleTimeString()
+  }
+
+  async function saveNetwork() {
+    if (!settings) {
+      return
+    }
+    const domains = networkDomains
+      .split(/\s+/)
+      .map((domain) => domain.trim())
+      .filter(Boolean)
+    settings = await updateSettings({
+      network_access_level: networkLevel,
+      network_access_domains: domains,
+      network_access_include_defaults: networkIncludeDefaults
+    })
+    networkDomains = settings.network_access_domains.join('\n')
+    networkSavedAt = new Date().toLocaleTimeString()
   }
 
   function addEnvRow() {
@@ -536,6 +589,66 @@
             {#if scheduleSavedAt}<span class="text-sm text-muted-foreground">Saved at {scheduleSavedAt}</span>{/if}
           </div>
         {/if}
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>Network access</Card.Title>
+        <Card.Description>
+          Controls outbound connectivity for the agent's workspace. The choice is written into the
+          agent's <code class="rounded bg-secondary px-1 py-0.5 text-xs">~/.claude/settings.json</code>
+          permissions on the next Recreate, so save here, then Recreate the workspace to apply.
+        </Card.Description>
+      </Card.Header>
+      <Card.Content class="space-y-5">
+        <div class="space-y-1.5">
+          <Label for="network-level">Access level</Label>
+          <Select.Root
+            type="single"
+            value={networkLevel}
+            onValueChange={(value) => (networkLevel = value as NetworkAccessLevel)}
+          >
+            <Select.Trigger id="network-level" class="w-full">{networkLabel}</Select.Trigger>
+            <Select.Content>
+              {#each NETWORK_LEVELS as level}
+                <Select.Item value={level.value} label={level.title}>
+                  <span class="flex flex-col gap-0.5 py-0.5">
+                    <span>{level.title}</span>
+                    <span class="text-xs text-muted-foreground">{level.description}</span>
+                  </span>
+                </Select.Item>
+              {/each}
+            </Select.Content>
+          </Select.Root>
+        </div>
+
+        {#if networkLevel === 'custom'}
+          <div class="space-y-1.5">
+            <Label for="network-domains">Allowed domains</Label>
+            <Textarea
+              id="network-domains"
+              rows={5}
+              class="font-mono"
+              placeholder={'api.example.com\n*.internal.example.com\nregistry.example.com'}
+              bind:value={networkDomains}
+            />
+            <p class="text-xs leading-relaxed text-muted-foreground">
+              One domain per line, or separated by spaces. Use
+              <code class="rounded bg-secondary px-1 py-0.5 text-xs">*.</code> for wildcard
+              subdomain matching.
+            </p>
+            <label class="flex items-center gap-2">
+              <Switch bind:checked={networkIncludeDefaults} />
+              <span class="text-sm">Also include the default list of common package managers</span>
+            </label>
+          </div>
+        {/if}
+
+        <div class="flex items-center gap-3">
+          <Button onclick={saveNetwork}>Save network access</Button>
+          {#if networkSavedAt}<span class="text-sm text-muted-foreground">Saved at {networkSavedAt}</span>{/if}
+        </div>
       </Card.Content>
     </Card.Root>
 


### PR DESCRIPTION
Closes #79.

## What

Adds a configurable outbound-network policy for the agent's workspace, modeled on Claude Code on the web's [network access levels](https://code.claude.com/docs/en/claude-code-on-the-web#access-levels):

- **None** - no outbound network access
- **Trusted** - the built-in allow-list of package registries, version-control hosts, and cloud SDKs only
- **Full** - any destination (unrestricted)
- **Custom** - the operator's own allow-list, optionally plus the defaults

A new **Network access** card in Settings presents a dropdown that mirrors the claude.ai selector (each option with a title and description). Selecting **Custom** reveals a textarea for allowed domains (one per line or whitespace-separated, `*.` wildcards supported) and an "also include the default package-manager domains" toggle.

## How enforcement works

Per the approach chosen on the issue, the policy is enforced through Claude Code's own `~/.claude/settings.json` permission system rather than a new proxy or firewall. `orchestrator::network` (a pure, unit-tested module) translates the policy into `permissions.allow` / `permissions.deny` rules, and provisioning merges that block into the workspace's `settings.json`, preserving any settings the operator ships in their config repo.

- **None** hard-denies the network tools (`WebFetch`, `WebSearch`, plus the common Bash fetchers). `deny` rules are enforced in every permission mode, including the `bypassPermissions` the orchestrator runs under, so this is a hard boundary.
- **Trusted / Custom** express the allowed destinations as `WebFetch(domain:...)` allow rules (the Claude-native way to name allowed addresses). These gate Claude's `WebFetch` tool; they do not hard-block arbitrary `Bash` egress under `bypassPermissions`. A follow-up could add a true egress proxy if hard per-domain enforcement is needed.
- **Full** applies no restriction.

The merge is idempotent and re-applies on workspace **Recreate** (the same cadence as the config repo), so the UI tells operators to save, then Recreate to apply.

## Notes

- Defaults to **Full** so existing deployments keep their current unrestricted access; operators opt into a stricter level deliberately.
- New migration `0011_network_access.sql` adds the enum and three settings columns. The fields round-trip through config export/import (with serde defaults so older bundles still import).

## Testing

- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (33 passing, including 5 new `orchestrator::network` tests covering each level).
- `yarn check` (0 errors) and `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)