### PR TITLE
Re-run failed CI once in the review loop to absorb flakes

### DIFF
--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -226,6 +226,80 @@ pub async fn ci_status(octo: &Octocrab, owner: &str, repo: &str, sha: &str) -> R
 }
 
 #[derive(Debug, Deserialize)]
+struct WorkflowRunsPage {
+    workflow_runs: Vec<WorkflowRun>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowRun {
+    id: u64,
+    status: String,
+    conclusion: Option<String>,
+    run_attempt: u32,
+}
+
+/// Re-runs the failed jobs of any first-attempt workflow run at `head_sha`.
+///
+/// Gives a failed run exactly one automatic retry before an agent fix turn or a
+/// human is spent on it, absorbing transient infrastructure flakes (a runner
+/// hiccup, a base-image pull failure, a network blip). Idempotency is stateless:
+/// a run that was already retried sits at `run_attempt >= 2` and is skipped, so
+/// repeated review passes never re-run the same commit's CI more than once.
+///
+/// Only `failure`, `timed_out`, and `startup_failure` runs are retried; a
+/// `cancelled` run (e.g. one superseded by `cancel-in-progress`) is left alone.
+///
+/// Returns the number of runs whose failed jobs were re-queued; `0` means
+/// nothing was retried (no eligible failures, or each had already been retried).
+///
+/// # Errors
+/// If listing the commit's workflow runs fails. A failure to re-queue an
+/// individual run is logged and skipped rather than aborting the sweep.
+pub async fn rerun_failed_runs(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    head_sha: &str,
+) -> Result<u64> {
+    let page: WorkflowRunsPage = octo
+        .get(
+            format!("/repos/{owner}/{repo}/actions/runs?head_sha={head_sha}&per_page={PER_PAGE}"),
+            None::<&()>,
+        )
+        .await
+        .wrap_err("failed to list workflow runs for the commit")?;
+
+    let mut reran = 0_u64;
+    for run in &page.workflow_runs {
+        let retriable = run.status == "completed"
+            && matches!(
+                run.conclusion.as_deref(),
+                Some("failure" | "timed_out" | "startup_failure")
+            );
+        // Skip anything that already used its one automatic retry.
+        if !retriable || run.run_attempt > 1 {
+            continue;
+        }
+        match octo
+            .post::<(), serde_json::Value>(
+                format!(
+                    "/repos/{owner}/{repo}/actions/runs/{id}/rerun-failed-jobs",
+                    id = run.id
+                ),
+                None,
+            )
+            .await
+        {
+            Ok(_) => reran += 1,
+            Err(error) => {
+                tracing::warn!(error = %error, run_id = run.id, "failed to re-run a workflow run");
+            }
+        }
+    }
+    Ok(reran)
+}
+
+#[derive(Debug, Deserialize)]
 struct GitRef {
     object: GitRefObject,
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -825,6 +825,22 @@ async fn review_once(state: &AppState) -> Result<()> {
             // This applies regardless of review policy, so PRs are greened before
             // a human ever looks at them.
             git::CiStatus::Failing(checks) => {
+                // Absorb a transient infrastructure flake before spending an
+                // agent fix turn (or a human) on it: re-run a failed, first-
+                // attempt workflow once and judge the retry on a later tick. A
+                // run already retried sits at attempt >= 2, so this fires at most
+                // once per commit and then lets the real verdict through.
+                match git::rerun_failed_runs(&github, owner, repo_name, &pull.head_sha).await {
+                    Ok(reran) if reran > 0 => {
+                        info!(task_id = %task.id, reran, "re-ran failed CI once for a possible flake");
+                        continue;
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(error = %error, task_id = %task.id, "could not re-run CI; treating as failed");
+                    }
+                }
+
                 if task.ci_fix_attempts < MAX_CI_FIX_ATTEMPTS {
                     queries::set_task_status(&state.db, task.id, TaskStatus::CiFailing).await?;
                 } else {


### PR DESCRIPTION
## What

Follow-up to #128. Now that the agent no longer watches CI in-turn, the review loop owns the one piece of smarts the agent used to do inline: re-running a transient infrastructure flake.

`review_loop`, on a failing PR, now calls `git::rerun_failed_runs` once before treating the failure as real. If it re-queued anything, the task stays in review and the retry is judged on a later tick; otherwise the existing path runs (hand to the agent, or block after the cap).

## Stateless idempotency

No new column or in-memory state: GitHub already tracks `run_attempt` per workflow run. A run that was already retried sits at `run_attempt >= 2` and is skipped, so a given commit's CI is re-run at most once. Only `failure` / `timed_out` / `startup_failure` runs are retried; a `cancelled` run (superseded by `cancel-in-progress`) is left alone.

## Tradeoff

A genuinely broken first failure also gets one automatic retry (~2 min on the self-hosted runners) before the agent is engaged. That is the cost of catching flakes without log-parsing heuristics, and it is easy to narrow later (e.g. only the Docker job) if the extra cycles are not worth it.

Two files, no migration. Part of #108 (the `Closes #108` already lives on #128).
