### PR TITLE
Cascade-delete a repository's tasks, with a confirm modal (#94)

### DIFF
--- a/api/migrations/0017_repo_cascade_delete.sql
+++ b/api/migrations/0017_repo_cascade_delete.sql
@@ -1,0 +1,14 @@
+-- Deleting a repository should purge everything synced from it. The task ->
+-- turns/events/questions/suggestions chain already cascades on delete, but
+-- `tasks.repo_id` was ON DELETE SET NULL, so deleting a repo orphaned its tasks
+-- on the board instead of removing them. Switch it to ON DELETE CASCADE so a
+-- repo delete trickles all the way down.
+--
+-- (The Jira board <-> repo association is a JSONB array, not a foreign key, so it
+-- cannot cascade here; `delete_repository` strips the repo id from it in the same
+-- transaction.)
+ALTER TABLE tasks DROP CONSTRAINT tasks_repo_id_fkey;
+
+ALTER TABLE tasks
+    ADD CONSTRAINT tasks_repo_id_fkey
+    FOREIGN KEY (repo_id) REFERENCES repositories(id) ON DELETE CASCADE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -268,6 +268,17 @@ pub struct Repository {
     pub updated_at: DateTime<Utc>,
 }
 
+/// What a repository delete will purge, so the UI can spell it out before the
+/// user confirms. Counts the repo's tasks and everything that cascades from them.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct RepoDeletionImpact {
+    pub tasks: i64,
+    pub turns: i64,
+    pub events: i64,
+    pub questions: i64,
+    pub suggestions: i64,
+}
+
 /// A Jira board we follow for tickets.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
 pub struct JiraBoard {

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -13,8 +13,9 @@ use uuid::Uuid;
 
 use super::models::{
     AnswerKind, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite, JiraBoard, JiraDeployment,
-    NetworkAccessLevel, PendingQuestion, Question, QuestionOption, QuestionStatus, Repository,
-    ReviewPolicy, Settings, SourceKind, Task, TaskColumn, TaskStatus, Turn,
+    NetworkAccessLevel, PendingQuestion, Question, QuestionOption, QuestionStatus,
+    RepoDeletionImpact, Repository, ReviewPolicy, Settings, SourceKind, Task, TaskColumn,
+    TaskStatus, Turn,
 };
 
 // --- Settings ----------------------------------------------------------------
@@ -445,11 +446,46 @@ pub async fn create_repository_if_absent(
     .await
 }
 
+/// Counts everything a delete of this repo would purge: its tasks and the
+/// turns, events, questions, and suggestions that cascade from them.
+pub async fn repo_deletion_impact(pool: &PgPool, id: Uuid) -> sqlx::Result<RepoDeletionImpact> {
+    sqlx::query_as::<_, RepoDeletionImpact>(
+        "SELECT \
+           (SELECT COUNT(*) FROM tasks WHERE repo_id = $1) AS tasks, \
+           (SELECT COUNT(*) FROM turns t \
+              JOIN tasks k ON t.task_id = k.id WHERE k.repo_id = $1) AS turns, \
+           (SELECT COUNT(*) FROM events e \
+              JOIN turns t ON e.turn_id = t.id \
+              JOIN tasks k ON t.task_id = k.id WHERE k.repo_id = $1) AS events, \
+           (SELECT COUNT(*) FROM questions q \
+              JOIN tasks k ON q.task_id = k.id WHERE k.repo_id = $1) AS questions, \
+           (SELECT COUNT(*) FROM environment_suggestions s \
+              JOIN tasks k ON s.task_id = k.id WHERE k.repo_id = $1) AS suggestions",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+}
+
+/// Deletes a repository and everything synced from it. The `tasks.repo_id` FK
+/// cascades to the repo's tasks, and tasks cascade to their turns/events/
+/// questions/suggestions, so the whole subtree goes in one statement. The Jira
+/// board association is a JSON array (no FK), so we strip the repo id from it in
+/// the same transaction to avoid a dangling reference on the next sync.
 pub async fn delete_repository(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "UPDATE jira_boards SET repo_ids = repo_ids - $1, updated_at = now() \
+         WHERE jsonb_exists(repo_ids, $1)",
+    )
+    .bind(id.to_string())
+    .execute(&mut *tx)
+    .await?;
     sqlx::query("DELETE FROM repositories WHERE id = $1")
         .bind(id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(())
 }
 

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -75,6 +75,7 @@ pub fn router(state: AppState) -> Router {
             "/repos/:id",
             axum::routing::put(repos::update).delete(repos::delete),
         )
+        .route("/repos/:id/deletion-impact", get(repos::deletion_impact))
         .route("/repos/import-org", post(repos::import_org))
         .route("/sync", post(repos::sync))
         .route("/jira/test", post(jira::test))

--- a/api/src/http/repos.rs
+++ b/api/src/http/repos.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use uuid::Uuid;
 
 use super::ApiResult;
-use crate::db::models::{Repository, ReviewPolicy};
+use crate::db::models::{RepoDeletionImpact, Repository, ReviewPolicy};
 use crate::db::queries;
 use crate::git;
 use crate::state::AppState;
@@ -104,12 +104,22 @@ pub async fn update(
     Ok(Json(repo))
 }
 
-/// `DELETE /api/v1/repos/:id`
+/// `GET /api/v1/repos/:id/deletion-impact` - what a delete would purge, so the
+/// UI can spell it out before the user confirms.
+pub async fn deletion_impact(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<RepoDeletionImpact>> {
+    Ok(Json(queries::repo_deletion_impact(&state.db, id).await?))
+}
+
+/// `DELETE /api/v1/repos/:id` - delete the repo and everything synced from it.
 pub async fn delete(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
     queries::delete_repository(&state.db, id).await?;
+    state.notify_board();
     Ok(Json(json!({ "deleted": true })))
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   NetworkAccessLevel,
   PendingQuestion,
   Question,
+  RepoDeletionImpact,
   Repository,
   ReviewPolicy,
   Settings,
@@ -112,6 +113,11 @@ export function upsertRepo(body: UpsertRepoRequest) {
 // full_name, would do).
 export function updateRepo(repoId: string, body: UpsertRepoRequest) {
   return apiClient.put(`repos/${repoId}`, { json: body }).json<Repository>()
+}
+
+// What a delete would purge, so the confirmation can spell it out first.
+export function repoDeletionImpact(repoId: string) {
+  return apiClient.get(`repos/${repoId}/deletion-impact`).json<RepoDeletionImpact>()
 }
 
 export function deleteRepo(repoId: string) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -196,6 +196,15 @@ export type Repository = {
   updated_at: string
 }
 
+// What deleting a repository will purge, shown in the delete confirmation.
+export type RepoDeletionImpact = {
+  tasks: number
+  turns: number
+  events: number
+  questions: number
+  suggestions: number
+}
+
 export type AgentEvent = {
   id: number
   turn_id: string

--- a/frontend/src/routes/repos/+page.svelte
+++ b/frontend/src/routes/repos/+page.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
-  import type { Repository, ReviewPolicy } from '$lib/types'
+  import type { RepoDeletionImpact, Repository, ReviewPolicy } from '$lib/types'
 
   import { onMount } from 'svelte'
   import { Pencil, Trash2 } from '@lucide/svelte'
 
-  import { deleteRepo, getSettings, importOrg, listRepos, updateRepo, upsertRepo } from '$lib/api'
+  import {
+    deleteRepo,
+    getSettings,
+    importOrg,
+    listRepos,
+    repoDeletionImpact,
+    updateRepo,
+    upsertRepo
+  } from '$lib/api'
   import * as Card from '$lib/components/ui/card'
   import * as Select from '$lib/components/ui/select'
-  import { Button } from '$lib/components/ui/button'
+  import * as AlertDialog from '$lib/components/ui/alert-dialog'
+  import { Button, buttonVariants } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
   import { Textarea } from '$lib/components/ui/textarea'
@@ -157,9 +166,39 @@
     await load()
   }
 
-  async function remove(repoId: string) {
-    await deleteRepo(repoId)
-    await load()
+  // Deleting a repo cascades to every task synced from it (and their logs,
+  // decisions, and notes), so confirm first and spell out the impact.
+  let deleteTarget = $state<Repository | null>(null)
+  let deleteImpact = $state<RepoDeletionImpact | null>(null)
+  let deleting = $state(false)
+
+  function askDelete(repo: Repository) {
+    deleteTarget = repo
+    deleteImpact = null
+    repoDeletionImpact(repo.id)
+      .then((impact) => {
+        // Ignore a late response if the user has since opened a different repo.
+        if (deleteTarget?.id === repo.id) {
+          deleteImpact = impact
+        }
+      })
+      .catch((error) => console.debug('failed to load deletion impact', error))
+  }
+
+  async function confirmDelete() {
+    const target = deleteTarget
+    if (!target) {
+      return
+    }
+    deleting = true
+    try {
+      await deleteRepo(target.id)
+      deleteTarget = null
+      deleteImpact = null
+      await load()
+    } finally {
+      deleting = false
+    }
   }
 
   async function runImportOrg() {
@@ -227,7 +266,7 @@
                 size="icon"
                 title="Delete"
                 class="text-destructive hover:text-destructive"
-                onclick={() => remove(repo.id)}
+                onclick={() => askDelete(repo)}
               >
                 <Trash2 class="size-4" />
               </Button>
@@ -325,3 +364,60 @@
     </Card.Content>
   </Card.Root>
 </div>
+
+<AlertDialog.Root
+  open={deleteTarget !== null}
+  onOpenChange={(open) => {
+    if (!open) {
+      deleteTarget = null
+    }
+  }}
+>
+  <AlertDialog.Content>
+    {#if deleteTarget}
+      <AlertDialog.Header>
+        <AlertDialog.Title>Delete {deleteTarget.full_name}?</AlertDialog.Title>
+        <AlertDialog.Description>
+          This permanently removes the repository and everything synced from it. This cannot be
+          undone.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+
+      <div class="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+        {#if deleteImpact}
+          <p class="mb-1 font-medium">This will also delete:</p>
+          <ul class="list-disc space-y-0.5 pl-5 text-muted-foreground">
+            <li>
+              {deleteImpact.tasks}
+              {deleteImpact.tasks === 1 ? 'task' : 'tasks'} (issues on the board)
+            </li>
+            <li>
+              {deleteImpact.turns} agent {deleteImpact.turns === 1 ? 'turn' : 'turns'} with
+              {deleteImpact.events} activity log {deleteImpact.events === 1 ? 'event' : 'events'}
+            </li>
+            <li>
+              {deleteImpact.questions}
+              {deleteImpact.questions === 1 ? 'decision' : 'decisions'} and
+              {deleteImpact.suggestions} environment {deleteImpact.suggestions === 1
+                ? 'note'
+                : 'notes'}
+            </li>
+          </ul>
+        {:else}
+          <p class="text-muted-foreground">Counting what will be removed…</p>
+        {/if}
+      </div>
+
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action
+          class={buttonVariants({ variant: 'destructive' })}
+          disabled={deleting}
+          onclick={confirmDelete}
+        >
+          {deleting ? 'Deleting…' : 'Delete repository'}
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    {/if}
+  </AlertDialog.Content>
+</AlertDialog.Root>


### PR DESCRIPTION
Closes #94.

## Problem
Deleting a repo left every issue synced from it orphaned on the board. The `tasks.repo_id` foreign key was `ON DELETE SET NULL`, so the tasks (and all their data) stuck around with a null repo.

## Change
- **Full cascade.** Migration `0017` switches `tasks.repo_id` to `ON DELETE CASCADE`. The task children (turns -> events, questions, environment suggestions) already cascade from `task_id`, so deleting a repo now trickles all the way down: tasks, agent turns, activity log events, decisions, and notes, all purged in one statement.
- **Jira association.** `delete_repository` now runs in a transaction that also strips the deleted repo id from any Jira board's `repo_ids` (that link is a JSON array, not a foreign key, so it can't cascade on its own and would otherwise dangle on the next sync). The delete handler also notifies the board so the purged cards disappear live.
- **Confirm modal.** New `GET /repos/:id/deletion-impact` returns the counts of what a delete would remove. The repos page now guards delete behind an `AlertDialog` that spells out exactly what goes (N tasks, agent turns + log events, decisions, and environment notes) before you confirm, with a destructive-styled confirm button.

## Notes
- The migration drops and re-adds the FK by its conventional name (`tasks_repo_id_fkey`, the inline-FK name Postgres generated in `0001`); no later migration renamed it.
- No DB-backed tests exist in this project (sqlx runs at runtime, no test database), so the cascade is enforced and verified at the schema level rather than in a unit test.

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (clean), `cargo test` (48 passing).
- Frontend: `yarn check` (0 errors) and `yarn build`.