### PR TITLE
Hide Read tool results in the activity log (closes #81)

### DIFF
--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -122,6 +122,36 @@
     return MARKER_COLORS[type as keyof typeof MARKER_COLORS] ?? 'text-foreground'
   }
 
+  // Read(...) results dump the whole file into the activity log, but the
+  // `Read(path)` tool-use line above already says which file was read. Collect
+  // the ids of Read tool calls so we can hide just their result bodies.
+  const readToolUseIds = $derived.by(() => {
+    const ids = new Set<string>()
+    for (const event of events) {
+      if (event.type === 'tool_use') {
+        const payload = event.payload as Record<string, unknown>
+        if (payload?.name === 'Read' && typeof payload?.id === 'string') {
+          ids.add(payload.id)
+        }
+      }
+    }
+    return ids
+  })
+
+  function isHiddenReadResult(event: StreamEvent): boolean {
+    if (event.type !== 'tool_result') {
+      return false
+    }
+    const payload = event.payload as Record<string, unknown>
+    // Keep failed reads visible (e.g. "file not found"); only hide the noisy
+    // successful file dumps.
+    if (payload?.is_error === true) {
+      return false
+    }
+    const toolUseId = payload?.tool_use_id
+    return typeof toolUseId === 'string' && readToolUseIds.has(toolUseId)
+  }
+
   function isCollapsible(type: string): boolean {
     return type === 'tool_use' || type === 'tool_result' || type === 'thinking'
   }
@@ -455,29 +485,31 @@
               <p class="text-muted-foreground">No activity yet.</p>
             {/if}
             {#each events as event, index (index)}
-              {@const collapsible = isCollapsible(event.type)}
-              {@const open = expanded[index] ?? false}
-              {@const indent = event.type === 'tool_result' || event.type === 'system' ? 'pl-4' : ''}
-              {#if collapsible}
-                <button
-                  type="button"
-                  onclick={() => toggle(index)}
-                  title={open ? 'Click to collapse' : 'Click to expand'}
-                  class="flex w-full gap-2 py-0.5 text-left hover:opacity-80 {indent}"
-                >
-                  <span class="w-[1ch] flex-none {markerColor(event.type)}">{marker(event.type)}</span>
-                  <span class={lineClasses(event.type, open)}>{describe(event)}</span>
-                </button>
-              {:else}
-                <div class="flex items-start gap-2 py-0.5 {indent}">
-                  <span class="w-[1ch] flex-none {markerColor(event.type)}">{marker(event.type)}</span>
-                  {#if event.type === 'assistant_text'}
-                    <!-- Render the agent's prose as full markdown. -->
-                    <div class="min-w-0 flex-1"><Markdown source={describe(event)} /></div>
-                  {:else}
+              {#if !isHiddenReadResult(event)}
+                {@const collapsible = isCollapsible(event.type)}
+                {@const open = expanded[index] ?? false}
+                {@const indent = event.type === 'tool_result' || event.type === 'system' ? 'pl-4' : ''}
+                {#if collapsible}
+                  <button
+                    type="button"
+                    onclick={() => toggle(index)}
+                    title={open ? 'Click to collapse' : 'Click to expand'}
+                    class="flex w-full gap-2 py-0.5 text-left hover:opacity-80 {indent}"
+                  >
+                    <span class="w-[1ch] flex-none {markerColor(event.type)}">{marker(event.type)}</span>
                     <span class={lineClasses(event.type, open)}>{describe(event)}</span>
-                  {/if}
-                </div>
+                  </button>
+                {:else}
+                  <div class="flex items-start gap-2 py-0.5 {indent}">
+                    <span class="w-[1ch] flex-none {markerColor(event.type)}">{marker(event.type)}</span>
+                    {#if event.type === 'assistant_text'}
+                      <!-- Render the agent's prose as full markdown. -->
+                      <div class="min-w-0 flex-1"><Markdown source={describe(event)} /></div>
+                    {:else}
+                      <span class={lineClasses(event.type, open)}>{describe(event)}</span>
+                    {/if}
+                  </div>
+                {/if}
               {/if}
             {/each}
           </div>


### PR DESCRIPTION
Closes #81.

## Problem

Every `Read(...)` tool call dumps the whole file (numbered lines) into the activity feed as a `tool_result`, even though the `Read(path)` tool-use line right above already says what was read. It's noise.

## Change

Display-only, in the task activity log:

- Build the set of `tool_use` ids whose tool name is `Read`, then skip rendering any `tool_result` whose `tool_use_id` is in that set. Correlation is by id (robust to parallel tool calls), using fields already present in the stored event payloads, so no backend/schema change is needed.
- Failed reads (`is_error`) stay visible, so a "file not found" or permission error isn't swallowed.
- The events are still stored and streamed unchanged; this only affects what the activity log renders.

## Testing

- `yarn check` (0 errors) and `yarn build`.
- Backend unaffected; `cargo +1.88 fmt --check` / `clippy --all-targets` / `test` still green (40 passing) after merging current `v3.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)