### PR TITLE
Add an internal ticket provider (#70)

### DIFF
--- a/api/migrations/0019_internal_source.sql
+++ b/api/migrations/0019_internal_source.sql
@@ -1,0 +1,8 @@
+-- A third ticket provider: tasks that live only in our database, with no GitHub
+-- or Jira backing. Created from the "Create issue" page; the agent can comment on
+-- them and open/close them through the same (now source-aware) task endpoints.
+--
+-- ADD VALUE must land in its own migration: Postgres won't let the new enum value
+-- be *used* in the same transaction it is added in, and the next migration
+-- references 'internal' in a partial index predicate.
+ALTER TYPE source_kind ADD VALUE IF NOT EXISTS 'internal';

--- a/api/migrations/0020_internal_comments.sql
+++ b/api/migrations/0020_internal_comments.sql
@@ -1,0 +1,19 @@
+-- Human-friendly sequential ids for internal tickets, shown as "#42".
+CREATE SEQUENCE IF NOT EXISTS internal_ticket_seq;
+
+-- Comments on internal tickets. GitHub and Jira keep comments on their own
+-- service; internal tickets need their own store. `author` is 'user' (the
+-- operator, from the UI) or 'agent' (Seraphim, via the agent helper).
+CREATE TABLE internal_comments (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id    UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    author     TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX internal_comments_task_idx ON internal_comments (task_id, created_at);
+
+-- An internal ticket's external_id comes from the sequence above, so it is unique
+-- on its own. The composite (repo_id, source_kind, external_id) constraint treats
+-- the NULL repo_id as distinct, so add a real guard against duplicates.
+CREATE UNIQUE INDEX tasks_internal_external_id_key ON tasks (external_id) WHERE source_kind = 'internal';

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -18,6 +18,8 @@ use uuid::Uuid;
 pub enum SourceKind {
     Github,
     Jira,
+    /// A ticket that lives only in our database, with no external tracker.
+    Internal,
 }
 
 /// What Seraphim does with a pull request once the agent opens it.
@@ -277,6 +279,17 @@ pub struct RepoDeletionImpact {
     pub events: i64,
     pub questions: i64,
     pub suggestions: i64,
+}
+
+/// One comment on an internal ticket. `author` is `"user"` (the operator) or
+/// `"agent"` (Seraphim).
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct InternalComment {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub author: String,
+    pub body: String,
+    pub created_at: DateTime<Utc>,
 }
 
 /// A Jira board we follow for tickets.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,8 +12,8 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnswerKind, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite, JiraBoard, JiraDeployment,
-    NetworkAccessLevel, PendingQuestion, Question, QuestionOption, QuestionStatus,
+    AnswerKind, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite, InternalComment, JiraBoard,
+    JiraDeployment, NetworkAccessLevel, PendingQuestion, Question, QuestionOption, QuestionStatus,
     RepoDeletionImpact, Repository, ReviewPolicy, Settings, SourceKind, Task, TaskColumn,
     TaskStatus, Turn,
 };
@@ -765,6 +765,61 @@ pub async fn set_task_notes(pool: &PgPool, id: Uuid, notes: &str) -> sqlx::Resul
         .execute(pool)
         .await?;
     Ok(())
+}
+
+// --- Internal tickets --------------------------------------------------------
+
+/// Creates an internal ticket (no external tracker). It lands in `Available` at
+/// the given position with a sequential, human-friendly external id.
+pub async fn create_internal_task(
+    pool: &PgPool,
+    title: &str,
+    body: &str,
+    state: &str,
+    initial_position: f64,
+) -> sqlx::Result<Task> {
+    sqlx::query_as::<_, Task>(
+        "INSERT INTO tasks \
+           (source_kind, external_id, title, body_snapshot, url, external_state, board_column, position) \
+         VALUES ('internal', nextval('internal_ticket_seq')::text, $1, $2, '', $3, 'available', $4) \
+         RETURNING *",
+    )
+    .bind(title)
+    .bind(body)
+    .bind(state)
+    .bind(initial_position)
+    .fetch_one(pool)
+    .await
+}
+
+/// An internal ticket's comments, oldest first.
+pub async fn list_internal_comments(
+    pool: &PgPool,
+    task_id: Uuid,
+) -> sqlx::Result<Vec<InternalComment>> {
+    sqlx::query_as::<_, InternalComment>(
+        "SELECT * FROM internal_comments WHERE task_id = $1 ORDER BY created_at",
+    )
+    .bind(task_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// Posts a comment to an internal ticket. `author` is "user" or "agent".
+pub async fn add_internal_comment(
+    pool: &PgPool,
+    task_id: Uuid,
+    author: &str,
+    body: &str,
+) -> sqlx::Result<InternalComment> {
+    sqlx::query_as::<_, InternalComment>(
+        "INSERT INTO internal_comments (task_id, author, body) VALUES ($1, $2, $3) RETURNING *",
+    )
+    .bind(task_id)
+    .bind(author)
+    .bind(body)
+    .fetch_one(pool)
+    .await
 }
 
 pub async fn set_task_status(pool: &PgPool, id: Uuid, status: TaskStatus) -> sqlx::Result<Task> {

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -58,6 +58,7 @@ pub fn router(state: AppState) -> Router {
         .route("/ping", get(|| async { Json(json!({ "status": "ok" })) }))
         .route("/board", get(board::get_board))
         .route("/board/stream", get(sse::board_stream))
+        .route("/tasks", post(tasks::create))
         .route("/tasks/:id", get(tasks::get_task))
         .route("/tasks/:id/issue", get(tasks::get_issue))
         .route("/tasks/:id/issue/state", post(tasks::set_issue_state))

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -9,10 +9,42 @@ use serde_json::json;
 use uuid::Uuid;
 
 use super::ApiResult;
-use crate::db::models::{EnvSuggestion, Event, Question, SourceKind, Task};
+use crate::db::models::{EnvSuggestion, Event, Question, SourceKind, Task, TaskColumn};
 use crate::db::queries;
 use crate::git;
+use crate::git::{IssueComment, IssueDetail, IssueThread, IssueUser};
 use crate::state::AppState;
+
+/// The display login for an internal-comment author ("user" -> the operator,
+/// "agent" -> Seraphim).
+fn internal_login(author: &str) -> String {
+    if author == "agent" { "Seraphim" } else { "You" }.to_string()
+}
+
+/// An `IssueUser` with no GitHub backing, for the internal conversation view.
+fn internal_user(login: String) -> IssueUser {
+    IssueUser {
+        login,
+        avatar_url: String::new(),
+        html_url: String::new(),
+    }
+}
+
+/// The synthetic issue header for an internal ticket, built from the task row.
+fn internal_issue_detail(task: &Task, state: &str) -> IssueDetail {
+    IssueDetail {
+        number: task.external_id.parse().unwrap_or(0),
+        title: task.title.clone(),
+        state: state.to_string(),
+        user: internal_user("You".to_string()),
+        body: Some(task.body_snapshot.clone()),
+        created_at: task.created_at.to_rfc3339(),
+        author_association: String::new(),
+        labels: Vec::new(),
+        assignees: Vec::new(),
+        milestone: None,
+    }
+}
 
 #[derive(Debug, Serialize)]
 pub struct TaskDetail {
@@ -110,9 +142,70 @@ async fn issue_coords(
     Ok(Ok((owner.to_string(), name.to_string(), task.external_id)))
 }
 
-/// `GET /api/v1/tasks/:id/issue` - the GitHub issue thread (body + comments +
-/// labels/assignees) for the GitHub-style conversation view.
+#[derive(Debug, Deserialize)]
+pub struct CreateTaskRequest {
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
+    /// `"open"` (default) or `"closed"`.
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
+/// `POST /api/v1/tasks` - create an internal ticket (no external tracker). Lands
+/// in `Available` for the operator to triage onto the board.
+pub async fn create(
+    State(state): State<AppState>,
+    Json(body): Json<CreateTaskRequest>,
+) -> ApiResult<Response> {
+    let title = body.title.trim();
+    if title.is_empty() {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "title is required" })),
+        )
+            .into_response());
+    }
+    let ticket_state = if body.state.as_deref() == Some("closed") {
+        "closed"
+    } else {
+        "open"
+    };
+    let position = queries::max_position_in_column(&state.db, TaskColumn::Available)
+        .await?
+        .unwrap_or(0.0)
+        + 1.0;
+    let task =
+        queries::create_internal_task(&state.db, title, body.body.trim(), ticket_state, position)
+            .await?;
+    state.notify_board();
+    Ok(Json(task).into_response())
+}
+
+/// `GET /api/v1/tasks/:id/issue` - the conversation view: a real GitHub issue
+/// thread, or a synthetic one (body + DB comments + state) for an internal ticket.
 pub async fn get_issue(State(state): State<AppState>, Path(id): Path<Uuid>) -> ApiResult<Response> {
+    if let Some(task) = queries::get_task(&state.db, id).await? {
+        if task.source_kind == SourceKind::Internal {
+            let comments = queries::list_internal_comments(&state.db, id)
+                .await?
+                .into_iter()
+                .map(|comment| IssueComment {
+                    user: internal_user(internal_login(&comment.author)),
+                    body: Some(comment.body),
+                    created_at: comment.created_at.to_rfc3339(),
+                    author_association: String::new(),
+                })
+                .collect();
+            let state_str = task.external_state.clone().unwrap_or_else(|| "open".into());
+            let thread = IssueThread {
+                issue: internal_issue_detail(&task, &state_str),
+                comments,
+            };
+            return Ok(Json(thread).into_response());
+        }
+    }
+
     let (owner, name, number) = match issue_coords(&state, id).await? {
         Ok(coords) => coords,
         Err(response) => return Ok(response),
@@ -133,6 +226,9 @@ pub async fn get_issue(State(state): State<AppState>, Path(id): Path<Uuid>) -> A
 #[derive(Debug, Deserialize)]
 pub struct CommentRequest {
     pub body: String,
+    /// For internal tickets: "user" (default) or "agent". Ignored for GitHub.
+    #[serde(default)]
+    pub author: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -156,6 +252,16 @@ pub async fn set_issue_state(
         )
             .into_response());
     }
+
+    // Internal tickets have no external service; toggle the state in our DB.
+    if let Some(task) = queries::get_task(&state.db, id).await? {
+        if task.source_kind == SourceKind::Internal {
+            queries::set_task_external_state(&state.db, id, &payload.state).await?;
+            state.notify_board();
+            return Ok(Json(internal_issue_detail(&task, &payload.state)).into_response());
+        }
+    }
+
     let (owner, name, number) = match issue_coords(&state, id).await? {
         Ok(coords) => coords,
         Err(response) => return Ok(response),
@@ -192,6 +298,26 @@ pub async fn add_comment(
         )
             .into_response());
     }
+
+    // Internal tickets store comments in our DB rather than on a service.
+    if let Some(task) = queries::get_task(&state.db, id).await? {
+        if task.source_kind == SourceKind::Internal {
+            let author = match payload.author.as_deref() {
+                Some("agent") => "agent",
+                _ => "user",
+            };
+            let comment =
+                queries::add_internal_comment(&state.db, id, author, &payload.body).await?;
+            let view = IssueComment {
+                user: internal_user(internal_login(&comment.author)),
+                body: Some(comment.body),
+                created_at: comment.created_at.to_rfc3339(),
+                author_association: String::new(),
+            };
+            return Ok(Json(view).into_response());
+        }
+    }
+
     let (owner, name, number) = match issue_coords(&state, id).await? {
         Ok(coords) => coords,
         Err(response) => return Ok(response),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -49,6 +49,11 @@ export function getTask(taskId: string) {
   return apiClient.get(`tasks/${taskId}`).json<TaskDetail>()
 }
 
+// Create an internal ticket (no GitHub/Jira backing). Returns the new task.
+export function createInternalTask(body: { title: string; body: string; state: 'open' | 'closed' }) {
+  return apiClient.post('tasks', { json: body }).json<Task>()
+}
+
 export function getIssueThread(taskId: string) {
   return apiClient.get(`tasks/${taskId}/issue`).json<IssueThread>()
 }

--- a/frontend/src/lib/components/IssueView.svelte
+++ b/frontend/src/lib/components/IssueView.svelte
@@ -57,6 +57,9 @@
   let posting = $state(false)
 
   const isGithub = $derived(task.source_kind === 'github')
+  // GitHub and internal tickets both render the conversation view (the backend
+  // synthesizes a thread for internal tickets from our DB). Jira stays body-only.
+  const hasThread = $derived(task.source_kind === 'github' || task.source_kind === 'internal')
 
   // Everyone who appears in the thread, de-duplicated, for the Participants list.
   const participants = $derived.by(() => {
@@ -89,13 +92,13 @@
   }
 
   async function load() {
-    if (!isGithub) {
+    if (!hasThread) {
       return
     }
     try {
       thread = await getIssueThread(task.id)
     } catch (error) {
-      loadError = error instanceof Error ? error.message : 'Failed to load the issue from GitHub.'
+      loadError = error instanceof Error ? error.message : 'Failed to load the issue.'
     }
   }
 
@@ -146,12 +149,24 @@
 
 {#snippet commentCard(user: IssueUser, createdAt: string, assoc: string, body: string | null)}
   <div class="flex gap-3">
-    <img src={user.avatar_url} alt={user.login} class="size-10 flex-none rounded-full" />
+    {#if user.avatar_url}
+      <img src={user.avatar_url} alt={user.login} class="size-10 flex-none rounded-full" />
+    {:else}
+      <div
+        class="flex size-10 flex-none items-center justify-center rounded-full bg-secondary text-sm font-semibold text-muted-foreground"
+      >
+        {user.login.slice(0, 1).toUpperCase()}
+      </div>
+    {/if}
     <div class="min-w-0 flex-1 rounded-lg border border-border">
       <div class="flex items-center gap-2 rounded-t-lg border-b border-border bg-secondary px-4 py-2 text-sm">
-        <a href={user.html_url} target="_blank" rel="noreferrer" class="font-semibold hover:text-primary">
-          {user.login}
-        </a>
+        {#if user.html_url}
+          <a href={user.html_url} target="_blank" rel="noreferrer" class="font-semibold hover:text-primary">
+            {user.login}
+          </a>
+        {:else}
+          <span class="font-semibold">{user.login}</span>
+        {/if}
         <span class="text-muted-foreground">commented on {formatDate(createdAt)}</span>
         {#if association(assoc)}
           <span class="ml-auto rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
@@ -247,7 +262,17 @@
             class="resize-y font-mono text-sm"
           />
           <div class="mt-2 flex flex-wrap items-center justify-end gap-2">
-            {#if thread.issue.state === 'open'}
+            {#if thread.issue.state === 'open' && !isGithub}
+              <!-- Internal tickets close plainly; no GitHub "reason" choices. -->
+              <Button
+                variant="outline"
+                disabled={updatingState}
+                onclick={() => changeState('closed')}
+              >
+                <CircleCheck class="size-4" />
+                {hasComment ? 'Close with comment' : 'Close issue'}
+              </Button>
+            {:else if thread.issue.state === 'open'}
               <!-- Split button: close (completed) + a dropdown of close reasons. -->
               <div class="flex">
                 <Button
@@ -296,8 +321,8 @@
             </Button>
           </div>
         </div>
-      {:else if !isGithub}
-        <!-- Non-GitHub source: render what the card holds, GitHub-styled. -->
+      {:else if !hasThread}
+        <!-- Jira (no thread fetch): render what the card holds, GitHub-styled. -->
         <div class="rounded-lg border border-border p-4">
           <Markdown source={task.body_snapshot} />
         </div>
@@ -307,8 +332,8 @@
       {/if}
     </div>
 
-    <!-- Sidebar -->
-    {#if thread}
+    <!-- Sidebar: GitHub-only (labels/assignees/milestone/participants). -->
+    {#if thread && isGithub}
       <aside class="hidden w-56 flex-none space-y-5 text-sm lg:block">
         <section>
           <h3 class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Assignees</h3>

--- a/frontend/src/lib/components/SourceIcon.svelte
+++ b/frontend/src/lib/components/SourceIcon.svelte
@@ -4,13 +4,16 @@
   // Brand marks via unplugin-icons (Simple Icons set), tree-shaken and offline.
   import GithubMark from '~icons/simple-icons/github'
   import JiraMark from '~icons/simple-icons/jira'
+  // Internal tickets have no brand; a database glyph marks "our DB only".
+  import InternalMark from '~icons/lucide/database'
 
   let { source, class: className = '' }: { source: SourceKind; class?: string } = $props()
 
   // One mark per issue source; add future providers here.
   const MARKS = {
     github: GithubMark,
-    jira: JiraMark
+    jira: JiraMark,
+    internal: InternalMark
   } as const satisfies Record<SourceKind, typeof GithubMark>
 
   const Mark = $derived(MARKS[source])

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -83,7 +83,7 @@ export type JiraBoard = {
   updated_at: string
 }
 
-export type SourceKind = 'github' | 'jira'
+export type SourceKind = 'github' | 'jira' | 'internal'
 
 export type Task = {
   id: string

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,11 +4,12 @@
   import '../app.css'
   import { onMount, onDestroy } from 'svelte'
   import { page } from '$app/stores'
-  import { Pause, TriangleAlert, Timer } from '@lucide/svelte'
+  import { Pause, Plus, TriangleAlert, Timer } from '@lucide/svelte'
 
   import { getBoard } from '$lib/api'
   import { isWithinSchedule } from '$lib/schedule'
   import { Toaster } from '$lib/components/ui/sonner'
+  import { buttonVariants } from '$lib/components/ui/button'
 
   import Notifications from '$lib/components/Notifications.svelte'
 
@@ -114,26 +115,31 @@
         </a>
       {/each}
     </nav>
-    {#if status}
-      <span
-        class="ml-auto inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold {PILLS[
-          status.key
-        ]}"
-        title="Agent status"
-      >
-        {#if status.key === 'paused'}
-          <Pause class="size-3.5" />
-        {:else if status.key === 'halted'}
-          <TriangleAlert class="size-3.5" />
-        {:else if status.key === 'cooldown'}
-          <Timer class="size-3.5" />
-        {:else}
-          <span class="size-2 rounded-full {DOTS[status.key as keyof typeof DOTS]}"></span>
-        {/if}
-        {status.label}
-      </span>
-    {/if}
-    <Notifications />
+    <div class="ml-auto flex items-center gap-3">
+      {#if status}
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold {PILLS[
+            status.key
+          ]}"
+          title="Agent status"
+        >
+          {#if status.key === 'paused'}
+            <Pause class="size-3.5" />
+          {:else if status.key === 'halted'}
+            <TriangleAlert class="size-3.5" />
+          {:else if status.key === 'cooldown'}
+            <Timer class="size-3.5" />
+          {:else}
+            <span class="size-2 rounded-full {DOTS[status.key as keyof typeof DOTS]}"></span>
+          {/if}
+          {status.label}
+        </span>
+      {/if}
+      <a href="/issues/new" class={buttonVariants({ variant: 'outline', size: 'sm' })}>
+        <Plus class="size-4" /> Create issue
+      </a>
+      <Notifications />
+    </div>
   </header>
   <main class="min-h-0 flex-1 overflow-auto">
     {@render children()}

--- a/frontend/src/routes/issues/new/+page.svelte
+++ b/frontend/src/routes/issues/new/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { goto } from '$app/navigation'
+  import { toast } from 'svelte-sonner'
+
+  import { createInternalTask } from '$lib/api'
+  import * as Card from '$lib/components/ui/card'
+  import { Button, buttonVariants } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Label } from '$lib/components/ui/label'
+  import { Textarea } from '$lib/components/ui/textarea'
+  import { Switch } from '$lib/components/ui/switch'
+
+  let title = $state('')
+  let description = $state('')
+  let open = $state(true)
+  let saving = $state(false)
+
+  async function submit() {
+    if (!title.trim()) {
+      toast.error('A title is required')
+      return
+    }
+    saving = true
+    try {
+      const task = await createInternalTask({
+        title: title.trim(),
+        body: description.trim(),
+        state: open ? 'open' : 'closed'
+      })
+      toast.success('Issue created')
+      goto(`/task/${task.id}`)
+    } catch {
+      toast.error('Could not create the issue')
+      saving = false
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-2xl space-y-5 px-6 py-6">
+  <div>
+    <a href="/" class="text-sm text-muted-foreground hover:text-foreground">← Board</a>
+    <h1 class="mt-2 text-2xl font-semibold">Create issue</h1>
+    <p class="text-sm text-muted-foreground">
+      An internal ticket tracked only in Seraphim, with no GitHub or Jira backing. It lands in
+      Available; add comments on the task page once it exists.
+    </p>
+  </div>
+
+  <Card.Root>
+    <Card.Content class="space-y-5 pt-6">
+      <div class="grid gap-2">
+        <Label for="title">Title</Label>
+        <Input id="title" placeholder="Short summary" bind:value={title} />
+      </div>
+
+      <div class="grid gap-2">
+        <Label for="description">Description</Label>
+        <Textarea
+          id="description"
+          rows={8}
+          placeholder="What needs doing? Markdown is supported."
+          bind:value={description}
+          class="resize-y"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Switch id="open" bind:checked={open} />
+        <Label for="open">{open ? 'Open' : 'Closed'}</Label>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <Button disabled={saving || !title.trim()} onclick={submit}>
+          {saving ? 'Creating…' : 'Create issue'}
+        </Button>
+        <a href="/" class={buttonVariants({ variant: 'outline' })}>Cancel</a>
+      </div>
+    </Card.Content>
+  </Card.Root>
+</div>

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -87,7 +87,10 @@ RUN node_dir="$(runuser -l codespace -c 'command -v node' | xargs dirname)" \
 # --- Seraphim agent helpers (post to the API; env injected per turn) ---------
 COPY seraphim-suggest /usr/local/bin/seraphim-suggest
 COPY seraphim-ask /usr/local/bin/seraphim-ask
-RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask
+COPY seraphim-comment /usr/local/bin/seraphim-comment
+COPY seraphim-state /usr/local/bin/seraphim-state
+RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
+    /usr/local/bin/seraphim-comment /usr/local/bin/seraphim-state
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/workspace/seraphim-comment
+++ b/workspace/seraphim-comment
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// seraphim-comment: the agent's way to post a comment on the current task's
+// ticket. The comment routes to wherever the ticket lives: GitHub for a GitHub
+// issue, or the internal database for an internal ticket (it is attributed to
+// the agent there). Use this for internal tickets, which have no `gh` to reach.
+//
+// Usage (text as an argument or on stdin):
+//   seraphim-comment "Implemented the change; tests pass."
+//   echo "..." | seraphim-comment
+
+const API_URL = process.env.SERAPHIM_API_URL
+const TASK_ID = process.env.SERAPHIM_TASK_ID
+
+function fail(message) {
+  console.error(`seraphim-comment: ${message}`)
+  process.exit(1)
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => (data += chunk))
+    process.stdin.on('end', () => resolve(data))
+  })
+}
+
+async function main() {
+  if (!API_URL || !TASK_ID) {
+    fail('SERAPHIM_API_URL and SERAPHIM_TASK_ID must be set (they are injected by the orchestrator)')
+  }
+
+  const body = (process.argv[2] ?? (await readStdin())).trim()
+  if (!body) {
+    fail('no comment text provided (pass it as an argument or on stdin)')
+  }
+
+  let response
+  try {
+    response = await fetch(`${API_URL}/api/v1/tasks/${TASK_ID}/comment`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ body, author: 'agent' })
+    })
+  } catch (error) {
+    fail(`could not reach the Seraphim API at ${API_URL}: ${error.message}`)
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    fail(`the API rejected the comment (HTTP ${response.status}): ${detail}`)
+  }
+
+  console.log('Comment posted to the task.')
+}
+
+main().catch((error) => fail(error.message))

--- a/workspace/seraphim-state
+++ b/workspace/seraphim-state
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// seraphim-state: the agent's way to open or close the current task's ticket.
+// Routes to wherever the ticket lives: GitHub for a GitHub issue, or the internal
+// database for an internal ticket. Use this for internal tickets, which have no
+// `gh` to reach.
+//
+// Usage:
+//   seraphim-state open
+//   seraphim-state closed
+
+const API_URL = process.env.SERAPHIM_API_URL
+const TASK_ID = process.env.SERAPHIM_TASK_ID
+
+function fail(message) {
+  console.error(`seraphim-state: ${message}`)
+  process.exit(1)
+}
+
+async function main() {
+  if (!API_URL || !TASK_ID) {
+    fail('SERAPHIM_API_URL and SERAPHIM_TASK_ID must be set (they are injected by the orchestrator)')
+  }
+
+  const state = String(process.argv[2] ?? '')
+    .trim()
+    .toLowerCase()
+  if (state !== 'open' && state !== 'closed') {
+    fail('usage: seraphim-state open|closed')
+  }
+
+  let response
+  try {
+    response = await fetch(`${API_URL}/api/v1/tasks/${TASK_ID}/issue/state`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ state })
+    })
+  } catch (error) {
+    fail(`could not reach the Seraphim API at ${API_URL}: ${error.message}`)
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    fail(`the API rejected the state change (HTTP ${response.status}): ${detail}`)
+  }
+
+  console.log(`Ticket marked ${state}.`)
+}
+
+main().catch((error) => fail(error.message))


### PR DESCRIPTION
Closes #70.

## What
A third ticket provider, **internal**, for tasks tracked only in Seraphim's database (no GitHub or Jira).

- **Create issue button** top-right of the navbar, linking to a dedicated page (`/issues/new`, not a modal) with Title, Description, and an Open/Closed toggle. Submitting creates the ticket and opens it.
- **Source-aware task endpoints.** `get_issue`, `set_issue_state`, and `add_comment` now branch on the task's source: for an internal ticket they serve a synthetic conversation thread built from our DB (the ticket body, its comments, and its open/closed state) instead of calling GitHub. So the existing GitHub-style conversation view renders internal tickets too, with graceful fallbacks (an initial-avatar and a plain author name where there's no GitHub account, and the GitHub-only sidebar/close-reasons hidden).
- **Comments** live in a new `internal_comments` table; the ticket id is a human-friendly sequence (`#42`). A `database` glyph marks the source on cards and the header.
- **Agent capability.** Two workspace helpers, `seraphim-comment` and `seraphim-state`, post through the same source-aware endpoints (comments from the agent are attributed to it). That is the requested "way for the agent to post comments and mark open/closed."

## Scope note (consistent with the Jira decision)
Auto-*coding* of internal tickets is intentionally not wired: `pick_next_todo` stays GitHub-only, because branch/PR work for a repo-less ticket is the same deferred non-GitHub execution model as Jira (#66). Internal tickets are fully user-managed on the board and comment/close-able by hand or by the agent via the helpers; auto-execution lands with that future work.

## Touched
- Migrations `0019` (add `internal` to the `source_kind` enum, in its own migration so the value can be referenced next) and `0020` (`internal_comments` table + ticket sequence + a uniqueness guard).
- `models.rs`/`queries.rs` (SourceKind variant, `InternalComment`, create/list/add queries), `http/tasks.rs` (source-aware handlers + `POST /tasks`), `http/mod.rs` (route).
- Frontend: `SourceKind`, `createInternalTask`, `SourceIcon`, navbar button, the create page, and `IssueView` rendering internal tickets.
- `workspace/seraphim-comment`, `workspace/seraphim-state`, `Dockerfile`.

## Migration-number note
This uses `0019`/`0020` (develop is at `0018`). Other in-flight PRs may also add migrations; whichever merges later may need a quick renumber. Flagging for the group merge.

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (clean), `cargo test` (48 passing).
- Frontend: `yarn check` (0 errors) and `yarn build`. The workspace image (which installs the new helpers) builds in the Docker CI job.