### PR TITLE
Move user decisions into the issue feed (#82)

### DIFF
--- a/frontend/src/lib/components/DecisionsFeed.svelte
+++ b/frontend/src/lib/components/DecisionsFeed.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  // The agent's decisions, rendered as part of the issue conversation: resolved
+  // ones as quiet history entries, the open one as an active prompt. This lives
+  // inside the issue feed (the left panel), not in a banner at the top of the
+  // task page, so a decision reads like another message in the thread.
+  import type { AnswerKind, Question } from '../types'
+
+  import { Sparkles, CircleCheck, CircleSlash } from '@lucide/svelte'
+
+  import { Button } from './ui/button'
+  import { Input } from './ui/input'
+
+  let {
+    questions,
+    onAnswer
+  }: {
+    questions: Question[]
+    onAnswer: (questionId: string, kind: AnswerKind, text: string) => void | Promise<void>
+  } = $props()
+
+  // Free text for the "something else" / "decline" choices, keyed by question id.
+  let customText = $state<Record<string, string>>({})
+  let declineText = $state<Record<string, string>>({})
+
+  // History first, the open question last, so it reads newest-at-the-bottom like
+  // the rest of the conversation.
+  const answered = $derived(questions.filter((question) => question.status !== 'pending'))
+  const pending = $derived(questions.filter((question) => question.status === 'pending'))
+
+  function formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    })
+  }
+
+  function answerSummary(question: Question): string {
+    if (question.status === 'declined') {
+      return question.answer ? `Declined: ${question.answer}` : 'Declined to choose'
+    }
+    return question.answer ?? ''
+  }
+</script>
+
+{#if questions.length}
+  <div class="space-y-4">
+    {#each answered as question (question.id)}
+      <!-- A resolved decision, shown as a quiet history entry in the feed. -->
+      <div class="flex gap-3">
+        <div
+          class="flex size-10 flex-none items-center justify-center rounded-full border border-border bg-secondary"
+        >
+          {#if question.status === 'declined'}
+            <CircleSlash class="size-5 text-muted-foreground" />
+          {:else}
+            <CircleCheck class="size-5 text-success" />
+          {/if}
+        </div>
+        <div class="min-w-0 flex-1 rounded-lg border border-border">
+          <div
+            class="flex items-center gap-2 rounded-t-lg border-b border-border bg-secondary px-4 py-2 text-sm"
+          >
+            <span class="font-semibold">Seraphim asked</span>
+            {#if question.answered_at}
+              <span class="text-muted-foreground">· you decided on {formatDate(question.answered_at)}</span>
+            {/if}
+            <span
+              class="ml-auto rounded-full border border-border px-2 py-0.5 text-xs capitalize text-muted-foreground"
+            >
+              {question.status}
+            </span>
+          </div>
+          <div class="space-y-1.5 px-4 py-3">
+            <p class="font-medium">{question.prompt}</p>
+            <p class="whitespace-pre-wrap text-sm text-muted-foreground">{answerSummary(question)}</p>
+          </div>
+        </div>
+      </div>
+    {/each}
+
+    {#each pending as question (question.id)}
+      <!-- The active decision: prominent, but still inside the conversation feed. -->
+      <div class="flex gap-3">
+        <div
+          class="flex size-10 flex-none items-center justify-center rounded-full border border-warning/50 bg-warning/10"
+        >
+          <Sparkles class="size-5 text-warning" />
+        </div>
+        <div class="min-w-0 flex-1 rounded-lg border border-warning/50">
+          <div
+            class="flex items-center gap-2 rounded-t-lg border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm font-semibold"
+          >
+            Seraphim needs your input
+          </div>
+          <div class="space-y-3 px-4 py-3">
+            <p class="font-medium">{question.prompt}</p>
+
+            <div class="flex flex-col gap-2">
+              {#each question.options as option}
+                <Button
+                  variant="outline"
+                  class="h-auto flex-col items-start whitespace-normal py-2 text-left"
+                  onclick={() => onAnswer(question.id, 'option', option.title)}
+                >
+                  <span class="font-semibold">{option.title}</span>
+                  {#if option.description}
+                    <span class="text-xs font-normal text-muted-foreground">{option.description}</span>
+                  {/if}
+                </Button>
+              {/each}
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs text-muted-foreground" for={`decision-custom-${question.id}`}>
+                Something else
+              </label>
+              <div class="flex gap-2">
+                <Input
+                  id={`decision-custom-${question.id}`}
+                  placeholder="Type your own answer"
+                  bind:value={customText[question.id]}
+                />
+                <Button
+                  disabled={!customText[question.id]?.trim()}
+                  onclick={() => onAnswer(question.id, 'custom', customText[question.id]?.trim() ?? '')}
+                >
+                  Send
+                </Button>
+              </div>
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs text-muted-foreground" for={`decision-decline-${question.id}`}>
+                Decline and chat about this
+              </label>
+              <div class="flex gap-2">
+                <Input
+                  id={`decision-decline-${question.id}`}
+                  placeholder="Optional note for the agent"
+                  bind:value={declineText[question.id]}
+                />
+                <Button
+                  variant="secondary"
+                  onclick={() => onAnswer(question.id, 'declined', declineText[question.id]?.trim() ?? '')}
+                >
+                  Decline
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/lib/components/IssueView.svelte
+++ b/frontend/src/lib/components/IssueView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { IssueThread, IssueUser, Task } from '../types'
+  import type { AnswerKind, IssueThread, IssueUser, Question, Task } from '../types'
 
   import { onMount } from 'svelte'
   import { toast } from 'svelte-sonner'
@@ -18,11 +18,21 @@
   import { addIssueComment, getIssueThread, setIssueState } from '../api'
   import Markdown from './Markdown.svelte'
   import SourceIcon from './SourceIcon.svelte'
+  import DecisionsFeed from './DecisionsFeed.svelte'
   import { Button, buttonVariants } from './ui/button'
   import { Textarea } from './ui/textarea'
   import * as DropdownMenu from './ui/dropdown-menu'
 
-  let { task }: { task: Task } = $props()
+  let {
+    task,
+    questions,
+    onAnswer
+  }: {
+    task: Task
+    // The agent's escalated decisions, rendered inline in the conversation feed.
+    questions: Question[]
+    onAnswer: (questionId: string, kind: AnswerKind, text: string) => void | Promise<void>
+  } = $props()
 
   // GitHub URLs derived from the issue link: the repo root and its "new issue"
   // chooser, so the header can link out without the repo full name on hand.
@@ -225,6 +235,9 @@
           {@render commentCard(comment.user, comment.created_at, comment.author_association, comment.body)}
         {/each}
 
+        <!-- The agent's decisions, inline in the feed below the conversation. -->
+        <DecisionsFeed {questions} {onAnswer} />
+
         <!-- Add a comment / change state -->
         <div class="rounded-lg border border-border p-3">
           <Textarea
@@ -288,6 +301,7 @@
         <div class="rounded-lg border border-border p-4">
           <Markdown source={task.body_snapshot} />
         </div>
+        <DecisionsFeed {questions} {onAnswer} />
       {:else if !loadError}
         <p class="text-sm text-muted-foreground">Loading issue…</p>
       {/if}

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -11,8 +11,6 @@
   import { PaneGroup, type PaneGroupAPI } from 'paneforge'
 
   import { Badge } from '$lib/components/ui/badge'
-  import { Button } from '$lib/components/ui/button'
-  import { Input } from '$lib/components/ui/input'
   import * as Alert from '$lib/components/ui/alert'
   import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import * as Resizable from '$lib/components/ui/resizable'
@@ -42,13 +40,6 @@
   // Show the live timer only while the agent is mid-turn, i.e. its latest event
   // isn't the turn's terminal `result`.
   const running = $derived(task?.status === 'working' && !!lastEvent && lastEvent.type !== 'result')
-
-  // Per-question free-text inputs for the "something else" and "decline" choices.
-  let customText = $state<Record<string, string>>({})
-  let declineText = $state<Record<string, string>>({})
-
-  const pendingQuestions = $derived(questions.filter((question) => question.status === 'pending'))
-  const answeredQuestions = $derived(questions.filter((question) => question.status !== 'pending'))
 
   async function toggleSuggestion(suggestion: EnvSuggestion) {
     // Optimistically flip so the checkbox feels instant, then persist; revert on
@@ -388,71 +379,6 @@
       </section>
     {/if}
 
-    {#if pendingQuestions.length}
-      <div class="rounded-lg border border-warning/40 bg-card p-4">
-        <h2 class="mb-3 text-sm font-semibold">The agent needs your input</h2>
-        {#each pendingQuestions as question (question.id)}
-          <div class="mb-3 rounded-md border border-border p-3 last:mb-0">
-            <p class="mb-3 font-medium">{question.prompt}</p>
-            <div class="mb-3 flex flex-col gap-2">
-              {#each question.options as option}
-                <Button
-                  variant="outline"
-                  class="h-auto flex-col items-start whitespace-normal py-2 text-left"
-                  onclick={() => submitAnswer(question.id, 'option', option.title)}
-                >
-                  <span class="font-semibold">{option.title}</span>
-                  {#if option.description}
-                    <span class="text-xs font-normal text-muted-foreground">{option.description}</span>
-                  {/if}
-                </Button>
-              {/each}
-            </div>
-            <div class="mb-2">
-              <label class="mb-1 block text-xs text-muted-foreground" for={`custom-${question.id}`}>
-                Something else
-              </label>
-              <div class="flex gap-2">
-                <Input id={`custom-${question.id}`} placeholder="Type your own answer" bind:value={customText[question.id]} />
-                <Button
-                  disabled={!customText[question.id]?.trim()}
-                  onclick={() => submitAnswer(question.id, 'custom', customText[question.id]?.trim() ?? '')}
-                >
-                  Send
-                </Button>
-              </div>
-            </div>
-            <div>
-              <label class="mb-1 block text-xs text-muted-foreground" for={`decline-${question.id}`}>
-                Decline and chat about this
-              </label>
-              <div class="flex gap-2">
-                <Input id={`decline-${question.id}`} placeholder="Optional note for the agent" bind:value={declineText[question.id]} />
-                <Button variant="secondary" onclick={() => submitAnswer(question.id, 'declined', declineText[question.id]?.trim() ?? '')}>
-                  Decline
-                </Button>
-              </div>
-            </div>
-          </div>
-        {/each}
-      </div>
-    {/if}
-
-    {#if answeredQuestions.length}
-      <div class="rounded-lg border border-border bg-card p-4">
-        <h2 class="mb-2 text-sm font-semibold">Decisions</h2>
-        {#each answeredQuestions as question (question.id)}
-          <div class="mb-2 border-l-2 border-border pl-3 last:mb-0">
-            <p class="text-sm font-medium">{question.prompt}</p>
-            <p class="flex items-center gap-2 text-sm text-muted-foreground">
-              <Badge variant="outline">{question.status}</Badge>
-              {question.answer || (question.status === 'declined' ? 'Declined to choose' : '')}
-            </p>
-          </div>
-        {/each}
-      </div>
-    {/if}
-
     <PaneGroup
       bind:this={paneGroup}
       direction="horizontal"
@@ -461,7 +387,7 @@
     >
       <Resizable.Pane defaultSize={55} minSize={30} class="min-w-0">
         <div class="h-full min-w-0 pr-3">
-          <IssueView {task} />
+          <IssueView {task} {questions} onAnswer={submitAnswer} />
         </div>
       </Resizable.Pane>
 


### PR DESCRIPTION
Closes #82.

## Problem
When the agent needed input, the open question and the "Decisions" history rendered as banners along the very top of the task view, detached from the conversation.

## Change
The decision UI now lives in the left issue panel, inline in the conversation feed, exactly where the issue asked for it (a hybrid feed, not written back to GitHub, and not at the top of the page).

- New `DecisionsFeed.svelte` renders:
  - **Resolved decisions** as quiet history entries (agent avatar, the prompt, your chosen answer, a status chip), styled to match the issue comment cards.
  - **The open question** as a prominent "Seraphim needs your input" card with the option buttons, a "Something else" free-text answer, and a "Decline and chat" note.
- It is rendered inside `IssueView`'s conversation, just below the comments, so a decision reads like another message in the thread. It shows for non-GitHub tasks too (below the body), since it does not depend on the GitHub thread.
- The two top-of-page blocks ("The agent needs your input" and "Decisions") are removed. The page passes `questions` and its existing `submitAnswer` handler down to `IssueView`; the per-question text-input state moved into the new component.

No backend or API changes: same `questions` data and the same answer endpoint.

## Verification
`yarn check` (0 errors, 0 warnings) and `yarn build` pass.