### PR TITLE
Live token-usage counter during agent turns (#140)

### DIFF
--- a/api/src/claude/events.rs
+++ b/api/src/claude/events.rs
@@ -12,6 +12,11 @@
 //! - `{"type":"user","message":{content:[{type:"tool_result",...}]}}`
 //! - `{"type":"result","subtype":"success","result":...,"session_id":...,"total_cost_usd":...}`
 //! - `{"type":"rate_limit_event","rate_limit_info":{...},"session_id":...}`
+//!
+//! With `--include-partial-messages` Claude Code also emits a firehose of
+//! `stream_event` lines (the raw Messages-API streaming protocol). We mine only
+//! the live token usage from `message_start` / `message_delta` and drop the rest,
+//! so the partial stream feeds the live counter without bloating the event log.
 
 use serde_json::Value;
 
@@ -48,8 +53,73 @@ pub enum AgentEventKind {
     /// along in the event payload (`raw`) for the UI to render; we only classify
     /// the line here so it can be styled instead of dumped as raw JSON.
     RateLimit,
+    /// Live token usage from a partial-message stream event (opted in with
+    /// `--include-partial-messages`). `message_start` carries the prompt cost
+    /// (`input_tokens` + cache fields); `message_delta` carries the live, rising
+    /// `output_tokens` for the current message. Used only to tick the stats
+    /// gauges, never persisted to the event log. `input_tokens.is_some()` marks a
+    /// `message_start` (a new assistant message), which restarts the per-message
+    /// output count.
+    Usage {
+        input_tokens: Option<i64>,
+        output_tokens: Option<i64>,
+        cache_read_input_tokens: Option<i64>,
+        cache_creation_input_tokens: Option<i64>,
+    },
     /// Any other line, preserved as-is.
     Other,
+}
+
+/// Accumulates the turn-level live token usage from the partial-message stream.
+///
+/// `message_delta.usage.output_tokens` is cumulative *per assistant message* and
+/// restarts at each `message_start` (every tool round-trip is a new message), so
+/// a turn total must sum each completed message's output and add the current
+/// message's live value. Input/cache recur per round-trip, so the context size is
+/// the latest message's prompt, not a sum.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UsageTracker {
+    /// Finalized output of the assistant messages completed so far this turn.
+    output_base: i64,
+    /// The current message's live (monotonically rising) output count.
+    current_output: i64,
+    /// The current message's prompt size (input + cache reads + cache creation).
+    context: i64,
+}
+
+impl UsageTracker {
+    /// Folds one [`AgentEventKind::Usage`] event in, given its four token fields.
+    /// `input_tokens.is_some()` marks a `message_start` (a new assistant message).
+    pub fn apply(
+        &mut self,
+        input_tokens: Option<i64>,
+        output_tokens: Option<i64>,
+        cache_read_input_tokens: Option<i64>,
+        cache_creation_input_tokens: Option<i64>,
+    ) {
+        if input_tokens.is_some() {
+            // A new assistant message: bank the previous message's output and
+            // restart the per-message count and the prompt size.
+            self.output_base += self.current_output;
+            self.current_output = output_tokens.unwrap_or(0);
+            self.context = input_tokens.unwrap_or(0)
+                + cache_read_input_tokens.unwrap_or(0)
+                + cache_creation_input_tokens.unwrap_or(0);
+        } else if let Some(output) = output_tokens {
+            // A `message_delta`: the live output count for the current message.
+            self.current_output = output;
+        }
+    }
+
+    /// Turn-cumulative output tokens generated so far.
+    pub fn output_tokens(&self) -> i64 {
+        self.output_base + self.current_output
+    }
+
+    /// The current assistant message's prompt size, for the context gauge.
+    pub fn context_tokens(&self) -> i64 {
+        self.context
+    }
 }
 
 impl AgentEvent {
@@ -63,6 +133,7 @@ impl AgentEvent {
             AgentEventKind::ToolResult { .. } => "tool_result",
             AgentEventKind::Result { .. } => "result",
             AgentEventKind::RateLimit => "rate_limit",
+            AgentEventKind::Usage { .. } => "usage",
             AgentEventKind::Other => "other",
         }
     }
@@ -143,6 +214,20 @@ pub fn parse_line(line: &str) -> Vec<AgentEvent> {
             session_id,
             raw: value,
         }],
+        // Partial-message stream events (`--include-partial-messages`): a firehose
+        // wrapped as `stream_event`. We extract only the live token usage from
+        // `message_start` / `message_delta` and drop every other partial
+        // (`content_block_delta`, `ping`, `message_stop`, ...) so they never reach
+        // the event log or the live feed.
+        Some("stream_event") => {
+            let inner = value.get("event").cloned().unwrap_or(Value::Null);
+            parse_stream_event(&inner, session_id, value)
+        }
+        // Defensive: some Claude Code versions may surface the raw partial type at
+        // the top level rather than wrapped in `stream_event`.
+        Some("message_start" | "message_delta") => {
+            parse_stream_event(&value, session_id, value.clone())
+        }
         _ => vec![AgentEvent {
             kind: AgentEventKind::Other,
             session_id,
@@ -237,6 +322,48 @@ fn parse_user(value: &Value, session_id: Option<&str>) -> Vec<AgentEvent> {
         }
     }
     events
+}
+
+/// Extracts the live token usage from a partial-message stream event, dropping
+/// everything else. `message_start` carries the prompt cost on `message.usage`;
+/// `message_delta` carries the rising output count on `usage`.
+fn parse_stream_event(inner: &Value, session_id: Option<String>, raw: Value) -> Vec<AgentEvent> {
+    let usage = match inner.get("type").and_then(Value::as_str) {
+        Some("message_start") => inner.pointer("/message/usage"),
+        Some("message_delta") => inner.get("usage"),
+        // content_block_delta, content_block_start/stop, message_stop, ping, ...
+        _ => None,
+    };
+    usage_event(usage, session_id, raw)
+        .map(|event| vec![event])
+        .unwrap_or_default()
+}
+
+/// Builds a [`AgentEventKind::Usage`] event from a Messages-API `usage` object,
+/// or `None` when there is nothing countable to report.
+fn usage_event(
+    usage: Option<&Value>,
+    session_id: Option<String>,
+    raw: Value,
+) -> Option<AgentEvent> {
+    let usage = usage?;
+    let field = |key: &str| usage.get(key).and_then(Value::as_i64);
+    let input_tokens = field("input_tokens");
+    let output_tokens = field("output_tokens");
+    // A usage block with neither an input nor an output count carries no signal.
+    if input_tokens.is_none() && output_tokens.is_none() {
+        return None;
+    }
+    Some(AgentEvent {
+        kind: AgentEventKind::Usage {
+            input_tokens,
+            output_tokens,
+            cache_read_input_tokens: field("cache_read_input_tokens"),
+            cache_creation_input_tokens: field("cache_creation_input_tokens"),
+        },
+        session_id,
+        raw,
+    })
 }
 
 /// Tool-result content may be a bare string or an array of content blocks.
@@ -391,6 +518,89 @@ mod tests {
                 assert_eq!(result_text.as_deref(), Some("Not logged in"));
             }
             other => panic!("expected result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_start_partial_yields_input_and_cache_usage() {
+        // The prompt-cost snapshot at the start of an assistant message.
+        let line = r#"{"type":"stream_event","session_id":"s1","event":{"type":"message_start","message":{"usage":{"input_tokens":1325,"cache_read_input_tokens":40000,"cache_creation_input_tokens":12,"output_tokens":3}}}}"#;
+        let events = parse_line(line);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].type_label(), "usage");
+        assert_eq!(
+            events[0].kind,
+            AgentEventKind::Usage {
+                input_tokens: Some(1325),
+                output_tokens: Some(3),
+                cache_read_input_tokens: Some(40000),
+                cache_creation_input_tokens: Some(12),
+            }
+        );
+    }
+
+    #[test]
+    fn message_delta_partial_yields_live_output_only() {
+        // The live, rising output count mid-generation (the example from the issue).
+        let line = r#"{"type":"stream_event","session_id":"s1","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":128}}}"#;
+        let events = parse_line(line);
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].kind,
+            AgentEventKind::Usage {
+                input_tokens: None,
+                output_tokens: Some(128),
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+            }
+        );
+    }
+
+    #[test]
+    fn bare_top_level_partial_is_also_parsed() {
+        // Defensive path: a partial surfaced without the `stream_event` wrapper.
+        let line = r#"{"type":"message_delta","usage":{"output_tokens":7}}"#;
+        let events = parse_line(line);
+        assert_eq!(events.len(), 1);
+        match &events[0].kind {
+            AgentEventKind::Usage { output_tokens, .. } => assert_eq!(*output_tokens, Some(7)),
+            other => panic!("expected usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_tracker_accumulates_output_across_message_boundaries() {
+        let mut tracker = UsageTracker::default();
+
+        // First assistant message: prompt cost, then output rises to 40.
+        tracker.apply(Some(1000), Some(2), Some(30000), Some(0));
+        assert_eq!(tracker.context_tokens(), 31000);
+        tracker.apply(None, Some(12), None, None);
+        tracker.apply(None, Some(40), None, None);
+        assert_eq!(tracker.output_tokens(), 40);
+
+        // A tool round-trip starts a new message: output resets per message, but
+        // the turn total keeps the prior 40 and the context reflects the new
+        // (larger, re-sent) prompt.
+        tracker.apply(Some(1500), Some(1), Some(32000), Some(8));
+        assert_eq!(tracker.context_tokens(), 33508);
+        assert_eq!(tracker.output_tokens(), 41); // 40 banked + 1 initial
+        tracker.apply(None, Some(25), None, None);
+        assert_eq!(tracker.output_tokens(), 65); // 40 banked + 25 live
+    }
+
+    #[test]
+    fn other_partial_events_are_dropped() {
+        // The firehose (content deltas, pings, stops) must not reach the event log.
+        for line in [
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0}}"#,
+            r#"{"type":"stream_event","event":{"type":"message_stop"}}"#,
+            r#"{"type":"stream_event","event":{"type":"ping"}}"#,
+            // A message_delta with no usage block carries no countable signal.
+            r#"{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"}}}"#,
+        ] {
+            assert!(parse_line(line).is_empty(), "should drop: {line}");
         }
     }
 

--- a/api/src/claude/exec.rs
+++ b/api/src/claude/exec.rs
@@ -66,6 +66,10 @@ fn build_command(args: &TurnArgs) -> Vec<String> {
         "stream-json".to_string(),
         // stream-json with -p requires --verbose to emit the full event stream.
         "--verbose".to_string(),
+        // Opt into the raw Messages-API stream events so we get live, per-chunk
+        // token usage (`message_start` / `message_delta`) for the live counter,
+        // not just the coarse totals at message/turn boundaries.
+        "--include-partial-messages".to_string(),
         "--permission-mode".to_string(),
         "bypassPermissions".to_string(),
         "--model".to_string(),
@@ -167,6 +171,7 @@ mod tests {
         assert!(command.contains(&"sess-1".to_string()));
         assert!(command.contains(&"bypassPermissions".to_string()));
         assert!(command.contains(&"stream-json".to_string()));
+        assert!(command.contains(&"--include-partial-messages".to_string()));
     }
 
     #[test]

--- a/api/src/claude/mod.rs
+++ b/api/src/claude/mod.rs
@@ -4,5 +4,5 @@
 pub mod events;
 pub mod exec;
 
-pub use events::AgentEventKind;
+pub use events::{AgentEventKind, UsageTracker};
 pub use exec::{run_turn, TurnArgs};

--- a/api/src/http/sse.rs
+++ b/api/src/http/sse.rs
@@ -22,6 +22,11 @@ pub async fn board_stream(
                 Ok(ServerEvent::Board) => {
                     yield Ok(Event::default().event("board").data("{}"));
                 }
+                // A throttled nudge that the in-progress turn's usage advanced, so
+                // the global stats banner refetches and the counter ticks live.
+                Ok(ServerEvent::Usage { .. }) => {
+                    yield Ok(Event::default().event("usage").data("{}"));
+                }
                 Ok(ServerEvent::Task { .. } | ServerEvent::Notification { .. }) => {}
                 // A lagged consumer just resyncs; a closed channel ends the stream.
                 Err(RecvError::Lagged(_)) => continue,
@@ -55,7 +60,7 @@ pub async fn notification_stream(
                 Ok(ServerEvent::Board) => {
                     yield Ok(Event::default().event("refresh").data("{}"));
                 }
-                Ok(ServerEvent::Task { .. }) => {}
+                Ok(ServerEvent::Task { .. } | ServerEvent::Usage { .. }) => {}
                 Err(RecvError::Lagged(_)) => continue,
                 Err(RecvError::Closed) => break,
             }
@@ -76,6 +81,11 @@ pub async fn task_stream(
                 Ok(ServerEvent::Task { task_id, payload }) if task_id == id => {
                     let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
                     yield Ok(Event::default().event("task").data(data));
+                }
+                // A throttled tick that this task's live token usage advanced; the
+                // Stats panel refetches without the partials reaching the feed.
+                Ok(ServerEvent::Usage { task_id }) if task_id == id => {
+                    yield Ok(Event::default().event("usage").data("{}"));
                 }
                 Ok(_) => {}
                 Err(RecvError::Lagged(_)) => continue,

--- a/api/src/http/stats.rs
+++ b/api/src/http/stats.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use super::ApiResult;
 use crate::db::models::{Settings, StatsAggregate};
 use crate::db::queries;
-use crate::state::AppState;
+use crate::state::{AppState, LiveUsage};
 
 #[derive(Debug, Serialize)]
 pub struct StatsResponse {
@@ -83,16 +83,27 @@ fn build_response(
     running_since: Option<DateTime<Utc>>,
     latest_usage: Option<&Value>,
     rate_limit: Option<&Value>,
+    live_usage: Option<LiveUsage>,
 ) -> StatsResponse {
     let input_total = agg.input_tokens + agg.cache_creation_tokens + agg.cache_read_tokens;
-    let context = latest_usage.map_or(0, context_tokens);
     let (usage_utilization, usage_resets_at) = rate_limit.map_or((None, None), rate_limit_fields);
+
+    // Overlay the in-progress turn's live usage (if any) on top of the persisted,
+    // completed-turn totals so the counter ticks mid-turn. Only output is added to
+    // the totals (output is turn-cumulative); input recurs per round-trip, so the
+    // live input feeds only the context gauge, not the cumulative input total. The
+    // persisted `result` event remains the source of truth once the turn lands.
+    let live_output = live_usage.map_or(0, |usage| usage.output_tokens);
+    let context = live_usage
+        .map(|usage| usage.context_tokens)
+        .filter(|&tokens| tokens > 0)
+        .unwrap_or_else(|| latest_usage.map_or(0, context_tokens));
 
     StatsResponse {
         cost_usd: agg.cost_usd,
         input_tokens: input_total,
-        output_tokens: agg.output_tokens,
-        total_tokens: input_total + agg.output_tokens,
+        output_tokens: agg.output_tokens + live_output,
+        total_tokens: input_total + agg.output_tokens + live_output,
         worked_ms: agg.worked_ms,
         running_since,
         context_tokens: context,
@@ -116,6 +127,8 @@ pub async fn global(State(state): State<AppState>) -> ApiResult<Json<StatsRespon
         running_since,
         latest_usage.as_ref(),
         rate_limit.as_ref(),
+        // One shared agent, so any in-progress turn's live usage counts globally.
+        state.live_usage(),
     )))
 }
 
@@ -135,6 +148,8 @@ pub async fn task(
         running_since,
         latest_usage.as_ref(),
         rate_limit.as_ref(),
+        // Only overlay the live counter when the running turn is this task's.
+        state.live_usage().filter(|usage| usage.task_id == id),
     )))
 }
 

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -18,7 +18,7 @@ mod usage;
 
 pub use provision::provision_workspace;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use eyre::{eyre, Result};
@@ -65,6 +65,11 @@ const RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(8);
 /// transient rate limit is treated as a real failure and surfaced on the card.
 /// Bounds the wait at roughly `RATE_LIMIT_COOLDOWN * RATE_LIMIT_RETRY_MAX`.
 const RATE_LIMIT_RETRY_MAX: u32 = 5;
+/// Minimum spacing between live token-usage SSE ticks during a turn. The partial
+/// stream updates the in-memory counter on every chunk; this throttles only the
+/// "refetch the gauges" nudge so a smooth-but-not-flooding ~3 ticks/second reach
+/// the UI.
+const LIVE_USAGE_TICK: Duration = Duration::from_millis(350);
 
 /// What kind of work a pulled card needs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -681,6 +686,14 @@ async fn stream_turn(
     // collected for an optional summary comment on the source issue.
     let mut thoughts: Vec<String> = Vec::new();
 
+    // Live token usage from the partial-message stream: the in-memory counter is
+    // updated on every chunk, but the SSE tick that refetches the gauges is
+    // throttled to `LIVE_USAGE_TICK` so the UI stays smooth without flooding.
+    let mut usage = crate::claude::UsageTracker::default();
+    let mut last_usage_tick: Option<Instant> = None;
+    // A stale overlay from a prior turn would otherwise show until the first tick.
+    state.set_live_usage(None);
+
     while let Some(item) = stream.next().await {
         let event = match item {
             Ok(event) => event,
@@ -690,6 +703,35 @@ async fn stream_turn(
                 break;
             }
         };
+
+        // Live token usage from a partial-message event. This is a firehose, so it
+        // is never persisted or streamed verbatim: it only updates the in-memory
+        // live counter, with a throttled SSE tick to refetch the gauges.
+        if let AgentEventKind::Usage {
+            input_tokens,
+            output_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+        } = &event.kind
+        {
+            usage.apply(
+                *input_tokens,
+                *output_tokens,
+                *cache_read_input_tokens,
+                *cache_creation_input_tokens,
+            );
+            state.set_live_usage(Some(crate::state::LiveUsage {
+                task_id: task.id,
+                output_tokens: usage.output_tokens(),
+                context_tokens: usage.context_tokens(),
+            }));
+            let now = Instant::now();
+            if last_usage_tick.is_none_or(|last| now.duration_since(last) >= LIVE_USAGE_TICK) {
+                state.notify_usage(task.id);
+                last_usage_tick = Some(now);
+            }
+            continue;
+        }
 
         if let Some(found) = &event.session_id {
             session_id = Some(found.clone());
@@ -776,6 +818,11 @@ async fn stream_turn(
         session_id.as_deref(),
     )
     .await?;
+
+    // The turn's usage is now persisted (the source of truth). Drop the live
+    // overlay and tick once more so the gauges settle on the final total.
+    state.set_live_usage(None);
+    state.notify_usage(task.id);
 
     // Optionally summarize this turn's reasoning back onto the source issue.
     // Best-effort: a failure here never affects the task's own outcome.

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -35,6 +35,28 @@ pub enum ServerEvent {
         task_title: String,
         prompt: String,
     },
+    /// A throttled tick that the in-progress turn's token usage advanced, so the
+    /// stats gauges refetch and the counter ticks live mid-turn. Carries no
+    /// numbers; the live values live on [`AppState::live_usage`] and are read by
+    /// the stats endpoints, keeping one source of truth.
+    Usage { task_id: Uuid },
+}
+
+/// The token usage of the turn currently generating, surfaced so the stats
+/// gauges advance smoothly mid-turn instead of only at message/turn boundaries.
+/// It is a live UI affordance, not the billing record (the `result` event remains
+/// the source of truth for persisted cost/usage).
+#[derive(Debug, Clone, Copy)]
+pub struct LiveUsage {
+    /// The task whose turn is generating.
+    pub task_id: Uuid,
+    /// Turn-cumulative output tokens so far: the finalized output of completed
+    /// assistant messages this turn plus the current message's live count.
+    pub output_tokens: i64,
+    /// The current assistant message's prompt size (input + cache), for the
+    /// context gauge. Input recurs per round-trip, so this is the latest message's
+    /// value, not a turn sum.
+    pub context_tokens: i64,
 }
 
 /// Clonable, shared state handed to every request handler and background task.
@@ -50,6 +72,10 @@ pub struct AppState {
     /// current turn. Purely an ephemeral UI signal, so it lives in memory rather
     /// than the database; the board handler reads it into the settings payload.
     cooldown_until: Arc<RwLock<Option<DateTime<Utc>>>>,
+    /// Live token usage of the turn currently generating, or `None` between turns.
+    /// Ephemeral (like [`Self::cooldown_until`]); the stats endpoints overlay it on
+    /// the persisted totals so the counter ticks during generation.
+    live_usage: Arc<RwLock<Option<LiveUsage>>>,
 }
 
 impl AppState {
@@ -61,6 +87,7 @@ impl AppState {
             events,
             internal_api_url,
             cooldown_until: Arc::new(RwLock::new(None)),
+            live_usage: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -73,6 +100,18 @@ impl AppState {
     /// follow this with [`Self::notify_board`] so the navbar status updates live.
     pub fn set_cooldown_until(&self, until: Option<DateTime<Utc>>) {
         *self.cooldown_until.write().expect("cooldown lock poisoned") = until;
+    }
+
+    /// The live token usage of the in-progress turn, if one is generating.
+    pub fn live_usage(&self) -> Option<LiveUsage> {
+        *self.live_usage.read().expect("live usage lock poisoned")
+    }
+
+    /// Sets (or clears with `None`) the in-progress turn's live token usage.
+    /// Cheap and called often; pair with the throttled [`Self::notify_usage`] for
+    /// the SSE tick rather than emitting on every update.
+    pub fn set_live_usage(&self, usage: Option<LiveUsage>) {
+        *self.live_usage.write().expect("live usage lock poisoned") = usage;
     }
 
     /// Builds a GitHub client from the token stored in the database. Built on
@@ -107,6 +146,12 @@ impl AppState {
     /// Pushes an agent event onto a task's live stream.
     pub fn notify_task(&self, task_id: Uuid, payload: serde_json::Value) {
         let _ = self.events.send(ServerEvent::Task { task_id, payload });
+    }
+
+    /// Ticks the stats gauges that the in-progress turn's usage advanced. Throttled
+    /// by the caller; carries no numbers (clients refetch the stats endpoint).
+    pub fn notify_usage(&self, task_id: Uuid) {
+        let _ = self.events.send(ServerEvent::Usage { task_id });
     }
 
     /// Announces a new question so the UI can toast and notify the user.

--- a/frontend/src/lib/components/Stats.svelte
+++ b/frontend/src/lib/components/Stats.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   // Live agent statistics, shown per task (a `taskId` is given) or globally (the
-  // board banner). Polls the stats endpoint and ticks the time display every
-  // second so a running turn counts up live.
+  // board banner). Polls the stats endpoint as a baseline and ticks the time
+  // display every second; during a turn it also refetches on the throttled
+  // `usage` SSE tick, so the token counter ticks up live mid-generation instead
+  // of only at message/turn boundaries.
   import type { Stats } from '$lib/types'
 
   import { onMount, onDestroy } from 'svelte'
@@ -16,6 +18,7 @@
   let now = $state(Date.now())
   let poll: ReturnType<typeof setInterval> | null = null
   let ticker: ReturnType<typeof setInterval> | null = null
+  let usageStream: EventSource | null = null
 
   async function refresh() {
     try {
@@ -27,13 +30,22 @@
 
   onMount(() => {
     refresh()
+    // A slow baseline poll reconciles with the persisted totals; the live ticking
+    // comes from the SSE `usage` nudges below.
     poll = setInterval(refresh, 5000)
     ticker = setInterval(() => (now = Date.now()), 1000)
+
+    // The board stream carries global usage ticks; a task's stream carries its
+    // own. The server already throttles these, so refetching on each is smooth.
+    const streamUrl = taskId ? `/api/v1/tasks/${taskId}/stream` : '/api/v1/board/stream'
+    usageStream = new EventSource(streamUrl)
+    usageStream.addEventListener('usage', () => refresh())
   })
 
   onDestroy(() => {
     if (poll) clearInterval(poll)
     if (ticker) clearInterval(ticker)
+    usageStream?.close()
   })
 
   // Worked time counts up live: the persisted total plus the elapsed time of any


### PR DESCRIPTION
Closes #140.

## What
The stats gauges used to "freeze" mid-turn and only jump when a tool call completed, the turn ended, or a rate-limit notice arrived. This opts into Claude Code's partial-message stream so the output-token count ticks up live during generation.

## How (per the issue's plan)

**1. Opt in (`exec.rs`).** Added `--include-partial-messages` to the `claude -p` argv.

**2. Parse the new shapes (`events.rs`).** With that flag Claude Code emits a firehose of `stream_event` lines. The parser now mines only the token usage from `message_start` (input + cache) and `message_delta` (the live, rising `output_tokens`) into a typed `AgentEventKind::Usage`, and **drops every other partial** (`content_block_delta`, `ping`, `message_stop`, ...) so they never reach the event log or the live feed. A defensive path also handles the raw partial type surfacing without the `stream_event` wrapper, in case the schema drifts.

A small pure `UsageTracker` does the turn-level accumulation: `message_delta.usage.output_tokens` is cumulative *per assistant message* and restarts at each `message_start` (every tool round-trip is a new message), so the tracker banks each completed message's output and adds the current message's live value. It is unit-tested for the event shapes and for accumulation across a message boundary (a tool round-trip).

**3. Track + emit a throttled live total (`orchestrator/mod.rs`, `state.rs`).** `stream_turn` feeds `Usage` events into the tracker, stores the running total in an ephemeral `live_usage` on `AppState` (same pattern as `cooldown_until`), and pushes a **throttled** (350ms) `usage` SSE tick. Partial events are never persisted or streamed verbatim; the in-memory counter updates every chunk but the UI nudge is throttled to ~3/sec. When the turn's `result` lands (the source of truth), the overlay is cleared and one final tick settles the gauges on the persisted total.

**4. Surface it.** `sse.rs` emits a named `usage` event on the board and task streams; `stats.rs` overlays the in-progress turn's live usage on the persisted, completed-turn totals so both the SSE tick and the existing 5s poll show live numbers; `Stats.svelte` subscribes to the `usage` tick and refetches.

## Display decision (gotcha #2)
- **Output** tokens are turn-cumulative and **added** to the displayed totals (they sum cleanly and converge to the `result` event's output).
- **Input / cache** tokens recur per round-trip, so summing them turn-cumulatively would double-count the re-sent conversation. The live input therefore feeds **only the context gauge** (the current message's prompt size), not the cumulative input total. The authoritative per-turn input/cost stays from the `result` event.

## Acceptance criteria
- [x] `--include-partial-messages` added in `exec.rs`.
- [x] `events.rs` parses `message_start` / `message_delta` usage into a typed event, with unit tests for the shapes.
- [x] Live, ticking output count in the activity UI during generation (the `usage` SSE tick + the stats overlay), well before the turn ends and without a rate-limit notice.
- [x] Partial events are not individually persisted or streamed; the tick is throttled (350ms).
- [x] Turn-level total accumulates output across assistant-message boundaries (unit-tested via `UsageTracker`, including a tool round-trip).
- [x] Final cost/usage still comes from the `result` event; `rate_limit_event` handling is unchanged.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (55 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass. The end-to-end "see it tick in the browser" check needs a live Claude session (the agent path has no CI integration test, as elsewhere); the parsing, accumulation, and throttling logic are unit-tested.