### PR TITLE
Close the issue on Done, reopen when pulled back to the queue (closes #104)

### DIFF
--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use axum::extract::{Path, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use uuid::Uuid;
 
 use super::ApiResult;
@@ -53,8 +54,23 @@ pub async fn move_task(
     Path(id): Path<Uuid>,
     Json(body): Json<MoveRequest>,
 ) -> ApiResult<Json<Task>> {
+    // The column the card is leaving, so we can reconcile the issue's open/closed
+    // state for the transition (closes on entering Done, reopens on leaving it).
+    let from = queries::get_task(&state.db, id)
+        .await?
+        .map(|task| task.board_column);
     let task = queries::move_task(&state.db, id, body.column, body.position).await?;
     state.notify_board();
+
+    // Best-effort: a GitHub failure must never fail the move itself.
+    if let Some(from) = from {
+        if let Err(error) =
+            crate::orchestrator::sync_for_move(&state, &task, from, body.column).await
+        {
+            warn!(error = %error, task = %task.id, "failed to sync issue state on move");
+        }
+    }
+
     Ok(Json(task))
 }
 

--- a/api/src/orchestrator/issues.rs
+++ b/api/src/orchestrator/issues.rs
@@ -1,0 +1,109 @@
+//! Keeping the source issue's open/closed state in step with the board column.
+//!
+//! Moving a task into **Done** closes its issue (`completed`); moving it back out
+//! of Done into **Available** or **To Do** reopens it. Every other transition is
+//! a no-op, as are non-GitHub tasks and tasks without a known repo.
+//!
+//! Best-effort: the caller logs any GitHub hiccup and never lets it block the
+//! move or the merge. GitHub's `PATCH` is idempotent, so re-closing an already
+//! closed issue (or re-opening an open one) is harmless and needs no pre-check.
+
+use eyre::Result;
+
+use crate::db::models::{SourceKind, Task, TaskColumn};
+use crate::db::queries;
+use crate::git;
+use crate::state::AppState;
+
+/// Reconciles the issue's open/closed state for `task` moving from `from` to
+/// `to`. Touches GitHub only for the two transitions that change the desired
+/// state; returns `Ok(())` immediately for anything else.
+pub async fn sync_for_move(
+    state: &AppState,
+    task: &Task,
+    from: TaskColumn,
+    to: TaskColumn,
+) -> Result<()> {
+    let Some((issue_state, reason)) = target_state(from, to) else {
+        return Ok(());
+    };
+
+    if task.source_kind != SourceKind::Github {
+        return Ok(());
+    }
+    let Some(repo_id) = task.repo_id else {
+        return Ok(());
+    };
+    let Some(repo) = queries::get_repository(&state.db, repo_id).await? else {
+        return Ok(());
+    };
+    let Some((owner, name)) = repo.full_name.split_once('/') else {
+        return Ok(());
+    };
+
+    git::set_issue_state(
+        &state.github().await?,
+        owner,
+        name,
+        &task.external_id,
+        issue_state,
+        reason,
+    )
+    .await?;
+    Ok(())
+}
+
+/// The `(state, state_reason)` an issue should have after a `from -> to` column
+/// move, or `None` for transitions that shouldn't touch the ticket: entering Done
+/// closes it (`completed`); leaving Done for Available/To Do reopens it.
+fn target_state(from: TaskColumn, to: TaskColumn) -> Option<(&'static str, Option<&'static str>)> {
+    match (from, to) {
+        (from, TaskColumn::Done) if from != TaskColumn::Done => Some(("closed", Some("completed"))),
+        (TaskColumn::Done, TaskColumn::Available | TaskColumn::Todo) => Some(("open", None)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entering_done_closes_as_completed() {
+        for from in [
+            TaskColumn::Available,
+            TaskColumn::Todo,
+            TaskColumn::InProgress,
+            TaskColumn::InReview,
+        ] {
+            assert_eq!(
+                target_state(from, TaskColumn::Done),
+                Some(("closed", Some("completed"))),
+                "{from:?} -> Done should close"
+            );
+        }
+    }
+
+    #[test]
+    fn leaving_done_for_the_queue_reopens() {
+        assert_eq!(
+            target_state(TaskColumn::Done, TaskColumn::Available),
+            Some(("open", None))
+        );
+        assert_eq!(
+            target_state(TaskColumn::Done, TaskColumn::Todo),
+            Some(("open", None))
+        );
+    }
+
+    #[test]
+    fn other_transitions_leave_the_issue_alone() {
+        // Reordering within Done, leaving Done for a non-queue lane, and moves
+        // that never involve Done all no-op.
+        assert_eq!(target_state(TaskColumn::Done, TaskColumn::Done), None);
+        assert_eq!(target_state(TaskColumn::Done, TaskColumn::InReview), None);
+        assert_eq!(target_state(TaskColumn::Done, TaskColumn::Ignored), None);
+        assert_eq!(target_state(TaskColumn::Available, TaskColumn::Todo), None);
+        assert_eq!(target_state(TaskColumn::Todo, TaskColumn::InProgress), None);
+    }
+}

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -10,12 +10,14 @@
 //! completion before the next is considered, so turns never overlap.
 
 mod availability;
+mod issues;
 mod network;
 mod prompt;
 mod provision;
 mod thoughts;
 mod usage;
 
+pub use issues::sync_for_move;
 pub use provision::provision_workspace;
 
 use std::time::Duration;
@@ -806,6 +808,14 @@ async fn review_once(state: &AppState) -> Result<()> {
                         )
                         .await?;
                         state.notify_board();
+                        // Deterministically close the issue now it's done, in case
+                        // the merge alone didn't (e.g. no "Closes #N" in the PR).
+                        if let Err(error) =
+                            issues::sync_for_move(state, &task, task.board_column, TaskColumn::Done)
+                                .await
+                        {
+                            warn!(error = %error, task_id = %task.id, "failed to close issue after merge");
+                        }
                         info!(task_id = %task.id, "auto-merged and marked done");
                     }
                     // A merge can fail for reasons retrying won't fix (conflicts


### PR DESCRIPTION
Closes #104.

## What

- When a task reaches the **Done** column, its GitHub issue is **deterministically closed** (as `completed`) - covering the case where the merge alone didn't close it (e.g. the agent's PR had no `Closes #N`).
- When a card is moved from **Done** back to **Available** or **To Do**, the issue is **reopened**.

## How

- New `orchestrator::issues::sync_for_move(state, task, from, to)` reconciles the issue's open/closed state for a column transition. The decision - which transitions act and the target `(state, reason)` - is a small pure function, `target_state`, with unit tests. GitHub's issue `PATCH` is idempotent, so re-closing an already-closed issue (or re-opening an open one) is harmless and needs no pre-check, which keeps it "close it if it wasn't already closed" without an extra API round-trip.
- Wired into **both** paths a task reaches Done:
  - the review loop's auto-merge (`finish_task(Done)` then close), and
  - the manual board move (`POST /tasks/:id/move`), which now captures the column the card is leaving so it can both close (entering Done) and reopen (leaving Done for the queue).
- Best-effort in both spots: a GitHub failure is logged and never fails the move or the merge. No-ops for non-GitHub tasks, repo-less tasks, reordering within Done, or leaving Done for a non-queue lane (e.g. In Review).

## Testing

- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (44 passing, incl. 3 new transition tests).
- No frontend changes (the board already refreshes after a move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)