### PR TITLE
Show the source ticket state on each board card (#111)

### DIFF
--- a/api/migrations/0015_task_ticket_state.sql
+++ b/api/migrations/0015_task_ticket_state.sql
@@ -1,0 +1,17 @@
+-- The source ticket's own lifecycle state, shown on each board card next to the
+-- agent's internal status. They answer different questions: `status` is where
+-- *our* agent is (working, awaiting review, ...), while this is where the ticket
+-- itself sits in its tracker. For GitHub that is "open" / "closed"; for Jira it
+-- will be the workflow status name (e.g. "To Do" / "In Progress" / "Done").
+--
+-- Free-form text rather than an enum because Jira states are project-defined.
+-- It is maintained wherever we learn the truth: issue sync only ever lists OPEN
+-- issues, so an upsert from sync writes "open", and closing or reopening the
+-- ticket from Seraphim (the control in the task view) writes the new state.
+-- NULL means "not yet known".
+ALTER TABLE tasks ADD COLUMN external_state TEXT;
+
+-- Existing GitHub cards were all synced from open issues, so seed them as "open"
+-- to populate the badge right away; the value self-corrects on the next sync or
+-- state change. Jira rows (none yet) stay NULL.
+UPDATE tasks SET external_state = 'open' WHERE source_kind = 'github';

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -251,6 +251,10 @@ pub struct Task {
     pub title: String,
     pub body_snapshot: String,
     pub url: String,
+    /// The source ticket's own state, distinct from the agent's `status`: for
+    /// GitHub "open" / "closed", for Jira the workflow status name. `None` until
+    /// a sync or state change records it.
+    pub external_state: Option<String>,
     pub board_column: TaskColumn,
     pub position: f64,
     pub status: TaskStatus,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -453,15 +453,17 @@ pub async fn upsert_issue_task(
     title: &str,
     body: &str,
     url: &str,
+    external_state: &str,
     initial_position: f64,
 ) -> sqlx::Result<Task> {
     sqlx::query_as::<_, Task>(
-        "INSERT INTO tasks (source_kind, external_id, repo_id, title, body_snapshot, url, board_column, position) \
-         VALUES ($1, $2, $3, $4, $5, $6, 'available', $7) \
+        "INSERT INTO tasks (source_kind, external_id, repo_id, title, body_snapshot, url, external_state, board_column, position) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'available', $8) \
          ON CONFLICT (repo_id, source_kind, external_id) DO UPDATE SET \
          title = EXCLUDED.title, \
          body_snapshot = EXCLUDED.body_snapshot, \
          url = EXCLUDED.url, \
+         external_state = EXCLUDED.external_state, \
          updated_at = now() \
          RETURNING *",
     )
@@ -471,9 +473,46 @@ pub async fn upsert_issue_task(
     .bind(title)
     .bind(body)
     .bind(url)
+    .bind(external_state)
     .bind(initial_position)
     .fetch_one(pool)
     .await
+}
+
+/// Records the source ticket's state on a task (e.g. "open"/"closed" after a
+/// close or reopen from the task view). Returns the refreshed task.
+pub async fn set_task_external_state(
+    pool: &PgPool,
+    id: Uuid,
+    external_state: &str,
+) -> sqlx::Result<Task> {
+    sqlx::query_as::<_, Task>(
+        "UPDATE tasks SET external_state = $2, updated_at = now() WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(external_state)
+    .fetch_one(pool)
+    .await
+}
+
+/// Reconciles a task's cached `external_state` with a freshly observed value,
+/// writing (and reporting `true`) only when it actually differs. Used when we
+/// fetch the live issue thread, so the badge catches state changes made outside
+/// Seraphim, e.g. a PR that closed the issue via a "Closes #N" keyword.
+pub async fn reconcile_task_external_state(
+    pool: &PgPool,
+    id: Uuid,
+    external_state: &str,
+) -> sqlx::Result<bool> {
+    let result = sqlx::query(
+        "UPDATE tasks SET external_state = $2, updated_at = now() \
+         WHERE id = $1 AND external_state IS DISTINCT FROM $2",
+    )
+    .bind(id)
+    .bind(external_state)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
 }
 
 pub async fn max_position_in_column(

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -102,6 +102,14 @@ pub async fn get_issue(State(state): State<AppState>, Path(id): Path<Uuid>) -> A
     };
     let github = state.github().await?;
     let thread = git::get_issue_thread(&github, &owner, &name, &number).await?;
+
+    // Reconcile the card's cached state with what GitHub reports now; the issue
+    // may have changed outside our close/reopen control (e.g. a merged PR that
+    // closed it via a keyword). Only refresh the board when it actually moved.
+    if queries::reconcile_task_external_state(&state.db, id, &thread.issue.state).await? {
+        state.notify_board();
+    }
+
     Ok(Json(thread).into_response())
 }
 
@@ -145,6 +153,12 @@ pub async fn set_issue_state(
         payload.reason.as_deref(),
     )
     .await?;
+
+    // Mirror the new state onto the task so the board card reflects it without a
+    // round-trip to GitHub, and nudge the board to refresh live.
+    queries::set_task_external_state(&state.db, id, &payload.state).await?;
+    state.notify_board();
+
     Ok(Json(issue).into_response())
 }
 

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -171,6 +171,8 @@ pub async fn sync_once(state: &AppState) -> Result<()> {
                 &issue.title,
                 &issue.body,
                 &issue.url,
+                // Sync only ever lists open issues, so any issue we see here is open.
+                "open",
                 next_position,
             )
             .await?;
@@ -962,6 +964,7 @@ mod tests {
             title: String::new(),
             body_snapshot: String::new(),
             url: String::new(),
+            external_state: None,
             board_column: TaskColumn::Todo,
             position: 0.0,
             status: TaskStatus::Queued,

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -282,6 +282,7 @@ mod tests {
             title: "Ask the user for help".to_string(),
             body_snapshot: String::new(),
             url: String::new(),
+            external_state: Some("open".to_string()),
             board_column: TaskColumn::InProgress,
             position: 0.0,
             status: TaskStatus::WaitingForInput,

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation'
   import { Pause } from '@lucide/svelte'
 
-  import { STATUS_BADGE, STATUS_LABELS } from '../types'
+  import { STATUS_BADGE, STATUS_LABELS, ticketStateBadge } from '../types'
   import { Badge } from './ui/badge'
   import SourceIcon from './SourceIcon.svelte'
 
@@ -23,6 +23,9 @@
   // Show just the repo name (after the owner); the full owner/repo is on hover.
   const repoShort = $derived(repoName ? repoName.split('/').pop() : null)
 
+  // The source ticket's open/closed (GitHub) or workflow (Jira) state, or null.
+  const ticketState = $derived(ticketStateBadge(task))
+
   function open() {
     goto(`/task/${task.id}`)
   }
@@ -38,10 +41,16 @@
     : 'border-border'}"
 >
   <div class="flex items-center justify-between gap-2">
-    <span class="flex min-w-0 items-center gap-1 truncate text-xs tabular-nums text-muted-foreground">
+    <span class="flex min-w-0 items-center gap-1 text-xs tabular-nums text-muted-foreground">
       {#if task.hold}<Pause class="size-3 flex-none" aria-label="On hold" />{/if}
       <SourceIcon source={task.source_kind} class="size-3.5 flex-none" />
-      {#if repoShort}<span class="font-semibold text-primary" title={repoName}>{repoShort}</span> · {/if}#{task.external_id}
+      {#if repoShort}<span class="truncate font-semibold text-primary" title={repoName}>{repoShort}</span>{/if}
+      <span class="flex-none">{#if repoShort} · {/if}#{task.external_id}</span>
+      {#if ticketState}
+        <Badge variant="outline" class="flex-none px-1.5 py-0 text-[10px] {ticketState.class}">
+          {ticketState.label}
+        </Badge>
+      {/if}
     </span>
     <Badge variant="outline" class={STATUS_BADGE[task.status]}>
       {STATUS_LABELS[task.status] ?? task.status}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -45,6 +45,21 @@ export const STATUS_BADGE = {
   failed: 'border-destructive/40 text-destructive'
 } as const satisfies Record<TaskStatus, string>
 
+// The label and badge classes for a task's *source ticket* state (the card's
+// second badge, distinct from the agent `status` above). GitHub issues are
+// always "open"/"closed"; Jira (when wired up) reports project-defined workflow
+// names, so those are shown verbatim. Returns null when the state is unknown.
+export function ticketStateBadge(task: Task): { label: string; class: string } | null {
+  const state = task.external_state
+  if (!state) return null
+  if (task.source_kind === 'github') {
+    return state === 'closed'
+      ? { label: 'Closed', class: 'border-muted-foreground/40 text-muted-foreground' }
+      : { label: 'Open', class: 'border-success/40 text-success' }
+  }
+  return { label: state, class: 'border-border text-muted-foreground' }
+}
+
 export type ReviewPolicy = 'auto_squash_merge' | 'human_review' | 'none'
 
 // How much of the internet the agent's workspace may reach (modeled on Claude
@@ -61,6 +76,9 @@ export type Task = {
   title: string
   body_snapshot: string
   url: string
+  // The source ticket's own state, separate from the agent `status` below: for
+  // GitHub "open"/"closed", for Jira the workflow status name. Null until known.
+  external_state: string | null
   board_column: TaskColumn
   position: number
   status: TaskStatus


### PR DESCRIPTION
Closes #111.

## What
Each task card now shows the **source ticket's own state** alongside the agent's internal status. They answer different questions: `status` is where Seraphim is (working, awaiting review, ...), while this is where the ticket sits in its tracker.

- **GitHub issues:** an `Open` (green) or `Closed` (muted) badge.
- **Jira (when wired up):** the workflow status name shown verbatim (todo / in progress / done / ...).

The badge sits next to the issue id on the left of the card, grouped with the source identity; the agent status badge stays on the right. The repo name truncates if space is tight so nothing overflows.

## How
New `tasks.external_state` column (free-form text, since Jira states are project-defined), maintained wherever we learn the truth, with no per-board GitHub calls:

- **Sync** only ever lists open issues, so each upsert records `open`.
- **Close / reopen from the task view** persists the new state and refreshes the board live.
- **Loading the issue thread** reconciles the cached value with GitHub's live state (writing only on a real change), so a ticket closed outside our control, e.g. by a merged PR with a `Closes #N` keyword, is caught the next time the task is viewed.

Existing GitHub cards are backfilled to `open` by the migration (they were all synced from open issues); the value self-corrects on the next sync or view.

## Touched
- `api/migrations/0015_task_ticket_state.sql` (new column + backfill)
- `api/src/db/models.rs`, `queries.rs` (field, upsert param, `set_`/`reconcile_task_external_state`)
- `api/src/http/tasks.rs` (persist on close/reopen, reconcile on thread load)
- `api/src/orchestrator/mod.rs` (sync passes `open`)
- `frontend/src/lib/types.ts` (`external_state`, `ticketStateBadge` helper), `Card.svelte` (render the badge)

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features`, `test` (41 passing)
- Frontend: `yarn check` (0 errors), `yarn build`