### PR TITLE
Auto-pause the agent near the subscription usage limit (closes #93)

### DIFF
--- a/api/migrations/0013_usage_limits.sql
+++ b/api/migrations/0013_usage_limits.sql
@@ -1,0 +1,15 @@
+-- Subscription usage-limit auto-pause. When the agent's turn reports a
+-- rate-limit notice at or beyond the configured utilization threshold, the
+-- orchestrator parks all new work until the limit window resets, then resumes.
+
+-- Whether to auto-pause when approaching/hitting the subscription limit.
+ALTER TABLE settings ADD COLUMN usage_limit_pause_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Utilization percent (0-100) at which to pause. Claude reports `utilization`
+-- once its window crosses the early-warning threshold (~80%), so the default
+-- pauses as soon as that warning fires.
+ALTER TABLE settings ADD COLUMN usage_limit_threshold INTEGER NOT NULL DEFAULT 80;
+
+-- Runtime state: when set and still in the future, the agent is auto-paused for
+-- usage; the loop clears it once the window reset time passes.
+ALTER TABLE settings ADD COLUMN usage_paused_until TIMESTAMPTZ;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -168,6 +168,14 @@ pub struct Settings {
     pub network_access_domains: Json<Vec<String>>,
     /// For `custom`: also allow the built-in package-manager/registry domains.
     pub network_access_include_defaults: bool,
+    /// Auto-pause new work when the subscription usage limit is (nearly) hit.
+    pub usage_limit_pause_enabled: bool,
+    /// Utilization percent (0-100) at which to auto-pause; Claude's own
+    /// early-warning fires around 80%.
+    pub usage_limit_threshold: i32,
+    /// Runtime state: while set and in the future, the agent is auto-paused for
+    /// usage and pulls no new work; cleared once the limit window resets.
+    pub usage_paused_until: Option<DateTime<Utc>>,
     /// Masked preview of the stored Claude token, e.g. `sk-ant-****abcd`. Not a
     /// DB column; the settings handler fills it from the raw token so an operator
     /// can recognize what is stored without it being revealed.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -30,7 +30,8 @@ const SETTINGS_COLUMNS: &str =
      (github_token <> '') AS github_token_set, \
      availability_enabled, availability_timezone, availability_windows, \
      availability_skip_dates, network_access_level, network_access_domains, \
-     network_access_include_defaults";
+     network_access_include_defaults, usage_limit_pause_enabled, \
+     usage_limit_threshold, usage_paused_until";
 
 pub async fn get_settings(pool: &PgPool) -> sqlx::Result<Settings> {
     sqlx::query_as::<_, Settings>(&format!(
@@ -62,6 +63,8 @@ pub async fn update_settings(
     network_access_level: Option<NetworkAccessLevel>,
     network_access_domains: Option<Json<Vec<String>>>,
     network_access_include_defaults: Option<bool>,
+    usage_limit_pause_enabled: Option<bool>,
+    usage_limit_threshold: Option<i32>,
 ) -> sqlx::Result<Settings> {
     sqlx::query_as::<_, Settings>(&format!(
         "UPDATE settings SET \
@@ -80,6 +83,9 @@ pub async fn update_settings(
          network_access_domains = COALESCE($13, network_access_domains), \
          network_access_include_defaults = \
              COALESCE($14, network_access_include_defaults), \
+         usage_limit_pause_enabled = \
+             COALESCE($15, usage_limit_pause_enabled), \
+         usage_limit_threshold = COALESCE($16, usage_limit_threshold), \
          updated_at = now() \
          WHERE id = 1 \
          RETURNING {SETTINGS_COLUMNS}"
@@ -98,6 +104,8 @@ pub async fn update_settings(
     .bind(network_access_level)
     .bind(network_access_domains)
     .bind(network_access_include_defaults)
+    .bind(usage_limit_pause_enabled)
+    .bind(usage_limit_threshold)
     .fetch_one(pool)
     .await
 }
@@ -105,6 +113,19 @@ pub async fn update_settings(
 pub async fn set_paused(pool: &PgPool, paused: bool) -> sqlx::Result<()> {
     sqlx::query("UPDATE settings SET agent_paused = $1, updated_at = now() WHERE id = 1")
         .bind(paused)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Sets (or clears with `None`) the automatic usage-limit pause: the moment the
+/// agent may resume pulling work once the subscription window resets.
+pub async fn set_usage_paused_until(
+    pool: &PgPool,
+    until: Option<chrono::DateTime<chrono::Utc>>,
+) -> sqlx::Result<()> {
+    sqlx::query("UPDATE settings SET usage_paused_until = $1, updated_at = now() WHERE id = 1")
+        .bind(until)
         .execute(pool)
         .await?;
     Ok(())

--- a/api/src/http/data.rs
+++ b/api/src/http/data.rs
@@ -38,6 +38,11 @@ pub struct SettingsExport {
     pub network_access_domains: Vec<String>,
     #[serde(default = "default_true")]
     pub network_access_include_defaults: bool,
+    // Default so bundles exported before the usage-limit feature still import.
+    #[serde(default = "default_true")]
+    pub usage_limit_pause_enabled: bool,
+    #[serde(default = "default_usage_threshold")]
+    pub usage_limit_threshold: i32,
 }
 
 /// Matches the database default so an older bundle imports as plain UTC.
@@ -52,6 +57,11 @@ fn default_network_level() -> NetworkAccessLevel {
 
 fn default_true() -> bool {
     true
+}
+
+/// Matches the database default usage-limit threshold (80%).
+fn default_usage_threshold() -> i32 {
+    80
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -97,6 +107,8 @@ pub async fn export(State(state): State<AppState>) -> ApiResult<Json<ConfigBundl
             network_access_level: settings.network_access_level,
             network_access_domains: settings.network_access_domains.0,
             network_access_include_defaults: settings.network_access_include_defaults,
+            usage_limit_pause_enabled: settings.usage_limit_pause_enabled,
+            usage_limit_threshold: settings.usage_limit_threshold,
         },
         repositories: repositories
             .into_iter()
@@ -141,6 +153,8 @@ pub async fn import(
         Some(settings.network_access_level),
         Some(SqlxJson(settings.network_access_domains)),
         Some(settings.network_access_include_defaults),
+        Some(settings.usage_limit_pause_enabled),
+        Some(settings.usage_limit_threshold),
     )
     .await?;
 

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -47,6 +47,8 @@ pub struct UpdateSettingsRequest {
     pub network_access_level: Option<NetworkAccessLevel>,
     pub network_access_domains: Option<Vec<String>>,
     pub network_access_include_defaults: Option<bool>,
+    pub usage_limit_pause_enabled: Option<bool>,
+    pub usage_limit_threshold: Option<i32>,
 }
 
 /// `PATCH /api/v1/settings` - patch the org profile (omitted fields untouched).
@@ -70,6 +72,8 @@ pub async fn update(
         body.network_access_level,
         body.network_access_domains.map(SqlxJson),
         body.network_access_include_defaults,
+        body.usage_limit_pause_enabled,
+        body.usage_limit_threshold,
     )
     .await?;
     state.notify_board();

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -90,6 +90,8 @@ async fn bootstrap_settings(db: &sqlx::PgPool, config: &Config) -> Result<()> {
             None,
             None,
             None,
+            None,
+            None,
         )
         .await?;
     }

--- a/api/src/orchestrator/availability.rs
+++ b/api/src/orchestrator/availability.rs
@@ -106,6 +106,9 @@ mod tests {
             network_access_level: NetworkAccessLevel::Full,
             network_access_domains: Json(Vec::new()),
             network_access_include_defaults: true,
+            usage_limit_pause_enabled: true,
+            usage_limit_threshold: 80,
+            usage_paused_until: None,
             claude_token_preview: None,
             github_token_preview: None,
         }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -13,6 +13,7 @@ mod availability;
 mod network;
 mod prompt;
 mod provision;
+mod usage;
 
 pub use provision::provision_workspace;
 
@@ -201,6 +202,15 @@ async fn next_actionable_task(state: &AppState) -> Result<Option<(Task, WorkMode
     let settings = queries::get_settings(&state.db).await?;
     if settings.agent_paused {
         return Ok(None);
+    }
+    // Automatic usage-limit pause: hold all new work until the subscription
+    // window resets, then clear the pause and resume pulling.
+    if let Some(until) = settings.usage_paused_until {
+        if Utc::now() < until {
+            return Ok(None);
+        }
+        queries::set_usage_paused_until(&state.db, None).await?;
+        state.notify_board();
     }
     // Hard halt: a configured config repo that failed to set up means the agent
     // is missing its instructions/skills. Refuse to pull work until it's fixed.
@@ -535,6 +545,9 @@ async fn run_agent_turn(
     let mut result_text: Option<String> = None;
     let mut total_cost: Option<f64> = None;
     let mut error_message: Option<String> = None;
+    // The reset time of the last usage pause we applied this turn, so repeated
+    // rate-limit notices don't re-write the same value.
+    let mut usage_pause_reset: Option<i64> = None;
 
     while let Some(item) = stream.next().await {
         let event = match item {
@@ -562,6 +575,30 @@ async fn run_agent_turn(
                     .clone()
                     .unwrap_or_else(|| "the agent reported an error".to_string());
                 error_message = Some(scrubber.scrub_text(&message));
+            }
+        }
+
+        // Watch the periodic `rate_limit_event` notices: once a usage window is
+        // (nearly) exhausted, park new work until it resets. This never aborts the
+        // current task - the agent loop only consults the pause before the *next*
+        // pull - so the running task always finishes first.
+        if settings.usage_limit_pause_enabled
+            && event.raw.get("type").and_then(serde_json::Value::as_str) == Some("rate_limit_event")
+        {
+            if let Some(info) = event.raw.get("rate_limit_info") {
+                if let Some(reset) = usage::pause_until(info, settings.usage_limit_threshold) {
+                    if usage_pause_reset != Some(reset) {
+                        if let Some(until) = chrono::DateTime::from_timestamp(reset, 0) {
+                            queries::set_usage_paused_until(&state.db, Some(until)).await?;
+                            state.notify_board();
+                            usage_pause_reset = Some(reset);
+                            warn!(
+                                resets_at = %until,
+                                "subscription usage limit reached; pausing new work until reset"
+                            );
+                        }
+                    }
+                }
             }
         }
 

--- a/api/src/orchestrator/network.rs
+++ b/api/src/orchestrator/network.rs
@@ -249,6 +249,9 @@ mod tests {
             network_access_level: level,
             network_access_domains: Json(domains.iter().map(|d| (*d).to_string()).collect()),
             network_access_include_defaults: include_defaults,
+            usage_limit_pause_enabled: true,
+            usage_limit_threshold: 80,
+            usage_paused_until: None,
             claude_token_preview: None,
             github_token_preview: None,
         }

--- a/api/src/orchestrator/usage.rs
+++ b/api/src/orchestrator/usage.rs
@@ -1,0 +1,131 @@
+//! Subscription usage-limit handling: decide, from a Claude `rate_limit_event`,
+//! whether to auto-pause the agent and until when the limit window resets.
+//!
+//! Claude Code periodically emits a `rate_limit_event` stream-json line carrying
+//! a `rate_limit_info` object: a `status` (`allowed` / `allowed_warning` /
+//! `rejected`, plus the `overage_*` variants), the window `rateLimitType`, a
+//! `resetsAt` unix timestamp, and a `utilization` percent that appears once the
+//! window crosses Claude's early-warning threshold (~80%). We pause when a window
+//! is rejected (exhausted) or its utilization has reached the operator's
+//! configured threshold, and the gate resumes once the reset time passes.
+//!
+//! This module is the pure, unit-tested decision core; the orchestrator wires it
+//! to the event stream and the settings row.
+
+use serde_json::Value;
+
+/// Given a `rate_limit_info` object and the operator's utilization `threshold`
+/// (percent, 0-100), returns the unix reset timestamp to pause until, or `None`
+/// if this notice does not warrant pausing.
+pub fn pause_until(info: &Value, threshold: i32) -> Option<i64> {
+    // The primary (non-overage) window.
+    if let Some(reset) = window_pause(
+        info.get("status").and_then(Value::as_str),
+        info.get("utilization"),
+        info.get("resetsAt").and_then(Value::as_i64),
+        threshold,
+    ) {
+        return Some(reset);
+    }
+    // The pay-as-you-go overage window, if it's the one in use.
+    if info
+        .get("isUsingOverage")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return window_pause(
+            info.get("overageStatus").and_then(Value::as_str),
+            info.get("overageUtilization"),
+            info.get("overageResetsAt").and_then(Value::as_i64),
+            threshold,
+        );
+    }
+    None
+}
+
+/// Decides a single window: pause when it's rejected (exhausted) or its
+/// early-warning has fired with utilization at/over the threshold.
+fn window_pause(
+    status: Option<&str>,
+    utilization: Option<&Value>,
+    resets_at: Option<i64>,
+    threshold: i32,
+) -> Option<i64> {
+    match status {
+        // Exhausted: the next call would be refused, so pause until reset.
+        Some("rejected" | "overage_rejected") => resets_at,
+        // Approaching: Claude reports `utilization` once the early-warning fires
+        // (~80%). Pause if it has reached the operator's threshold; if the number
+        // is absent, the warning itself is the signal.
+        Some("allowed_warning") => {
+            let over_threshold = utilization
+                .and_then(parse_utilization)
+                .is_none_or(|pct| pct >= f64::from(threshold));
+            if over_threshold {
+                resets_at
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Normalizes `utilization` to a 0-100 percent, accepting either a fraction
+/// (`0.82`) or an already-scaled percent (`82`).
+fn parse_utilization(value: &Value) -> Option<f64> {
+    let raw = value.as_f64()?;
+    Some(if raw <= 1.0 { raw * 100.0 } else { raw })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn allowed_window_never_pauses() {
+        let info = json!({ "status": "allowed", "rateLimitType": "five_hour", "resetsAt": 1000 });
+        assert_eq!(pause_until(&info, 80), None);
+    }
+
+    #[test]
+    fn rejected_pauses_until_reset_regardless_of_threshold() {
+        let info = json!({ "status": "rejected", "resetsAt": 1781142000_i64 });
+        assert_eq!(pause_until(&info, 95), Some(1781142000));
+    }
+
+    #[test]
+    fn warning_pauses_once_utilization_reaches_threshold() {
+        // Percent form.
+        let info = json!({ "status": "allowed_warning", "utilization": 82, "resetsAt": 500 });
+        assert_eq!(pause_until(&info, 80), Some(500));
+        // Fraction form normalizes to the same percent.
+        let frac = json!({ "status": "allowed_warning", "utilization": 0.82, "resetsAt": 500 });
+        assert_eq!(pause_until(&frac, 80), Some(500));
+    }
+
+    #[test]
+    fn warning_below_threshold_does_not_pause() {
+        let info = json!({ "status": "allowed_warning", "utilization": 70, "resetsAt": 500 });
+        assert_eq!(pause_until(&info, 80), None);
+    }
+
+    #[test]
+    fn warning_without_utilization_pauses_on_the_signal_alone() {
+        let info = json!({ "status": "allowed_warning", "resetsAt": 500 });
+        assert_eq!(pause_until(&info, 80), Some(500));
+    }
+
+    #[test]
+    fn overage_rejected_pauses_until_overage_reset() {
+        let info = json!({
+            "status": "allowed",
+            "resetsAt": 1000,
+            "isUsingOverage": true,
+            "overageStatus": "overage_rejected",
+            "overageResetsAt": 2000
+        });
+        assert_eq!(pause_until(&info, 80), Some(2000));
+    }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -148,6 +148,8 @@ export type UpdateSettingsRequest = {
   network_access_level?: NetworkAccessLevel
   network_access_domains?: string[]
   network_access_include_defaults?: boolean
+  usage_limit_pause_enabled?: boolean
+  usage_limit_threshold?: number
 }
 
 export function updateSettings(body: UpdateSettingsRequest) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -112,6 +112,12 @@ export type Settings = {
   network_access_domains: string[]
   // For "custom": also allow the built-in package-manager/registry domains.
   network_access_include_defaults: boolean
+  // Auto-pause new work when the subscription usage limit is (nearly) hit.
+  usage_limit_pause_enabled: boolean
+  // Utilization percent (0-100) at which to auto-pause.
+  usage_limit_threshold: number
+  // While set and in the future, the agent is auto-paused for usage (ISO string).
+  usage_paused_until: string | null
   // Masked previews of the stored tokens (e.g. "sk-ant-****abcd"), or null when
   // unset. The raw tokens are never sent.
   claude_token_preview: string | null

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -153,6 +153,16 @@
   </Alert.Root>
 {/if}
 
+{#if settings?.usage_paused_until && new Date(settings.usage_paused_until).getTime() > Date.now()}
+  <Alert.Root class="mx-6 mt-4 border-warning/40">
+    <Alert.Title>Paused: subscription usage limit reached.</Alert.Title>
+    <Alert.Description>
+      New work is on hold until the usage window resets at
+      {new Date(settings.usage_paused_until).toLocaleString()}. The agent resumes automatically.
+    </Alert.Description>
+  </Alert.Root>
+{/if}
+
 <div class="flex items-center justify-between px-6 pb-1 pt-4">
   <div class="flex items-baseline gap-2">
     {#if settings}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -85,6 +85,7 @@
   let networkDomains = $state('')
   let networkIncludeDefaults = $state(true)
   let networkSavedAt = $state<string | null>(null)
+  let usageSavedAt = $state<string | null>(null)
 
   // Order and copy mirror the claude.ai network-access selector.
   const NETWORK_LEVELS: { value: NetworkAccessLevel; title: string; description: string }[] = [
@@ -210,6 +211,17 @@
     })
     networkDomains = settings.network_access_domains.join('\n')
     networkSavedAt = new Date().toLocaleTimeString()
+  }
+
+  async function saveUsage() {
+    if (!settings) {
+      return
+    }
+    settings = await updateSettings({
+      usage_limit_pause_enabled: settings.usage_limit_pause_enabled,
+      usage_limit_threshold: settings.usage_limit_threshold
+    })
+    usageSavedAt = new Date().toLocaleTimeString()
   }
 
   function addEnvRow() {
@@ -660,6 +672,57 @@
         <div class="flex items-center gap-3">
           <Button onclick={saveNetwork}>Save network access</Button>
           {#if networkSavedAt}<span class="text-sm text-muted-foreground">Saved at {networkSavedAt}</span>{/if}
+        </div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>Usage limits</Card.Title>
+        <Card.Description>
+          When the agent's subscription usage approaches its limit, pause new work until the limit
+          window resets, then resume automatically. A task already in progress always finishes first.
+        </Card.Description>
+      </Card.Header>
+      <Card.Content class="space-y-5">
+        <div class="flex items-center gap-2">
+          <Switch id="usage-enabled" bind:checked={settings.usage_limit_pause_enabled} />
+          <Label for="usage-enabled">Auto-pause near the usage limit</Label>
+        </div>
+
+        {#if settings.usage_limit_pause_enabled}
+          <div class="space-y-1.5">
+            <Label for="usage-threshold">Pause at utilization</Label>
+            <div class="flex items-center gap-2">
+              <Input
+                id="usage-threshold"
+                type="number"
+                min="1"
+                max="100"
+                class="w-24"
+                bind:value={settings.usage_limit_threshold}
+              />
+              <span class="text-sm text-muted-foreground">% of the current window</span>
+            </div>
+            <p class="text-xs leading-relaxed text-muted-foreground">
+              Claude reports utilization once a window crosses its early-warning threshold (around
+              80%), so the default pauses as soon as that warning fires. A reached (100%) limit
+              always pauses regardless.
+            </p>
+          </div>
+
+          {#if settings.usage_paused_until && new Date(settings.usage_paused_until).getTime() > Date.now()}
+            <div class="rounded-md border border-warning/40 bg-card p-3 text-sm">
+              Paused for usage until
+              <strong>{new Date(settings.usage_paused_until).toLocaleString()}</strong>. The agent
+              resumes automatically when the window resets.
+            </div>
+          {/if}
+        {/if}
+
+        <div class="flex items-center gap-3">
+          <Button onclick={saveUsage}>Save usage limits</Button>
+          {#if usageSavedAt}<span class="text-sm text-muted-foreground">Saved at {usageSavedAt}</span>{/if}
         </div>
       </Card.Content>
     </Card.Root>


### PR DESCRIPTION
Closes #93.

## Approach

Per the discussion on the issue, Claude Code periodically emits `rate_limit_event` stream-json notices (the same payload as #80) carrying everything needed:

```json
{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","rateLimitType":"five_hour","utilization":82,"resetsAt":1781142000,"isUsingOverage":false,"overageStatus":"allowed","overageResetsAt":1781124000}}
```

`status` is `allowed` / `allowed_warning` / `rejected` (plus `overage_*`), `utilization` is a percent that appears once the window crosses Claude's early-warning threshold (~80%), and `resetsAt` is a unix reset timestamp. So the issue's "pause at 80%" maps directly onto Claude's own warning, and we get a precise reset time to resume from.

## What it does

- The orchestrator watches `rate_limit_event` notices during each turn. A pure, unit-tested `orchestrator::usage::pause_until` decides whether to pause: it pauses when a window is `rejected` (exhausted) or its `utilization` has reached the configured threshold (default 80%), and returns the reset timestamp.
- When triggered, it records `settings.usage_paused_until`. The **running task always finishes first** - this only gates the *next* pull, satisfying "pause all work after the current task wraps up."
- The agent loop's `next_actionable_task` holds all new work while `usage_paused_until` is in the future and **clears it automatically once the reset passes**, resuming work (the issue's "watch and re-queue" aspect).

## Settings & UI

- New settings: `usage_limit_pause_enabled` (default on) and `usage_limit_threshold` (default 80), plus the runtime `usage_paused_until`. Migration `0013`.
- A **Usage limits** card in Settings (toggle + threshold, with a live "paused until …" indicator), and a **board banner** showing the reset time while paused.
- Round-trips through config export/import (with serde defaults for older bundles).

## Note

The pre-emptive percentage isn't readable before a window crosses Claude's early-warning, so `utilization` (and thus a threshold below ~80%) only takes effect once that warning fires; a reached (100%) limit always pauses regardless. This is the most faithful mapping the emitted data allows.

## Testing

- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (39 passing, incl. 6 new `usage` tests).
- `yarn check` (0 errors) and `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)