### PR TITLE
Add a global notepad beside the board (#91)

### DIFF
--- a/api/migrations/0018_global_notepad.sql
+++ b/api/migrations/0018_global_notepad.sql
@@ -1,0 +1,5 @@
+-- A single global scratchpad shown beside the kanban board. It lives on the
+-- settings row but is read/written through a dedicated endpoint, not the settings
+-- round-trip, so the (potentially large) text never rides along with every board
+-- or settings poll. Private: stored only here, never sent anywhere.
+ALTER TABLE settings ADD COLUMN notepad TEXT NOT NULL DEFAULT '';

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -136,6 +136,23 @@ pub async fn set_paused(pool: &PgPool, paused: bool) -> sqlx::Result<()> {
     Ok(())
 }
 
+/// The global scratchpad shown beside the board.
+pub async fn get_notepad(pool: &PgPool) -> sqlx::Result<String> {
+    sqlx::query_scalar("SELECT notepad FROM settings WHERE id = 1")
+        .fetch_one(pool)
+        .await
+}
+
+/// Saves the global scratchpad. Does not touch `updated_at`: the notepad is a
+/// scratchpad saved often and orthogonal to the rest of the settings.
+pub async fn set_notepad(pool: &PgPool, content: &str) -> sqlx::Result<()> {
+    sqlx::query("UPDATE settings SET notepad = $1 WHERE id = 1")
+        .bind(content)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 /// Sets (or clears with `None`) the automatic usage-limit pause: the moment the
 /// agent may resume pulling work once the subscription window resets.
 pub async fn set_usage_paused_until(

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -7,6 +7,7 @@
 mod board;
 mod data;
 mod jira;
+mod notepad;
 mod questions;
 mod repos;
 mod settings;
@@ -87,6 +88,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/settings", get(settings::get).patch(settings::update))
         .route("/settings/pause", post(settings::set_pause))
+        .route("/notepad", get(notepad::get).put(notepad::set))
         .route("/settings/tokens", post(settings::set_tokens))
         .route(
             "/settings/env",

--- a/api/src/http/notepad.rs
+++ b/api/src/http/notepad.rs
@@ -1,0 +1,39 @@
+//! The global scratchpad shown beside the board. A single private value, read and
+//! written on its own so the (potentially large) text stays out of the board and
+//! settings payloads.
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use super::ApiResult;
+use crate::db::queries;
+use crate::state::AppState;
+
+#[derive(Debug, Serialize)]
+pub struct NotepadResponse {
+    pub content: String,
+}
+
+/// `GET /api/v1/notepad`
+pub async fn get(State(state): State<AppState>) -> ApiResult<Json<NotepadResponse>> {
+    let content = queries::get_notepad(&state.db).await?;
+    Ok(Json(NotepadResponse { content }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NotepadRequest {
+    pub content: String,
+}
+
+/// `PUT /api/v1/notepad` - save the global scratchpad. No board notification: the
+/// notepad is private and changes nothing anyone else can see.
+pub async fn set(
+    State(state): State<AppState>,
+    Json(body): Json<NotepadRequest>,
+) -> ApiResult<Json<NotepadResponse>> {
+    queries::set_notepad(&state.db, &body.content).await?;
+    Ok(Json(NotepadResponse {
+        content: body.content,
+    }))
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,16 @@ export function getBoard() {
   return apiClient.get('board').json<BoardResponse>()
 }
 
+// The global scratchpad shown beside the board. Read/saved on its own so the
+// text never rides along with every board poll.
+export function getNotepad() {
+  return apiClient.get('notepad').json<{ content: string }>()
+}
+
+export function setNotepad(content: string) {
+  return apiClient.put('notepad', { json: { content } }).json<{ content: string }>()
+}
+
 export function getTask(taskId: string) {
   return apiClient.get(`tasks/${taskId}`).json<TaskDetail>()
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -4,14 +4,26 @@
 
   import { onMount, onDestroy } from 'svelte'
   import { dndzone } from 'svelte-dnd-action'
-  import { RefreshCw, Pause, Play } from '@lucide/svelte'
+  import { NotebookPen, RefreshCw, Pause, Play } from '@lucide/svelte'
+  import { PaneGroup } from 'paneforge'
 
   import { COLUMNS } from '$lib/types'
-  import { getBoard, listRepos, moveTask, provisionWorkspace, setPaused, syncNow } from '$lib/api'
+  import {
+    getBoard,
+    getNotepad,
+    listRepos,
+    moveTask,
+    provisionWorkspace,
+    setNotepad,
+    setPaused,
+    syncNow
+  } from '$lib/api'
   import { isWithinSchedule } from '$lib/schedule'
   import Card from '$lib/components/Card.svelte'
   import { Button } from '$lib/components/ui/button'
+  import { Textarea } from '$lib/components/ui/textarea'
   import * as Alert from '$lib/components/ui/alert'
+  import * as Resizable from '$lib/components/ui/resizable'
 
   const FLIP_MS = 150
 
@@ -30,6 +42,49 @@
   let eventSource: EventSource | null = null
   // Maps a task's repo_id to its full name, so each card can show its source repo.
   let repoNames = $state<Record<string, string>>({})
+
+  // --- Global notepad --------------------------------------------------------
+  // A scratchpad in a resizable pane beside the board. Default collapsed; the
+  // user's open/closed choice and the text both persist.
+  const NOTEPAD_OPEN_KEY = 'seraphim.notepadOpen'
+
+  function readNotepadOpen(): boolean {
+    return typeof localStorage !== 'undefined' && localStorage.getItem(NOTEPAD_OPEN_KEY) === 'true'
+  }
+
+  let notesOpen = $state(readNotepadOpen())
+  let notepad = $state('')
+  let notepadStatus = $state<'idle' | 'saving' | 'saved'>('idle')
+  let notepadTimer: ReturnType<typeof setTimeout> | null = null
+
+  function setNotesOpen(open: boolean) {
+    notesOpen = open
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(NOTEPAD_OPEN_KEY, String(open))
+    }
+  }
+
+  function scheduleNotepadSave() {
+    notepadStatus = 'saving'
+    if (notepadTimer) {
+      clearTimeout(notepadTimer)
+    }
+    notepadTimer = setTimeout(saveNotepad, 700)
+  }
+
+  async function saveNotepad() {
+    if (notepadTimer) {
+      clearTimeout(notepadTimer)
+      notepadTimer = null
+    }
+    try {
+      await setNotepad(notepad)
+      notepadStatus = 'saved'
+    } catch (error) {
+      console.debug('failed to save notepad', error)
+      notepadStatus = 'idle'
+    }
+  }
 
   async function load() {
     const [board, repos] = await Promise.all([getBoard(), listRepos()])
@@ -131,12 +186,23 @@
 
   onMount(() => {
     load()
+    // The notepad loads once, separately from the board: the board stream below
+    // reloads on every change, which must never clobber an in-progress edit.
+    getNotepad()
+      .then((result) => (notepad = result.content))
+      .catch((error) => console.debug('failed to load notepad', error))
     // Live board: the API ticks this stream whenever anything changes.
     eventSource = new EventSource('/api/v1/board/stream')
     eventSource.addEventListener('board', () => load())
   })
 
-  onDestroy(() => eventSource?.close())
+  onDestroy(() => {
+    eventSource?.close()
+    // Flush a pending notepad edit so leaving the page doesn't drop it.
+    if (notepadTimer) {
+      void saveNotepad()
+    }
+  })
 </script>
 
 <!--
@@ -187,6 +253,15 @@
       {/if}
     </div>
     <div class="flex gap-2">
+      <Button
+        variant={notesOpen ? 'default' : 'outline'}
+        size="icon"
+        title={notesOpen ? 'Close notes' : 'Show notes'}
+        aria-label={notesOpen ? 'Close notes' : 'Show notes'}
+        onclick={() => setNotesOpen(!notesOpen)}
+      >
+        <NotebookPen class="size-4" />
+      </Button>
       <Button variant="outline" size="sm" disabled={checking} onclick={checkIssues}>
         <RefreshCw class="size-4 {checking ? 'animate-spin' : ''}" />
         {checking ? 'Checking…' : 'Check issues'}
@@ -207,9 +282,7 @@
     </div>
   </div>
 
-  <div
-    class="grid grid-cols-1 items-start gap-3 p-4 lg:min-h-0 lg:flex-1 lg:grid-cols-6 lg:px-6 lg:pb-6"
-  >
+  {#snippet kanbanColumns()}
     {#each COLUMNS as column}
       <section class="flex max-h-full min-h-0 flex-col rounded-lg border border-border bg-card">
         <header
@@ -242,5 +315,65 @@
         </div>
       </section>
     {/each}
-  </div>
+  {/snippet}
+
+  {#if notesOpen}
+    <!--
+      Board + notepad, split by a drag bar. Dragging the notepad fully to the
+      right collapses it past its min size, which hides it entirely and hands the
+      whole width back to the board (same as clicking "Close notes").
+    -->
+    <PaneGroup
+      direction="horizontal"
+      class="flex h-[70vh] w-full overflow-hidden lg:h-auto lg:min-h-0 lg:flex-1"
+    >
+      <Resizable.Pane defaultSize={72} minSize={40} class="min-w-0">
+        <div
+          class="grid h-full min-h-0 grid-cols-1 items-start gap-3 p-4 lg:grid-cols-6 lg:px-6 lg:pb-6"
+        >
+          {@render kanbanColumns()}
+        </div>
+      </Resizable.Pane>
+
+      <Resizable.Handle
+        withHandle
+        class="w-1.5 bg-border transition-colors hover:bg-primary data-[active]:bg-primary"
+      />
+
+      <Resizable.Pane
+        defaultSize={28}
+        minSize={18}
+        collapsible
+        collapsedSize={0}
+        onCollapse={() => setNotesOpen(false)}
+        class="min-w-0"
+      >
+        <div class="h-full py-4 pl-2 pr-6">
+          <div class="flex h-full min-w-0 flex-col rounded-lg border border-border bg-card">
+            <header
+              class="flex flex-none items-center justify-between gap-2 border-b border-border px-4 py-2.5"
+            >
+              <span class="text-xs uppercase tracking-wide text-muted-foreground">Notepad</span>
+              <span class="text-xs text-muted-foreground">
+                {#if notepadStatus === 'saving'}Saving…{:else if notepadStatus === 'saved'}Saved{/if}
+              </span>
+            </header>
+            <Textarea
+              bind:value={notepad}
+              oninput={scheduleNotepadSave}
+              onblur={saveNotepad}
+              placeholder="A global scratchpad for anything…"
+              class="min-h-0 flex-1 resize-none rounded-none rounded-b-lg border-0 bg-transparent text-sm focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          </div>
+        </div>
+      </Resizable.Pane>
+    </PaneGroup>
+  {:else}
+    <div
+      class="grid grid-cols-1 items-start gap-3 p-4 lg:min-h-0 lg:flex-1 lg:grid-cols-6 lg:px-6 lg:pb-6"
+    >
+      {@render kanbanColumns()}
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
Closes #91.

## What
A persistent global scratchpad in a resizable pane on the right of the kanban page, modeled on the task view's split.

- **Default collapsed**: the board fills the whole width, and an icon button in the header toggles the notepad. Its tooltip reads "Show notes" when closed and "Close notes" when open.
- **Drag bar** between the board and the notepad to resize, just like the task view.
- **Collapse to hide**: dragging the notepad fully to the right collapses it past its minimum size, which hides it entirely and hands the full width back to the board (same end state as clicking "Close notes").
- **Massive textarea** filling the pane, that **auto-saves**: debounced while typing, flushed on blur, and flushed again on navigate-away, so you never have to think about saving.

## How it's stored
A single value on the `settings` row (migration `0018`), read and written through a dedicated `GET` / `PUT /api/v1/notepad` endpoint rather than the settings round-trip, so the (potentially large) text never rides along with every board or settings poll. It is loaded once on mount, separately from the board's live SSE reload, so incoming board activity can never clobber an in-progress edit. The open/closed choice is remembered in localStorage; the text itself lives in the database.

## Note on the migration number
This adds `0018_global_notepad.sql` (develop is at `0017`). The still-open PR #90 also adds a `0017_*` migration; if it lands after this, a quick renumber may be needed. Flagging for the group merge.

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (clean), `cargo test` (48 passing).
- Frontend: `yarn check` (0 errors) and `yarn build`.