### PR TITLE
Gather clarifying questions into one wizard panel (#118)

### DIFF
--- a/frontend/src/lib/components/DecisionsFeed.svelte
+++ b/frontend/src/lib/components/DecisionsFeed.svelte
@@ -1,28 +1,23 @@
 <script lang="ts">
   // The agent's decisions, rendered as part of the issue conversation: resolved
-  // ones as quiet history entries, the open one as an active prompt. This lives
-  // inside the issue feed (the left panel), not in a banner at the top of the
-  // task page, so a decision reads like another message in the thread.
-  import type { AnswerKind, Question } from '../types'
+  // ones as quiet history entries, and any open questions gathered into a single
+  // wizard (one panel, not a stack of cards). This lives inside the issue feed
+  // (the left panel), not in a banner at the top of the task page.
+  import type { AnswerSubmission, Question } from '../types'
 
-  import { Sparkles, CircleCheck, CircleSlash } from '@lucide/svelte'
+  import { CircleCheck, CircleSlash } from '@lucide/svelte'
 
-  import { Button } from './ui/button'
-  import { Input } from './ui/input'
+  import QuestionWizard from './QuestionWizard.svelte'
 
   let {
     questions,
-    onAnswer
+    onSubmit
   }: {
     questions: Question[]
-    onAnswer: (questionId: string, kind: AnswerKind, text: string) => void | Promise<void>
+    onSubmit: (answers: AnswerSubmission[]) => void | Promise<void>
   } = $props()
 
-  // Free text for the "something else" / "decline" choices, keyed by question id.
-  let customText = $state<Record<string, string>>({})
-  let declineText = $state<Record<string, string>>({})
-
-  // History first, the open question last, so it reads newest-at-the-bottom like
+  // History first, the open wizard last, so it reads newest-at-the-bottom like
   // the rest of the conversation.
   const answered = $derived(questions.filter((question) => question.status !== 'pending'))
   const pending = $derived(questions.filter((question) => question.status === 'pending'))
@@ -37,7 +32,7 @@
 
   function answerSummary(question: Question): string {
     if (question.status === 'declined') {
-      return question.answer ? `Declined: ${question.answer}` : 'Declined to choose'
+      return question.answer ? `Declined: ${question.answer}` : 'Skipped'
     }
     return question.answer ?? ''
   }
@@ -79,78 +74,8 @@
       </div>
     {/each}
 
-    {#each pending as question (question.id)}
-      <!-- The active decision: prominent, but still inside the conversation feed. -->
-      <div class="flex gap-3">
-        <div
-          class="flex size-10 flex-none items-center justify-center rounded-full border border-warning/50 bg-warning/10"
-        >
-          <Sparkles class="size-5 text-warning" />
-        </div>
-        <div class="min-w-0 flex-1 rounded-lg border border-warning/50">
-          <div
-            class="flex items-center gap-2 rounded-t-lg border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm font-semibold"
-          >
-            Seraphim needs your input
-          </div>
-          <div class="space-y-3 px-4 py-3">
-            <p class="font-medium">{question.prompt}</p>
-
-            <div class="flex flex-col gap-2">
-              {#each question.options as option}
-                <Button
-                  variant="outline"
-                  class="h-auto flex-col items-start whitespace-normal py-2 text-left"
-                  onclick={() => onAnswer(question.id, 'option', option.title)}
-                >
-                  <span class="font-semibold">{option.title}</span>
-                  {#if option.description}
-                    <span class="text-xs font-normal text-muted-foreground">{option.description}</span>
-                  {/if}
-                </Button>
-              {/each}
-            </div>
-
-            <div>
-              <label class="mb-1 block text-xs text-muted-foreground" for={`decision-custom-${question.id}`}>
-                Something else
-              </label>
-              <div class="flex gap-2">
-                <Input
-                  id={`decision-custom-${question.id}`}
-                  placeholder="Type your own answer"
-                  bind:value={customText[question.id]}
-                />
-                <Button
-                  disabled={!customText[question.id]?.trim()}
-                  onclick={() => onAnswer(question.id, 'custom', customText[question.id]?.trim() ?? '')}
-                >
-                  Send
-                </Button>
-              </div>
-            </div>
-
-            <div>
-              <label class="mb-1 block text-xs text-muted-foreground" for={`decision-decline-${question.id}`}>
-                Decline and chat about this
-              </label>
-              <div class="flex gap-2">
-                <Input
-                  id={`decision-decline-${question.id}`}
-                  placeholder="Optional note for the agent"
-                  bind:value={declineText[question.id]}
-                />
-                <Button
-                  variant="secondary"
-                  onclick={() => onAnswer(question.id, 'declined', declineText[question.id]?.trim() ?? '')}
-                >
-                  Decline
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    {/each}
+    {#if pending.length}
+      <QuestionWizard questions={pending} {onSubmit} />
+    {/if}
   </div>
 {/if}

--- a/frontend/src/lib/components/IssueView.svelte
+++ b/frontend/src/lib/components/IssueView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AnswerKind, IssueThread, IssueUser, Question, Task } from '../types'
+  import type { AnswerSubmission, IssueThread, IssueUser, Question, Task } from '../types'
 
   import { onMount } from 'svelte'
   import { toast } from 'svelte-sonner'
@@ -26,12 +26,12 @@
   let {
     task,
     questions,
-    onAnswer
+    onSubmit
   }: {
     task: Task
     // The agent's escalated decisions, rendered inline in the conversation feed.
     questions: Question[]
-    onAnswer: (questionId: string, kind: AnswerKind, text: string) => void | Promise<void>
+    onSubmit: (answers: AnswerSubmission[]) => void | Promise<void>
   } = $props()
 
   // GitHub URLs derived from the issue link: the repo root and its "new issue"
@@ -236,7 +236,7 @@
         {/each}
 
         <!-- The agent's decisions, inline in the feed below the conversation. -->
-        <DecisionsFeed {questions} {onAnswer} />
+        <DecisionsFeed {questions} {onSubmit} />
 
         <!-- Add a comment / change state -->
         <div class="rounded-lg border border-border p-3">
@@ -301,7 +301,7 @@
         <div class="rounded-lg border border-border p-4">
           <Markdown source={task.body_snapshot} />
         </div>
-        <DecisionsFeed {questions} {onAnswer} />
+        <DecisionsFeed {questions} {onSubmit} />
       {:else if !loadError}
         <p class="text-sm text-muted-foreground">Loading issue…</p>
       {/if}

--- a/frontend/src/lib/components/QuestionWizard.svelte
+++ b/frontend/src/lib/components/QuestionWizard.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  // A single panel that walks the user through the agent's clarifying questions
+  // one at a time (rather than stacking a card per question): a progress bar,
+  // back / skip / next, and a final review step to confirm every answer or jump
+  // back and change one before sending them all at once.
+  import type { AnswerSubmission, Question } from '../types'
+
+  import { Sparkles } from '@lucide/svelte'
+
+  import { Button } from './ui/button'
+  import { Input } from './ui/input'
+
+  let {
+    questions,
+    onSubmit
+  }: {
+    // The pending questions, in ask order.
+    questions: Question[]
+    onSubmit: (answers: AnswerSubmission[]) => void | Promise<void>
+  } = $props()
+
+  // `step` indexes the questions; `step === questions.length` is the review page.
+  let step = $state(0)
+  // Per-question draft answers, keyed by question id. An option choice wins over
+  // typed text; `skipped` marks a question the user passed on.
+  let optionChoice = $state<Record<string, string>>({})
+  let customDraft = $state<Record<string, string>>({})
+  let skipped = $state<Record<string, boolean>>({})
+  let submitting = $state(false)
+
+  const total = $derived(questions.length)
+  const onReview = $derived(step >= total)
+  const current = $derived(questions[Math.min(step, Math.max(total - 1, 0))])
+
+  // The resolved answer for a question, or null while it is still untouched.
+  function answerFor(id: string): { kind: AnswerSubmission['kind']; text: string } | null {
+    if (optionChoice[id]) {
+      return { kind: 'option', text: optionChoice[id] }
+    }
+    const custom = customDraft[id]?.trim()
+    if (custom) {
+      return { kind: 'custom', text: custom }
+    }
+    if (skipped[id]) {
+      return { kind: 'declined', text: '' }
+    }
+    return null
+  }
+
+  const allResolved = $derived(questions.every((question) => answerFor(question.id) !== null))
+
+  function chooseOption(id: string, title: string) {
+    optionChoice[id] = title
+    customDraft[id] = ''
+    skipped[id] = false
+  }
+
+  // Typing a custom answer supersedes any picked option.
+  function onCustomInput(id: string) {
+    optionChoice[id] = ''
+    skipped[id] = false
+  }
+
+  function back() {
+    step = Math.max(step - 1, 0)
+  }
+
+  function next() {
+    step = Math.min(step + 1, total)
+  }
+
+  function skipCurrent() {
+    const id = current.id
+    skipped[id] = true
+    optionChoice[id] = ''
+    customDraft[id] = ''
+    next()
+  }
+
+  function reviewLabel(question: Question): string {
+    const answer = answerFor(question.id)
+    if (!answer) {
+      return 'Not answered yet'
+    }
+    return answer.kind === 'declined' ? 'Skipped' : answer.text
+  }
+
+  async function send() {
+    submitting = true
+    try {
+      const answers: AnswerSubmission[] = questions.map((question) => {
+        const answer = answerFor(question.id) ?? { kind: 'declined' as const, text: '' }
+        return { questionId: question.id, kind: answer.kind, text: answer.text }
+      })
+      await onSubmit(answers)
+    } catch (error) {
+      console.debug('failed to send answers', error)
+      submitting = false
+    }
+  }
+</script>
+
+{#if total > 0}
+  <div class="flex gap-3">
+    <div
+      class="flex size-10 flex-none items-center justify-center rounded-full border border-warning/50 bg-warning/10"
+    >
+      <Sparkles class="size-5 text-warning" />
+    </div>
+
+    <div class="min-w-0 flex-1 rounded-lg border border-warning/50">
+      <div
+        class="flex items-center justify-between gap-2 rounded-t-lg border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm"
+      >
+        <span class="font-semibold">Seraphim needs your input</span>
+        <span class="text-xs text-muted-foreground">
+          {onReview ? 'Review & send' : `Question ${step + 1} of ${total}`}
+        </span>
+      </div>
+
+      <div class="space-y-4 px-4 py-3">
+        <!-- Progress: one segment per question plus a trailing review segment. -->
+        <div class="flex items-center gap-1.5">
+          {#each questions as question, index (question.id)}
+            <button
+              type="button"
+              aria-label={`Go to question ${index + 1}`}
+              onclick={() => (step = index)}
+              class="h-1.5 flex-1 rounded-full transition-colors {index < step
+                ? 'bg-primary'
+                : index === step && !onReview
+                  ? 'bg-primary/60'
+                  : 'bg-border'}"
+            ></button>
+          {/each}
+          <div class="h-1.5 w-8 rounded-full transition-colors {onReview ? 'bg-primary' : 'bg-border'}"></div>
+        </div>
+
+        {#if !onReview}
+          <!-- One question at a time. -->
+          <p class="font-medium">{current.prompt}</p>
+
+          <div class="flex flex-col gap-2">
+            {#each current.options as option}
+              <Button
+                variant={optionChoice[current.id] === option.title ? 'default' : 'outline'}
+                class="h-auto flex-col items-start whitespace-normal py-2 text-left"
+                onclick={() => chooseOption(current.id, option.title)}
+              >
+                <span class="font-semibold">{option.title}</span>
+                {#if option.description}
+                  <span
+                    class="text-xs font-normal {optionChoice[current.id] === option.title
+                      ? ''
+                      : 'text-muted-foreground'}"
+                  >
+                    {option.description}
+                  </span>
+                {/if}
+              </Button>
+            {/each}
+          </div>
+
+          <div>
+            <label class="mb-1 block text-xs text-muted-foreground" for={`wizard-custom-${current.id}`}>
+              Or type your own answer
+            </label>
+            <Input
+              id={`wizard-custom-${current.id}`}
+              placeholder="Type your own answer"
+              bind:value={customDraft[current.id]}
+              oninput={() => onCustomInput(current.id)}
+            />
+          </div>
+
+          <div class="flex items-center justify-between gap-2 pt-1">
+            <Button variant="ghost" size="sm" disabled={step === 0} onclick={back}>Back</Button>
+            <div class="flex gap-2">
+              <Button variant="outline" size="sm" onclick={skipCurrent}>Skip</Button>
+              <Button size="sm" disabled={answerFor(current.id) === null} onclick={next}>
+                {step === total - 1 ? 'Review' : 'Next'}
+              </Button>
+            </div>
+          </div>
+        {:else}
+          <!-- Final review: confirm each answer, or jump back to change one. -->
+          <p class="text-sm text-muted-foreground">Confirm your answers, then send them to the agent.</p>
+
+          <div class="space-y-2">
+            {#each questions as question, index (question.id)}
+              {@const answer = answerFor(question.id)}
+              <div class="rounded-md border border-border p-3">
+                <div class="flex items-start justify-between gap-2">
+                  <p class="min-w-0 text-sm font-medium">{question.prompt}</p>
+                  <Button variant="ghost" size="sm" class="flex-none" onclick={() => (step = index)}>
+                    Edit
+                  </Button>
+                </div>
+                <p class="mt-1 whitespace-pre-wrap text-sm {answer ? 'text-muted-foreground' : 'text-warning'}">
+                  {reviewLabel(question)}
+                </p>
+              </div>
+            {/each}
+          </div>
+
+          <div class="flex items-center justify-between gap-2 pt-1">
+            <Button variant="ghost" size="sm" onclick={back}>Back</Button>
+            <Button size="sm" disabled={submitting || !allResolved} onclick={send}>
+              {submitting ? 'Sending…' : 'Send answers'}
+            </Button>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -196,6 +196,11 @@ export type EnvSuggestion = {
 export type QuestionStatus = 'pending' | 'answered' | 'declined'
 export type AnswerKind = 'option' | 'custom' | 'declined'
 
+// One answer submitted from the review step of the clarify-questions wizard.
+// A skipped question is sent as `declined` (the agent is still unblocked and
+// told it was skipped).
+export type AnswerSubmission = { questionId: string; kind: AnswerKind; text: string }
+
 export type QuestionOption = {
   title: string
   description: string

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AgentEvent, AnswerKind, EnvSuggestion, Question, Task } from '$lib/types'
+  import type { AgentEvent, AnswerSubmission, EnvSuggestion, Question, Task } from '$lib/types'
 
   import { onMount, onDestroy, tick } from 'svelte'
   import { toast } from 'svelte-sonner'
@@ -54,8 +54,13 @@
     }
   }
 
-  async function submitAnswer(questionId: string, kind: AnswerKind, text: string) {
-    await answerQuestion(questionId, kind, text)
+  // Persist every answer from the wizard's review step, then reload once. The
+  // agent only resumes when no pending question remains, so submitting them
+  // together (in order) is safe.
+  async function submitAnswers(answers: AnswerSubmission[]) {
+    for (const answer of answers) {
+      await answerQuestion(answer.questionId, answer.kind, answer.text)
+    }
     await load()
   }
 
@@ -387,7 +392,7 @@
     >
       <Resizable.Pane defaultSize={55} minSize={30} class="min-w-0">
         <div class="h-full min-w-0 pr-3">
-          <IssueView {task} {questions} onAnswer={submitAnswer} />
+          <IssueView {task} {questions} onSubmit={submitAnswers} />
         </div>
       </Resizable.Pane>
 


### PR DESCRIPTION
Closes #118.

## Problem
When the agent asked several clarifying questions, the task view stacked one card per question (the reported "x3 panels on top of each other"), and each had its own Send.

## Change
The pending questions are now gathered into a single `QuestionWizard` panel in the issue feed:

- **Progress bar** at the top: one segment per question plus a trailing review segment, with a "Question N of M" / "Review & send" label. Segments are clickable to jump back to a step.
- **One question at a time** with **Back / Skip / Next**. Pick an option or type your own answer; Next advances (relabelled "Review" on the last question). Skip passes on a question.
- **Final review step** lists every question with the chosen answer (or "Skipped"), each with an Edit button to jump back and change it, then one **Send answers** button.

Answers are collected locally and submitted together when you send. That is safe because the agent only resumes once no question is left pending (`pick_resume_ready`), so persisting them in order never resumes mid-way. A skipped question is recorded as `declined`, which still resolves it and is delivered to the agent (it is told the question was skipped).

The answered-decision history feed is unchanged. `DecisionsFeed` now delegates pending questions to `QuestionWizard`, and its per-question `onAnswer` callback became a single `onSubmit(answers)` (threaded through `IssueView` and the task page).

## Verification
`yarn check` (0 errors, 0 warnings) and `yarn build` pass. Frontend-only; no backend or API changes (same answer endpoint, called once per question on send).