### PR TITLE
Show the issue author's avatar on kanban cards (#68)

### DIFF
--- a/api/migrations/0022_issue_author.sql
+++ b/api/migrations/0022_issue_author.sql
@@ -1,0 +1,5 @@
+-- The login and avatar of whoever opened a synced GitHub issue, captured during
+-- sync so the kanban card can show their profile picture without a per-card API
+-- call. NULL for tasks with no known author (Jira/internal, or older rows).
+ALTER TABLE tasks ADD COLUMN author_login TEXT;
+ALTER TABLE tasks ADD COLUMN author_avatar_url TEXT;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -338,6 +338,10 @@ pub struct Task {
     pub title: String,
     pub body_snapshot: String,
     pub url: String,
+    /// The login and avatar URL of whoever opened the issue, shown on the board
+    /// card. `None` for tasks with no known author (Jira/internal).
+    pub author_login: Option<String>,
+    pub author_avatar_url: Option<String>,
     /// The source ticket's own state, distinct from the agent's `status`: for
     /// GitHub "open" / "closed", for Jira the workflow status name. `None` until
     /// a sync or state change records it.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -524,6 +524,7 @@ pub async fn get_task(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Task>> {
 /// Inserts a freshly-synced issue into `Available`, or refreshes the cached
 /// title/body/url of one we already track. Never touches the human-curated
 /// `board_column`, `position`, or `status`.
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert_issue_task(
     pool: &PgPool,
     source_kind: SourceKind,
@@ -533,16 +534,20 @@ pub async fn upsert_issue_task(
     body: &str,
     url: &str,
     external_state: &str,
+    author_login: &str,
+    author_avatar_url: &str,
     initial_position: f64,
 ) -> sqlx::Result<Task> {
     sqlx::query_as::<_, Task>(
-        "INSERT INTO tasks (source_kind, external_id, repo_id, title, body_snapshot, url, external_state, board_column, position) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, 'available', $8) \
+        "INSERT INTO tasks (source_kind, external_id, repo_id, title, body_snapshot, url, external_state, author_login, author_avatar_url, board_column, position) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'available', $10) \
          ON CONFLICT (repo_id, source_kind, external_id) DO UPDATE SET \
          title = EXCLUDED.title, \
          body_snapshot = EXCLUDED.body_snapshot, \
          url = EXCLUDED.url, \
          external_state = EXCLUDED.external_state, \
+         author_login = EXCLUDED.author_login, \
+         author_avatar_url = EXCLUDED.author_avatar_url, \
          updated_at = now() \
          RETURNING *",
     )
@@ -553,6 +558,8 @@ pub async fn upsert_issue_task(
     .bind(body)
     .bind(url)
     .bind(external_state)
+    .bind(author_login)
+    .bind(author_avatar_url)
     .bind(initial_position)
     .fetch_one(pool)
     .await

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -22,6 +22,9 @@ pub struct OpenIssue {
     pub title: String,
     pub body: String,
     pub url: String,
+    /// The login and avatar of whoever opened the issue, for the board card.
+    pub author_login: String,
+    pub author_avatar_url: String,
 }
 
 /// Lists open issues for a repo (excluding PRs), optionally label-filtered.
@@ -51,6 +54,8 @@ pub async fn list_open_issues(
             title: issue.title,
             body: issue.body.unwrap_or_default(),
             url: issue.html_url.to_string(),
+            author_login: issue.user.login,
+            author_avatar_url: issue.user.avatar_url.to_string(),
         })
         .collect())
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -173,6 +173,8 @@ pub async fn sync_once(state: &AppState) -> Result<()> {
                 &issue.url,
                 // Sync only ever lists open issues, so any issue we see here is open.
                 "open",
+                &issue.author_login,
+                &issue.author_avatar_url,
                 next_position,
             )
             .await?;
@@ -1014,6 +1016,8 @@ mod tests {
             title: String::new(),
             body_snapshot: String::new(),
             url: String::new(),
+            author_login: None,
+            author_avatar_url: None,
             external_state: None,
             board_column: TaskColumn::Todo,
             position: 0.0,

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -290,6 +290,8 @@ mod tests {
             title: "Ask the user for help".to_string(),
             body_snapshot: String::new(),
             url: String::new(),
+            author_login: None,
+            author_avatar_url: None,
             external_state: Some("open".to_string()),
             board_column: TaskColumn::InProgress,
             position: 0.0,

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -63,7 +63,18 @@
     </Badge>
   </div>
 
-  <div class="mt-2 text-sm leading-snug">{task.title}</div>
+  <div class="mt-2 flex items-start gap-2">
+    {#if task.author_avatar_url}
+      <img
+        src={task.author_avatar_url}
+        alt={task.author_login ?? 'issue author'}
+        title={task.author_login ? `Opened by ${task.author_login}` : 'Issue author'}
+        class="mt-0.5 size-5 flex-none rounded-full"
+        onerror={(event) => ((event.currentTarget as HTMLImageElement).style.display = 'none')}
+      />
+    {/if}
+    <div class="min-w-0 text-sm leading-snug">{task.title}</div>
+  </div>
 
   <!-- Loud on purpose: pulses until the user acknowledges the suggestions on the task. -->
   {#if suggestionCount > 0}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -93,6 +93,9 @@ export type Task = {
   title: string
   body_snapshot: string
   url: string
+  // The login and avatar URL of whoever opened the issue. Null when unknown.
+  author_login: string | null
+  author_avatar_url: string | null
   // The source ticket's own state, separate from the agent `status` below: for
   // GitHub "open"/"closed", for Jira the workflow status name. Null until known.
   external_state: string | null


### PR DESCRIPTION
Closes #68.

## What
Each kanban card now shows the profile picture of whoever opened the issue, next to the title, with an "Opened by `<login>`" tooltip.

## How
The avatar would be expensive to fetch per card, so it's captured once during sync: the GitHub issue list already carries the author (`issue.user.login` / `avatar_url`), so `list_open_issues` now returns them, and they're stored on the task (new `author_login` / `author_avatar_url` columns, migration `0022`). The board response already serializes the whole task, so the card just reads `task.author_avatar_url`.

- Existing GitHub cards pick up the avatar on the next sync (the upsert refreshes the author fields).
- Jira and internal tasks have no GitHub author, so they show no avatar (the columns are null).
- A broken avatar URL hides the image rather than showing a broken-image icon.

## Heads up: a pre-existing duplicate migration on develop
While working this I noticed develop currently has **two** migrations numbered `0021` (`0021_stats_reset.sql` from #74 and `0021_task_blocking.sql` from #125, both merged without renumbering). That's a duplicate sqlx version: CI doesn't catch it (the test job never runs migrations against a database), but a fresh API boot will fail when `sqlx::migrate!` hits the second version-21 with a different checksum. **This PR does not touch those files** (I numbered mine `0022` to avoid making it a three-way collision and to keep my change clean), but one of the `0021_*` files should be renumbered (e.g. to `0023`) in a follow-up. I left it for you rather than silently renumbering a merged migration, since that can surprise an already-applied database.

## Verification
- API: `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (clean), `cargo test` (48 passing).
- Frontend: `yarn check` (0 errors) and `yarn build`.