### PR TITLE
Render Write/Edit tool calls as a red/green diff in the activity log (#107)

### DIFF
--- a/frontend/src/lib/components/DiffView.svelte
+++ b/frontend/src/lib/components/DiffView.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import type { DiffLine, DiffLineKind } from '$lib/diff'
+
+  let { lines, added, removed }: { lines: DiffLine[]; added: number; removed: number } = $props()
+
+  // A long Write would otherwise flood the log; show a generous window and note
+  // the remainder rather than rendering hundreds of rows.
+  const MAX_ROWS = 200
+  const shown = $derived(lines.slice(0, MAX_ROWS))
+  const overflow = $derived(Math.max(0, lines.length - MAX_ROWS))
+
+  const SIGN: Record<DiffLineKind, string> = { add: '+', del: '-', context: ' ' }
+
+  // The whole row is washed in a subtle red/green; the sign gutter carries the
+  // same hue so the change reads at a glance even on a wrapped line.
+  const ROW_CLASS: Record<DiffLineKind, string> = {
+    add: 'bg-success/15',
+    del: 'bg-destructive/15',
+    context: ''
+  }
+  const GUTTER_CLASS: Record<DiffLineKind, string> = {
+    add: 'text-success',
+    del: 'text-destructive',
+    context: 'text-muted-foreground/50'
+  }
+
+  function plural(count: number, word: string): string {
+    return `${count} ${word}${count === 1 ? '' : 's'}`
+  }
+</script>
+
+<div class="min-w-0 flex-1">
+  <div class="text-xs text-muted-foreground">
+    Added {plural(added, 'line')}, removed {plural(removed, 'line')}
+  </div>
+
+  {#if shown.length}
+    <div class="mt-1 overflow-hidden rounded-md border border-border text-xs">
+      {#each shown as line}
+        <div class="flex {ROW_CLASS[line.kind]}">
+          <span class="w-[2ch] flex-none select-none text-center {GUTTER_CLASS[line.kind]}">
+            {SIGN[line.kind]}
+          </span>
+          <span
+            class="min-w-0 flex-1 whitespace-pre-wrap break-words pr-2 {line.kind === 'context'
+              ? 'text-muted-foreground'
+              : 'text-foreground'}"
+          >
+            {line.text || ' '}
+          </span>
+        </div>
+      {/each}
+      {#if overflow > 0}
+        <div class="px-2 py-1 text-muted-foreground">… {plural(overflow, 'more line')} not shown</div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/lib/diff.ts
+++ b/frontend/src/lib/diff.ts
@@ -1,0 +1,175 @@
+// Turning a Write/Edit/MultiEdit tool call into a line-level diff for the
+// activity log, so an edit reads as a red/green patch instead of a "file
+// updated" snippet.
+//
+// We only have what the tool call carried: for an Edit, the `old_string` and
+// `new_string` it swapped; for a Write, the full new `content` (we never see the
+// prior file, so a Write is shown as all-additions). That is enough for a
+// faithful patch of the change itself, though not for the file's absolute line
+// numbers, which only the agent's own editor knows.
+
+export type DiffLineKind = 'add' | 'del' | 'context'
+
+export type DiffLine = {
+  kind: DiffLineKind
+  text: string
+}
+
+export type EditDiff = {
+  /** How the tool is labelled in the log: "Write" for new content, "Update" for an edit. */
+  verb: 'Write' | 'Update'
+  /** The edited file, shortened for display (the `/workspace/` prefix dropped). */
+  path: string
+  lines: DiffLine[]
+  added: number
+  removed: number
+}
+
+/** The tools whose calls we render as a diff. */
+const DIFF_TOOLS = new Set(['Write', 'Edit', 'MultiEdit'])
+
+// The longest-common-subsequence table is O(n*m); edits are tiny so that is
+// nothing, but a pathologically large Write should not lock the tab. Past this
+// many cells we skip the table and show a plain replace-all.
+const LCS_CELL_CAP = 4_000_000
+
+/**
+ * Splits text into lines for diffing, dropping the phantom empty line a trailing
+ * newline produces so "a\nb\n" is two lines, not three.
+ */
+function toLines(text: string): string[] {
+  if (text === '') {
+    return []
+  }
+  const lines = text.split('\n')
+  if (lines.length > 1 && lines[lines.length - 1] === '') {
+    lines.pop()
+  }
+  return lines
+}
+
+/**
+ * A classic longest-common-subsequence line diff: shared lines become context,
+ * lines only in `oldText` become deletions, lines only in `newText` additions.
+ */
+export function diffLines(oldText: string, newText: string): DiffLine[] {
+  const a = toLines(oldText)
+  const b = toLines(newText)
+
+  if (a.length * b.length > LCS_CELL_CAP) {
+    return [
+      ...a.map((text): DiffLine => ({ kind: 'del', text })),
+      ...b.map((text): DiffLine => ({ kind: 'add', text }))
+    ]
+  }
+
+  // dp[i][j] = length of the LCS of a[i:] and b[j:].
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0)
+  )
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+
+  // Walk the table, preferring deletions before additions so a replaced block
+  // reads old-then-new, the way a unified diff does.
+  const lines: DiffLine[] = []
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      lines.push({ kind: 'context', text: a[i] })
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      lines.push({ kind: 'del', text: a[i] })
+      i++
+    } else {
+      lines.push({ kind: 'add', text: b[j] })
+      j++
+    }
+  }
+  while (i < a.length) {
+    lines.push({ kind: 'del', text: a[i++] })
+  }
+  while (j < b.length) {
+    lines.push({ kind: 'add', text: b[j++] })
+  }
+  return lines
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+/** Drops the workspace prefix so paths read as `repo/src/foo.rs`, not the full mount path. */
+function shortenPath(path: string): string {
+  return path.replace(/^\/workspace\//, '')
+}
+
+function summarize(verb: EditDiff['verb'], path: string, lines: DiffLine[]): EditDiff {
+  let added = 0
+  let removed = 0
+  for (const line of lines) {
+    if (line.kind === 'add') added++
+    else if (line.kind === 'del') removed++
+  }
+  return { verb, path: shortenPath(path), lines, added, removed }
+}
+
+/**
+ * Builds the diff model for a Write/Edit/MultiEdit `tool_use` payload, or returns
+ * null for any other tool so the caller can fall back to its default rendering.
+ */
+export function editDiff(payload: Record<string, unknown>): EditDiff | null {
+  const name = String(payload?.name ?? '')
+  if (!DIFF_TOOLS.has(name)) {
+    return null
+  }
+  const input = (payload?.input ?? {}) as Record<string, unknown>
+  const path = asString(input.file_path)
+  if (!path) {
+    return null
+  }
+
+  if (name === 'Write') {
+    const content = asString(input.content)
+    if (content === null) {
+      return null
+    }
+    // No prior file to compare against, so the new content is all additions.
+    const lines = toLines(content).map((text): DiffLine => ({ kind: 'add', text }))
+    return summarize('Write', path, lines)
+  }
+
+  if (name === 'Edit') {
+    const oldString = asString(input.old_string)
+    const newString = asString(input.new_string)
+    if (oldString === null || newString === null) {
+      return null
+    }
+    return summarize('Update', path, diffLines(oldString, newString))
+  }
+
+  // MultiEdit: a sequence of edits against one file; diff each and concatenate.
+  const edits = Array.isArray(input.edits) ? input.edits : null
+  if (!edits) {
+    return null
+  }
+  const lines: DiffLine[] = []
+  for (const raw of edits) {
+    const edit = (raw ?? {}) as Record<string, unknown>
+    const oldString = asString(edit.old_string)
+    const newString = asString(edit.new_string)
+    if (oldString === null || newString === null) {
+      continue
+    }
+    lines.push(...diffLines(oldString, newString))
+  }
+  if (lines.length === 0) {
+    return null
+  }
+  return summarize('Update', path, lines)
+}

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -20,6 +20,8 @@
   import IssueView from '$lib/components/IssueView.svelte'
   import Markdown from '$lib/components/Markdown.svelte'
   import JsonHighlight from '$lib/components/JsonHighlight.svelte'
+  import DiffView from '$lib/components/DiffView.svelte'
+  import { editDiff } from '$lib/diff'
 
   const taskId = $page.params.id ?? ''
 
@@ -133,15 +135,18 @@
     return MARKER_COLORS[type as keyof typeof MARKER_COLORS] ?? 'text-foreground'
   }
 
-  // Read(...) results dump the whole file into the activity log, but the
-  // `Read(path)` tool-use line above already says which file was read. Collect
-  // the ids of Read tool calls so we can hide just their result bodies.
-  const readToolUseIds = $derived.by(() => {
+  // Some tool results are noise once the tool-use line above is shown: Read
+  // dumps the whole file, and Write/Edit just echo "file updated" while the diff
+  // we render says far more. Collect the ids of those calls so we can hide their
+  // (successful) result bodies. Errors always stay visible.
+  const QUIET_RESULT_TOOLS = new Set(['Read', 'Write', 'Edit', 'MultiEdit'])
+
+  const quietResultToolIds = $derived.by(() => {
     const ids = new Set<string>()
     for (const event of events) {
       if (event.type === 'tool_use') {
         const payload = event.payload as Record<string, unknown>
-        if (payload?.name === 'Read' && typeof payload?.id === 'string') {
+        if (QUIET_RESULT_TOOLS.has(String(payload?.name)) && typeof payload?.id === 'string') {
           ids.add(payload.id)
         }
       }
@@ -149,18 +154,17 @@
     return ids
   })
 
-  function isHiddenReadResult(event: StreamEvent): boolean {
+  function isHiddenToolResult(event: StreamEvent): boolean {
     if (event.type !== 'tool_result') {
       return false
     }
     const payload = event.payload as Record<string, unknown>
-    // Keep failed reads visible (e.g. "file not found"); only hide the noisy
-    // successful file dumps.
+    // Keep failures visible (e.g. "file not found", a rejected edit).
     if (payload?.is_error === true) {
       return false
     }
     const toolUseId = payload?.tool_use_id
-    return typeof toolUseId === 'string' && readToolUseIds.has(toolUseId)
+    return typeof toolUseId === 'string' && quietResultToolIds.has(toolUseId)
   }
 
   function isCollapsible(type: string): boolean {
@@ -525,11 +529,24 @@
               <p class="text-muted-foreground">No activity yet.</p>
             {/if}
             {#each events as event, index (index)}
-              {#if !isHiddenReadResult(event)}
+              {#if !isHiddenToolResult(event)}
                 {@const collapsible = isCollapsible(event.type)}
                 {@const open = expanded[index] ?? false}
                 {@const indent = event.type === 'tool_result' || event.type === 'system' ? 'pl-4' : ''}
-                {#if collapsible}
+                {@const diff =
+                  event.type === 'tool_use'
+                    ? editDiff(event.payload as Record<string, unknown>)
+                    : null}
+                {#if diff}
+                  <!-- Write/Edit calls render as a red/green patch, not a bare summary line. -->
+                  <div class="flex items-start gap-2 py-0.5">
+                    <span class="w-[1ch] flex-none text-primary">●</span>
+                    <div class="min-w-0 flex-1">
+                      <div class="truncate text-primary">{diff.verb}({diff.path})</div>
+                      <DiffView lines={diff.lines} added={diff.added} removed={diff.removed} />
+                    </div>
+                  </div>
+                {:else if collapsible}
                   <button
                     type="button"
                     onclick={() => toggle(index)}


### PR DESCRIPTION
Closes #107.

## Problem
In the agent activity log, a file edit showed only the bare tool line and a "file updated" snippet, telling you nothing about what changed:

```
● Write(/workspace/Seraphim/api/src/orchestrator/issues.rs)
⎿ File created successfully at: ...
```

## Change
Write / Edit / MultiEdit calls now render as a proper patch, the way the issue asked:

- An `Update(path)` header (or `Write(path)` for new content), with the `/workspace/` prefix dropped so the path reads `repo/src/foo.rs`.
- An `Added N lines, removed M lines` summary.
- The changed lines, with **the whole row washed in a subtle green for additions and a subtle red for deletions** (`bg-success/15` / `bg-destructive/15`), plus a matching `+` / `-` gutter. Context lines are muted.
- The redundant "file updated" success snippet is now hidden, exactly the way Read file dumps already are. Failed edits/writes stay visible.

A long write is windowed to 200 rows with a "… N more lines not shown" note so it can't flood the log.

## How it works
The diff is built entirely from the tool call's own payload, so there's no new dependency and no extra backend data:
- **Edit:** a small longest-common-subsequence line diff of `old_string` vs `new_string`.
- **Write:** the new `content` shown as additions (we never see the prior file).
- **MultiEdit:** each edit diffed and concatenated.

New files: `frontend/src/lib/diff.ts` (the diff model + LCS) and `frontend/src/lib/components/DiffView.svelte` (the rows). The page (`routes/task/[id]/+page.svelte`) detects these tools and renders the diff block, and the existing hidden-result helper was broadened to cover Write/Edit.

## Note on line numbers
The issue's mock-up shows absolute file line numbers (514, 515, ...). Those aren't in the stream payload, only the agent's own editor knows the file offset, so the patch uses a `+`/`-` gutter rather than inventing numbers that could be wrong. The red/green row highlighting, which was the explicit ask, is delivered in full.

## Verification
I traced the diff against the issue's exact example and it reproduces it (1 context line, 2 removed, 3 added, "Added 3 lines, removed 2 lines"). `yarn check` (0 errors) and `yarn build` pass.