### PR TITLE
Theme the scrollbars to match the dark palette (closes #85)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -112,3 +112,37 @@
     font-family: var(--font-sans);
   }
 }
+
+/* Slim, theme-matched scrollbars in place of the chunky native ones. The thumb
+   is a translucent tint of the muted text color (so it reads on the background,
+   the card, and the secondary panels alike) and brightens on hover; the track
+   stays transparent. Unlayered so it isn't overridden by Tailwind's base reset. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--muted-foreground) 40%, transparent) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  /* The transparent border + padding-box clip insets the thumb to a slim pill. */
+  background-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--muted-foreground) 60%, transparent);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}


### PR DESCRIPTION
Closes #85.

The native scrollbars stood out against the dark UI. This swaps them for slim, theme-matched ones in `app.css`:

- The thumb is a translucent tint of `--muted-foreground` (so it reads on the background, cards, and secondary panels alike), brightening on hover; the track is transparent.
- A transparent border + `background-clip: padding-box` insets the thumb into a slim rounded pill.
- Covers both WebKit (`::-webkit-scrollbar*`) and Firefox (`scrollbar-width` / `scrollbar-color`). Rules are unlayered so Tailwind's base reset doesn't override them, and they're global so every scroll container (activity log, board columns, drawers, etc.) picks them up.

## Testing

- `yarn check` (0 errors) and `yarn build`; confirmed the scrollbar rules are emitted in the built CSS. CSS-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)