### PR TITLE
Add blocking tasks that serialize the queue (#125)

### DIFF
--- a/api/migrations/0021_task_blocking.sql
+++ b/api/migrations/0021_task_blocking.sql
@@ -1,0 +1,4 @@
+-- A "blocking" task serializes the queue: while it sits in In Progress (being
+-- worked or parked waiting for input), the agent pulls no new To Do work, so a
+-- task that depends on it finishing first is never started in parallel.
+ALTER TABLE tasks ADD COLUMN blocking BOOLEAN NOT NULL DEFAULT FALSE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -338,6 +338,9 @@ pub struct Task {
     /// Fix turns already spent on this task's failing CI (bounds retry thrash).
     pub ci_fix_attempts: i32,
     pub hold: bool,
+    /// When true, while this task is in progress the agent pulls no new work, so
+    /// dependent tasks wait until it finishes (queue serialization).
+    pub blocking: bool,
     /// The operator's private scratchpad for this task. Stored only here and
     /// never written back to the source ticket.
     pub notes: String,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -756,6 +756,30 @@ pub async fn set_task_hold(pool: &PgPool, id: Uuid, hold: bool) -> sqlx::Result<
     .await
 }
 
+/// Flags a task as blocking (or clears it). While a blocking task is in progress,
+/// the agent pulls no new work.
+pub async fn set_task_blocking(pool: &PgPool, id: Uuid, blocking: bool) -> sqlx::Result<Task> {
+    sqlx::query_as::<_, Task>(
+        "UPDATE tasks SET blocking = $2, updated_at = now() WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(blocking)
+    .fetch_one(pool)
+    .await
+}
+
+/// Whether any blocking task is currently in progress. A fresh task that
+/// finishes (success or failure) leaves `in_progress`, so a blocking task still
+/// sitting here is unfinished, being worked or parked waiting for input, and the
+/// agent must not start anything new.
+pub async fn has_active_blocking_task(pool: &PgPool) -> sqlx::Result<bool> {
+    sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM tasks WHERE blocking = TRUE AND board_column = 'in_progress')",
+    )
+    .fetch_one(pool)
+    .await
+}
+
 /// Saves the operator's private scratchpad for a task. Does not touch
 /// `updated_at`: notes are orthogonal to the task's lifecycle and saved often.
 pub async fn set_task_notes(pool: &PgPool, id: Uuid, notes: &str) -> sqlx::Result<()> {

--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -108,3 +108,20 @@ pub async fn set_hold(
     state.notify_board();
     Ok(Json(task))
 }
+
+#[derive(Debug, Deserialize)]
+pub struct BlockingRequest {
+    pub blocking: bool,
+}
+
+/// `POST /api/v1/tasks/:id/blocking` - mark a card blocking: while it is in
+/// progress, the agent starts no new work.
+pub async fn set_blocking(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<BlockingRequest>,
+) -> ApiResult<Json<Task>> {
+    let task = queries::set_task_blocking(&state.db, id, body.blocking).await?;
+    state.notify_board();
+    Ok(Json(task))
+}

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -66,6 +66,7 @@ pub fn router(state: AppState) -> Router {
         .route("/tasks/:id/stream", get(sse::task_stream))
         .route("/tasks/:id/move", post(board::move_task))
         .route("/tasks/:id/hold", post(board::set_hold))
+        .route("/tasks/:id/blocking", post(board::set_blocking))
         .route("/tasks/:id/notes", axum::routing::put(tasks::set_notes))
         .route("/agent/suggestions", post(suggestions::create))
         .route("/suggestions/:id/ack", post(suggestions::acknowledge))

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -280,8 +280,13 @@ async fn next_actionable_task(state: &AppState) -> Result<Option<(Task, WorkMode
     if let Some(task) = queries::pick_next_ci_fix(&state.db).await? {
         return Ok(Some((task, WorkMode::FixCi)));
     }
-    if let Some(task) = queries::pick_next_todo(&state.db).await? {
-        return Ok(Some((task, WorkMode::Fresh)));
+    // A blocking task in progress (being worked or parked waiting for input)
+    // serializes the queue: pull no new To Do work until it finishes. Resumes
+    // and CI fixes above continue existing in-flight work and are not gated.
+    if !queries::has_active_blocking_task(&state.db).await? {
+        if let Some(task) = queries::pick_next_todo(&state.db).await? {
+            return Ok(Some((task, WorkMode::Fresh)));
+        }
     }
     // Idle: circle back to a PR we gave up on and try once more (cooldown-gated).
     if let Some(task) =
@@ -1013,6 +1018,7 @@ mod tests {
             error: None,
             ci_fix_attempts: 0,
             hold: false,
+            blocking: false,
             notes: String::new(),
             session_id: None,
             started_at: None,

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -292,6 +292,7 @@ mod tests {
             error: None,
             ci_fix_attempts: 0,
             hold: false,
+            blocking: false,
             notes: String::new(),
             session_id: None,
             started_at: None,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,6 +78,11 @@ export function setTaskHold(taskId: string, hold: boolean) {
   return apiClient.post(`tasks/${taskId}/hold`, { json: { hold } }).json<Task>()
 }
 
+// Mark a task blocking: while it is in progress, the agent starts no new work.
+export function setTaskBlocking(taskId: string, blocking: boolean) {
+  return apiClient.post(`tasks/${taskId}/blocking`, { json: { blocking } }).json<Task>()
+}
+
 // Save the private per-task notepad. Stored only in our DB, never sent to the ticket.
 export function setTaskNotes(taskId: string, notes: string) {
   return apiClient.put(`tasks/${taskId}/notes`, { json: { notes } }).json<{ saved: boolean }>()

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -2,7 +2,7 @@
   import type { Task } from '../types'
 
   import { goto } from '$app/navigation'
-  import { Pause } from '@lucide/svelte'
+  import { Pause, Ban } from '@lucide/svelte'
 
   import { STATUS_BADGE, STATUS_LABELS, ticketStateBadge } from '../types'
   import { Badge } from './ui/badge'
@@ -37,12 +37,18 @@
   onclick={open}
   onkeydown={(event) => event.key === 'Enter' && open()}
   class="cursor-grab rounded-lg border bg-secondary p-3 transition-colors hover:border-primary {task.hold
-    ? 'border-dashed opacity-60'
-    : 'border-border'}"
+    ? 'border-dashed border-border opacity-60'
+    : task.blocking
+      ? 'border-warning'
+      : 'border-border'}"
 >
   <div class="flex items-center justify-between gap-2">
     <span class="flex min-w-0 items-center gap-1 text-xs tabular-nums text-muted-foreground">
       {#if task.hold}<Pause class="size-3 flex-none" aria-label="On hold" />{/if}
+      {#if task.blocking}<Ban
+          class="size-3 flex-none text-warning"
+          aria-label="Blocking: holds the queue until finished"
+        />{/if}
       <SourceIcon source={task.source_kind} class="size-3.5 flex-none" />
       {#if repoShort}<span class="truncate font-semibold text-primary" title={repoName}>{repoShort}</span>{/if}
       <span class="flex-none">{#if repoShort} · {/if}#{task.external_id}</span>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -104,6 +104,8 @@ export type Task = {
   error: string | null
   ci_fix_attempts: number
   hold: boolean
+  // While in progress, the agent pulls no new work until this task finishes.
+  blocking: boolean
   // The operator's private scratchpad; stored only here, never sent to the ticket.
   notes: string
   session_id: string | null

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -4,12 +4,13 @@
   import { onMount, onDestroy, tick } from 'svelte'
   import { toast } from 'svelte-sonner'
   import { page } from '$app/stores'
-  import { ChevronDown, NotebookPen, Pause, Play } from '@lucide/svelte'
+  import { Ban, ChevronDown, NotebookPen, Pause, Play } from '@lucide/svelte'
 
   import {
     acknowledgeSuggestion,
     answerQuestion,
     getTask,
+    setTaskBlocking,
     setTaskHold,
     setTaskNotes
   } from '$lib/api'
@@ -257,6 +258,21 @@
     toast.success(held ? 'Task held — the agent will skip it' : 'Hold released')
   }
 
+  // Blocking toggle: a quick, reversible flag, so no confirmation dialog.
+  async function toggleBlocking() {
+    if (!task) {
+      return
+    }
+    const blocking = !task.blocking
+    await setTaskBlocking(task.id, blocking)
+    await load()
+    toast.success(
+      blocking
+        ? 'Marked blocking — the agent starts nothing new while this is in progress'
+        : 'No longer blocking'
+    )
+  }
+
   // Human labels for the rate-limit window and status codes Claude emits.
   const RATE_LIMIT_WINDOWS: Record<string, string> = {
     five_hour: '5-hour limit',
@@ -496,6 +512,18 @@
               <Badge variant="outline" class={STATUS_BADGE[task.status]}>
                 {STATUS_LABELS[task.status] ?? task.status}
               </Badge>
+              <button
+                type="button"
+                onclick={toggleBlocking}
+                title="While in progress, the agent starts no new work until this task finishes"
+                class={buttonVariants({
+                  variant: task.blocking ? 'default' : 'outline',
+                  size: 'sm'
+                })}
+              >
+                <Ban class="size-3.5" />
+                {task.blocking ? 'Blocking' : 'Block'}
+              </button>
               <AlertDialog.Root>
                 <AlertDialog.Trigger class={buttonVariants({ variant: 'outline', size: 'sm' })}>
                   {#if task.hold}


### PR DESCRIPTION
Closes #125.

## What
A per-task **blocking** flag. While a blocking task is in progress, the agent starts no new work, so a task that depends on it finishing first (e.g. "search part 1" before "search part 2") is never worked in parallel.

- **Mark it from the UI**: the task page has a **Block / Blocking** toggle next to Hold. A blocking card shows an amber border and a `Ban` icon on the board.
- **The gate**: before pulling a fresh To Do task, the agent checks whether any blocking task is in the In Progress column. If so, it pulls nothing new until that task finishes.

## Why "in the In Progress column" is the right signal
A fresh task that finishes, whether it opens a PR (success) or fails, **leaves** In Progress (it moves to In Review). The only way a task stays in In Progress is being actively worked or parked `waiting_for_input`, both "not finished". So `blocking AND board_column = 'in_progress'` cleanly means "a blocking task is still unfinished", with no risk of a failed task deadlocking the queue.

The gate is applied only to the fresh-work pull (`pick_next_todo`). Resumes (delivering the user's answer to a parked task) and CI fixes are continuations of existing in-flight work, not new starts, so a blocking task that asks a question can still be answered and finished, lifting the gate.

## Touched
- Migration `0021_task_blocking.sql`; `Task.blocking` (+ sample literals); `set_task_blocking` and `has_active_blocking_task` queries; the guard in `next_actionable_task`; `POST /tasks/:id/blocking` handler + route.
- Frontend: `Task.blocking` type, `setTaskBlocking`, the card border/icon, and the task-page toggle.

## Migration-number note
Uses `0021` (develop is at `0020`). My open #74 PR also adds a `0021`; whichever merges later may need a quick renumber. Flagging for the group merge.

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (clean), `cargo test` (48 passing).
- Frontend: `yarn check` (0 errors) and `yarn build`.