### PR TITLE
Render rate-limit events cleanly in the activity log (closes #80)

### DIFF
--- a/api/src/claude/events.rs
+++ b/api/src/claude/events.rs
@@ -11,6 +11,7 @@
 //! - `{"type":"assistant","message":{content:[...]},"session_id":...}`
 //! - `{"type":"user","message":{content:[{type:"tool_result",...}]}}`
 //! - `{"type":"result","subtype":"success","result":...,"session_id":...,"total_cost_usd":...}`
+//! - `{"type":"rate_limit_event","rate_limit_info":{...},"session_id":...}`
 
 use serde_json::Value;
 
@@ -43,6 +44,10 @@ pub enum AgentEventKind {
         result_text: Option<String>,
         is_error: bool,
     },
+    /// A subscription rate-limit notice. The structured `rate_limit_info` rides
+    /// along in the event payload (`raw`) for the UI to render; we only classify
+    /// the line here so it can be styled instead of dumped as raw JSON.
+    RateLimit,
     /// Any other line, preserved as-is.
     Other,
 }
@@ -57,6 +62,7 @@ impl AgentEvent {
             AgentEventKind::ToolUse { .. } => "tool_use",
             AgentEventKind::ToolResult { .. } => "tool_result",
             AgentEventKind::Result { .. } => "result",
+            AgentEventKind::RateLimit => "rate_limit",
             AgentEventKind::Other => "other",
         }
     }
@@ -127,6 +133,13 @@ pub fn parse_line(line: &str) -> Vec<AgentEvent> {
                             .is_some_and(|subtype| subtype != "success")
                     }),
             },
+            session_id,
+            raw: value,
+        }],
+        // A periodic usage notice (`rate_limit_info` payload). Classify it so the
+        // UI can render it cleanly rather than dumping the raw JSON line.
+        Some("rate_limit_event") => vec![AgentEvent {
+            kind: AgentEventKind::RateLimit,
             session_id,
             raw: value,
         }],
@@ -386,5 +399,19 @@ mod tests {
         let events = parse_line("warning: something happened");
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, AgentEventKind::Other);
+    }
+
+    #[test]
+    fn classifies_rate_limit_event_and_keeps_its_payload() {
+        let line = r#"{"type":"rate_limit_event","rate_limit_info":{"rateLimitType":"five_hour","status":"allowed","resetsAt":1781142000},"session_id":"s9"}"#;
+        let events = parse_line(line);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, AgentEventKind::RateLimit);
+        assert_eq!(events[0].type_label(), "rate_limit");
+        // The structured info rides along in the payload for the UI to render.
+        assert_eq!(
+            events[0].raw.pointer("/rate_limit_info/rateLimitType"),
+            Some(&Value::String("five_hour".to_string()))
+        );
     }
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -32,6 +32,9 @@
   --success-foreground: #0b1020;
   --warning: #d29922;
   --warning-foreground: #0b1020;
+  /* A poppy cyan for informational log markers (e.g. rate-limit notices). */
+  --info: #22d3ee;
+  --info-foreground: #0b1020;
 
   /* Legacy variables kept so any not-yet-migrated style still resolves. */
   --bg: var(--background);
@@ -70,6 +73,8 @@
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -100,7 +100,8 @@
     result: '●',
     thinking: '✻',
     tool_result: '⎿',
-    system: '⎿'
+    system: '⎿',
+    rate_limit: '◆'
   } as const satisfies Record<string, string>
 
   const MARKER_COLORS = {
@@ -109,7 +110,8 @@
     result: 'text-success',
     thinking: 'text-warning',
     tool_result: 'text-muted-foreground',
-    system: 'text-muted-foreground'
+    system: 'text-muted-foreground',
+    rate_limit: 'text-info'
   } as const satisfies Record<string, string>
 
   function marker(type: string): string {
@@ -132,6 +134,8 @@
       color = 'text-muted-foreground'
     } else if (type === 'thinking') {
       color = 'italic text-warning'
+    } else if (type === 'rate_limit') {
+      color = 'font-medium text-info'
     }
     if (!open && type === 'tool_use') {
       return `min-w-0 flex-1 truncate ${color}`
@@ -163,6 +167,56 @@
     await setTaskHold(task.id, held)
     await load()
     toast.success(held ? 'Task held — the agent will skip it' : 'Hold released')
+  }
+
+  // Human labels for the rate-limit window and status codes Claude emits.
+  const RATE_LIMIT_WINDOWS: Record<string, string> = {
+    five_hour: '5-hour limit',
+    weekly: 'weekly limit'
+  }
+  const RATE_LIMIT_STATUSES: Record<string, string> = {
+    allowed: 'allowed',
+    allowed_warning: 'approaching limit',
+    rejected: 'limit reached'
+  }
+
+  function humanize(value: string): string {
+    return value.replace(/_/g, ' ')
+  }
+
+  // A reset moment as "3:40 PM (in 2h 14m)", or just the clock time once it's past.
+  function formatReset(unixSeconds: number): string {
+    const date = new Date(unixSeconds * 1000)
+    const time = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    const diffMinutes = Math.round((date.getTime() - Date.now()) / 60000)
+    if (diffMinutes <= 0) {
+      return time
+    }
+    const relative =
+      diffMinutes < 60 ? `${diffMinutes}m` : `${Math.floor(diffMinutes / 60)}h ${diffMinutes % 60}m`
+    return `${time} (in ${relative})`
+  }
+
+  // Turns a rate_limit_event payload into one clean line instead of raw JSON.
+  function describeRateLimit(payload: Record<string, unknown>): string {
+    const info = payload?.rate_limit_info as Record<string, unknown> | undefined
+    if (!info) {
+      return 'Rate limit update'
+    }
+    const window = RATE_LIMIT_WINDOWS[String(info.rateLimitType)] ?? humanize(String(info.rateLimitType ?? 'usage'))
+    const status = RATE_LIMIT_STATUSES[String(info.status)] ?? humanize(String(info.status ?? ''))
+    let line = `Rate limit · ${window}: ${status}`
+    if (typeof info.resetsAt === 'number') {
+      line += `, resets ${formatReset(info.resetsAt)}`
+    }
+    if (info.isUsingOverage) {
+      const overage = RATE_LIMIT_STATUSES[String(info.overageStatus)] ?? humanize(String(info.overageStatus ?? ''))
+      line += ` · overage ${overage}`
+      if (typeof info.overageResetsAt === 'number') {
+        line += `, resets ${formatReset(info.overageResetsAt)}`
+      }
+    }
+    return line
   }
 
   // The most telling argument of a tool call, so `Bash(cargo build)` reads at a
@@ -197,6 +251,9 @@
     if (event.type === 'result') {
       const cost = payload?.total_cost_usd
       return `turn complete${cost ? ` · $${cost}` : ''}`
+    }
+    if (event.type === 'rate_limit') {
+      return describeRateLimit(payload)
     }
     return JSON.stringify(event.payload)
   }


### PR DESCRIPTION
Closes #80.

## Problem

Claude Code periodically emits a `rate_limit_event` stream-json line:

```json
{"rate_limit_info":{"isUsingOverage":false,"overageResetsAt":1781124000,"overageStatus":"allowed","rateLimitType":"five_hour","resetsAt":1781142000,"status":"allowed"},"session_id":"...","type":"rate_limit_event","uuid":"..."}
```

The parser didn't recognize the `type`, so it fell through to `Other` and the raw JSON was dumped into the activity feed as a plain white-dot message.

## Change

- **Parser** (`claude/events.rs`): classify `type: "rate_limit_event"` as a new `AgentEventKind::RateLimit` (event label `rate_limit`). The structured `rate_limit_info` rides along in the event payload, so the UI has everything it needs to render it (with a unit test).
- **Activity log** (task page): a `rate_limit` event now renders as one clean, human-readable line, e.g. `Rate limit · 5-hour limit: allowed, resets 3:40 PM (in 2h 14m)`, including overage details when present. Window/status codes are humanized and the reset time shows both clock time and a relative countdown.
- **Color**: shown in a poppy cyan via a new semantic `info` token (`--info: #22d3ee`), with a diamond `◆` marker, consistent with the existing `success`/`warning` marker styling.

## Testing

- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (34 passing, incl. the new parser test).
- `yarn check` (0 errors) and `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)