### PR TITLE
Add a private per-task notepad (#90)

### DIFF
--- a/api/migrations/0017_task_notes.sql
+++ b/api/migrations/0017_task_notes.sql
@@ -1,0 +1,4 @@
+-- A private per-task scratchpad: free-text notes only the operator sees. Stored
+-- in our database and deliberately never written back to the source ticket
+-- (GitHub / Jira), unlike comments or the reasoning summaries.
+ALTER TABLE tasks ADD COLUMN notes TEXT NOT NULL DEFAULT '';

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -314,6 +314,9 @@ pub struct Task {
     /// Fix turns already spent on this task's failing CI (bounds retry thrash).
     pub ci_fix_attempts: i32,
     pub hold: bool,
+    /// The operator's private scratchpad for this task. Stored only here and
+    /// never written back to the source ticket.
+    pub notes: String,
     pub session_id: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -703,6 +703,17 @@ pub async fn set_task_hold(pool: &PgPool, id: Uuid, hold: bool) -> sqlx::Result<
     .await
 }
 
+/// Saves the operator's private scratchpad for a task. Does not touch
+/// `updated_at`: notes are orthogonal to the task's lifecycle and saved often.
+pub async fn set_task_notes(pool: &PgPool, id: Uuid, notes: &str) -> sqlx::Result<()> {
+    sqlx::query("UPDATE tasks SET notes = $2 WHERE id = $1")
+        .bind(id)
+        .bind(notes)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 pub async fn set_task_status(pool: &PgPool, id: Uuid, status: TaskStatus) -> sqlx::Result<Task> {
     sqlx::query_as::<_, Task>(
         "UPDATE tasks SET status = $2, last_activity_at = now(), updated_at = now() \

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -64,6 +64,7 @@ pub fn router(state: AppState) -> Router {
         .route("/tasks/:id/stream", get(sse::task_stream))
         .route("/tasks/:id/move", post(board::move_task))
         .route("/tasks/:id/hold", post(board::set_hold))
+        .route("/tasks/:id/notes", axum::routing::put(tasks::set_notes))
         .route("/agent/suggestions", post(suggestions::create))
         .route("/suggestions/:id/ack", post(suggestions::acknowledge))
         .route("/agent/questions", post(questions::ask))

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -49,6 +49,23 @@ pub async fn get_task(
     .into_response())
 }
 
+#[derive(Debug, Deserialize)]
+pub struct NotesRequest {
+    pub notes: String,
+}
+
+/// `PUT /api/v1/tasks/:id/notes` - save the operator's private scratchpad for a
+/// task. Stored only in our database; never sent to the source ticket. No board
+/// notification, since notes are private and change nothing others can see.
+pub async fn set_notes(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<NotesRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    queries::set_task_notes(&state.db, id, &body.notes).await?;
+    Ok(Json(json!({ "saved": true })))
+}
+
 /// Resolves a task to its GitHub `(owner, repo, issue number)`, or an error
 /// response when the task isn't a GitHub issue with a linked repository.
 async fn issue_coords(

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1013,6 +1013,7 @@ mod tests {
             error: None,
             ci_fix_attempts: 0,
             hold: false,
+            notes: String::new(),
             session_id: None,
             started_at: None,
             finished_at: None,

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -292,6 +292,7 @@ mod tests {
             error: None,
             ci_fix_attempts: 0,
             hold: false,
+            notes: String::new(),
             session_id: None,
             started_at: None,
             finished_at: None,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,11 @@ export function setTaskHold(taskId: string, hold: boolean) {
   return apiClient.post(`tasks/${taskId}/hold`, { json: { hold } }).json<Task>()
 }
 
+// Save the private per-task notepad. Stored only in our DB, never sent to the ticket.
+export function setTaskNotes(taskId: string, notes: string) {
+  return apiClient.put(`tasks/${taskId}/notes`, { json: { notes } }).json<{ saved: boolean }>()
+}
+
 // --- Environment suggestions -------------------------------------------------
 
 export function acknowledgeSuggestion(suggestionId: string, acknowledged: boolean) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -104,6 +104,8 @@ export type Task = {
   error: string | null
   ci_fix_attempts: number
   hold: boolean
+  // The operator's private scratchpad; stored only here, never sent to the ticket.
+  notes: string
   session_id: string | null
   started_at: string | null
   finished_at: string | null

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -4,13 +4,20 @@
   import { onMount, onDestroy, tick } from 'svelte'
   import { toast } from 'svelte-sonner'
   import { page } from '$app/stores'
-  import { Pause, Play } from '@lucide/svelte'
+  import { ChevronDown, NotebookPen, Pause, Play } from '@lucide/svelte'
 
-  import { acknowledgeSuggestion, answerQuestion, getTask, setTaskHold } from '$lib/api'
+  import {
+    acknowledgeSuggestion,
+    answerQuestion,
+    getTask,
+    setTaskHold,
+    setTaskNotes
+  } from '$lib/api'
   import { STATUS_BADGE, STATUS_LABELS } from '$lib/types'
   import { PaneGroup, type PaneGroupAPI } from 'paneforge'
 
   import { Badge } from '$lib/components/ui/badge'
+  import { Textarea } from '$lib/components/ui/textarea'
   import * as Alert from '$lib/components/ui/alert'
   import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import * as Resizable from '$lib/components/ui/resizable'
@@ -62,6 +69,36 @@
       await answerQuestion(answer.questionId, answer.kind, answer.text)
     }
     await load()
+  }
+
+  // Private per-task notepad. Initialized once from the loaded task (not on every
+  // SSE-driven reload, which would clobber in-progress edits) and auto-saved.
+  let notes = $state('')
+  let notesInitialized = false
+  let notesOpen = $state(false)
+  let notesStatus = $state<'idle' | 'saving' | 'saved'>('idle')
+  let notesTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleNotesSave() {
+    notesStatus = 'saving'
+    if (notesTimer) {
+      clearTimeout(notesTimer)
+    }
+    notesTimer = setTimeout(saveNotes, 700)
+  }
+
+  async function saveNotes() {
+    if (notesTimer) {
+      clearTimeout(notesTimer)
+      notesTimer = null
+    }
+    try {
+      await setTaskNotes(taskId, notes)
+      notesStatus = 'saved'
+    } catch (error) {
+      console.debug('failed to save notes', error)
+      notesStatus = 'idle'
+    }
   }
 
   // Tool use/results/thinking start collapsed; any number can be open at once.
@@ -201,6 +238,12 @@
     }))
     suggestions = detail.suggestions
     questions = detail.questions
+    // Seed the notepad once, and open it if there is already something to read.
+    if (!notesInitialized) {
+      notes = detail.task.notes
+      notesOpen = notes.trim().length > 0
+      notesInitialized = true
+    }
   }
 
   // Hold toggle, behind a confirmation so it's a deliberate action.
@@ -338,6 +381,10 @@
     if (timer) {
       clearInterval(timer)
     }
+    // Flush a pending notes edit so leaving the page doesn't drop it.
+    if (notesTimer) {
+      void saveNotes()
+    }
   })
 </script>
 
@@ -383,6 +430,44 @@
         </ul>
       </section>
     {/if}
+
+    <!-- Private scratchpad: stored only here, never written to the source ticket. -->
+    <section class="flex-none rounded-lg border border-border bg-card">
+      <button
+        type="button"
+        onclick={() => (notesOpen = !notesOpen)}
+        class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-secondary/40"
+      >
+        <NotebookPen class="size-4 flex-none text-muted-foreground" />
+        <span class="font-semibold">Private notes</span>
+        {#if notes.trim()}
+          <span class="size-1.5 flex-none rounded-full bg-primary" title="This task has notes"></span>
+        {/if}
+        <span class="ml-auto text-xs text-muted-foreground">
+          {#if notesStatus === 'saving'}Saving…{:else if notesStatus === 'saved'}Saved{/if}
+        </span>
+        <ChevronDown
+          class="size-4 flex-none text-muted-foreground transition-transform {notesOpen
+            ? 'rotate-180'
+            : ''}"
+        />
+      </button>
+      {#if notesOpen}
+        <div class="space-y-1.5 border-t border-border p-3">
+          <Textarea
+            rows={8}
+            placeholder="Scratchpad for your own notes on this task…"
+            bind:value={notes}
+            oninput={scheduleNotesSave}
+            onblur={saveNotes}
+            class="resize-y text-sm"
+          />
+          <p class="text-xs text-muted-foreground">
+            Only you can see these. They are stored privately and never sent to GitHub or Jira.
+          </p>
+        </div>
+      {/if}
+    </section>
 
     <PaneGroup
       bind:this={paneGroup}


### PR DESCRIPTION
Closes #90.

## What
A large, private scratchpad textarea on each task view. The notes are stored only in our database and are **never** written back to the source ticket (GitHub / Jira), so they stay for your eyes only.

- New `tasks.notes` column (migration `0017`).
- `PUT /api/v1/tasks/:id/notes` to save them.
- A collapsible **Private notes** panel above the task panes with a resizable textarea, an inline "Saving… / Saved" indicator, a dot when the task has notes, and a one-line reminder that they are private.

## Behavior details
- The textarea is seeded once from the loaded task and is **not** re-seeded on the SSE-driven reloads that the task view does on every agent event, so live activity never clobbers an in-progress edit.
- Saves are debounced (~700ms), flushed immediately on blur, and flushed again on navigate-away so nothing is lost.
- Saving notes deliberately does not bump the task's `updated_at` or notify the board, since they are private and change nothing anyone else can see.
- The panel opens automatically when a task already has notes; otherwise it stays collapsed to keep the page tidy.

## Note on the migration number
This adds `0017_task_notes.sql`. Another open PR (#94) also adds a `0017_*` migration; whichever merges second will need a quick renumber. Flagging it for the group merge.

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (clean), `cargo test` (48 passing).
- Frontend: `yarn check` (0 errors) and `yarn build`.