### PR TITLE
Close the linked GitHub issue when a task auto-merges to done (#143)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,11 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    `SERAPHIM_TASK_ID` + `SERAPHIM_API_URL`. One task awaited to completion before
    the next (no overlap).
 3. **review** — watches every open PR's CI: green → squash-merge
-   (`auto_squash_merge` repos) → **Done**, else wait; red → hand back to the
-   agent, bounded by `MAX_CI_FIX_ATTEMPTS` (3) before parking it `ci_blocked` for
-   a human. A failed merge (e.g. base conflict) also parks it `ci_blocked` rather
+   (`auto_squash_merge` repos) → **Done** (and, for a GitHub-sourced task, closes
+   the linked issue with `state_reason: "completed"` when `close_issue_on_done` is
+   set, the default; best-effort), else wait; red → hand back to the agent,
+   bounded by `MAX_CI_FIX_ATTEMPTS` (3) before parking it `ci_blocked` for a
+   human. A failed merge (e.g. base conflict) also parks it `ci_blocked` rather
    than retrying forever.
 
 ## Ports & URLs

--- a/api/migrations/0026_close_issue_on_done.sql
+++ b/api/migrations/0026_close_issue_on_done.sql
@@ -1,0 +1,6 @@
+-- When a GitHub-sourced task auto-merges to Done, close its linked issue with
+-- state_reason "completed", so the Done column doesn't fill with issues still
+-- open on GitHub. The agent merges PRs into `develop`, so GitHub's own
+-- keyword-close (which fires only on the default branch) never triggers. On by
+-- default; operators who prefer keyword-on-main can turn it off.
+ALTER TABLE settings ADD COLUMN close_issue_on_done BOOLEAN NOT NULL DEFAULT TRUE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -193,6 +193,9 @@ pub struct Settings {
     pub usage_paused_until: Option<DateTime<Utc>>,
     /// Post a per-turn summary of the agent's reasoning back to the source issue.
     pub post_thoughts_enabled: bool,
+    /// Close the linked GitHub issue (`state_reason: "completed"`) when a task
+    /// auto-merges to Done. Off lets operators rely on GitHub's keyword-on-main.
+    pub close_issue_on_done: bool,
     /// Whether the Jira integration is turned on (a connection is configured).
     pub jira_enabled: bool,
     /// Cloud vs Server/Data Center, deciding auth scheme and REST version.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -33,6 +33,7 @@ const SETTINGS_COLUMNS: &str =
      availability_skip_dates, network_access_level, network_access_domains, \
      network_access_include_defaults, usage_limit_pause_enabled, \
      usage_limit_threshold, usage_paused_until, post_thoughts_enabled, \
+     close_issue_on_done, \
      jira_enabled, jira_deployment, jira_base_url, jira_email, \
      (jira_api_token <> '') AS jira_token_set, \
      (github_webhook_secret <> '') AS github_webhook_secret_set, \
@@ -75,6 +76,7 @@ pub async fn update_settings(
     jira_deployment: Option<JiraDeployment>,
     jira_base_url: Option<String>,
     jira_email: Option<String>,
+    close_issue_on_done: Option<bool>,
 ) -> sqlx::Result<Settings> {
     sqlx::query_as::<_, Settings>(&format!(
         "UPDATE settings SET \
@@ -101,6 +103,7 @@ pub async fn update_settings(
          jira_deployment = COALESCE($19, jira_deployment), \
          jira_base_url = COALESCE($20, jira_base_url), \
          jira_email = COALESCE($21, jira_email), \
+         close_issue_on_done = COALESCE($22, close_issue_on_done), \
          updated_at = now() \
          WHERE id = 1 \
          RETURNING {SETTINGS_COLUMNS}"
@@ -126,6 +129,7 @@ pub async fn update_settings(
     .bind(jira_deployment)
     .bind(jira_base_url)
     .bind(jira_email)
+    .bind(close_issue_on_done)
     .fetch_one(pool)
     .await
 }

--- a/api/src/http/data.rs
+++ b/api/src/http/data.rs
@@ -45,6 +45,9 @@ pub struct SettingsExport {
     pub usage_limit_threshold: i32,
     #[serde(default)]
     pub post_thoughts_enabled: bool,
+    // Matches the database default (TRUE) so older bundles keep closing issues.
+    #[serde(default = "default_true")]
+    pub close_issue_on_done: bool,
     // Jira connection (non-secret parts only; the API token is never exported,
     // like the Claude/GitHub tokens). Followed boards are machine-specific (they
     // reference repo ids), so they are not part of the bundle.
@@ -128,6 +131,7 @@ pub async fn export(State(state): State<AppState>) -> ApiResult<Json<ConfigBundl
             usage_limit_pause_enabled: settings.usage_limit_pause_enabled,
             usage_limit_threshold: settings.usage_limit_threshold,
             post_thoughts_enabled: settings.post_thoughts_enabled,
+            close_issue_on_done: settings.close_issue_on_done,
             jira_enabled: settings.jira_enabled,
             jira_deployment: settings.jira_deployment,
             jira_base_url: settings.jira_base_url,
@@ -183,6 +187,7 @@ pub async fn import(
         Some(settings.jira_deployment),
         Some(settings.jira_base_url),
         Some(settings.jira_email),
+        Some(settings.close_issue_on_done),
     )
     .await?;
 

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -52,6 +52,7 @@ pub struct UpdateSettingsRequest {
     pub usage_limit_pause_enabled: Option<bool>,
     pub usage_limit_threshold: Option<i32>,
     pub post_thoughts_enabled: Option<bool>,
+    pub close_issue_on_done: Option<bool>,
     pub jira_enabled: Option<bool>,
     pub jira_deployment: Option<JiraDeployment>,
     pub jira_base_url: Option<String>,
@@ -86,6 +87,7 @@ pub async fn update(
         body.jira_deployment,
         body.jira_base_url,
         body.jira_email,
+        body.close_issue_on_done,
     )
     .await?;
     state.notify_board();

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -570,6 +570,7 @@ mod tests {
             usage_limit_threshold: 80,
             usage_paused_until: None,
             post_thoughts_enabled: false,
+            close_issue_on_done: true,
             jira_enabled: true,
             jira_deployment: JiraDeployment::Cloud,
             jira_base_url: "https://acme.atlassian.net".to_string(),

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -100,6 +100,8 @@ async fn bootstrap_settings(db: &sqlx::PgPool, config: &Config) -> Result<()> {
             None,
             None,
             None,
+            // close_issue_on_done: settings-only, keeps its DB default.
+            None,
         )
         .await?;
     }

--- a/api/src/orchestrator/availability.rs
+++ b/api/src/orchestrator/availability.rs
@@ -110,6 +110,7 @@ mod tests {
             usage_limit_threshold: 80,
             usage_paused_until: None,
             post_thoughts_enabled: false,
+            close_issue_on_done: true,
             jira_enabled: false,
             jira_deployment: crate::db::models::JiraDeployment::Cloud,
             jira_base_url: String::new(),

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -907,6 +907,13 @@ async fn review_once(state: &AppState) -> Result<()> {
                         .await?;
                         state.notify_board();
                         info!(task_id = %task.id, "auto-merged and marked done");
+
+                        // Close the linked GitHub issue so Done doesn't leave it
+                        // open. The agent merges into `develop`, so GitHub's own
+                        // keyword-close (default-branch only) never fires. Best-
+                        // effort and idempotent: a failure (or an already-closed
+                        // issue) never affects the completed task.
+                        close_linked_issue(&github, &settings, &task, owner, repo_name).await;
                     }
                     // A merge can fail for reasons retrying won't fix (conflicts
                     // with the base, restricted merge settings). Record it and
@@ -928,6 +935,42 @@ async fn review_once(state: &AppState) -> Result<()> {
 }
 
 // --- Helpers -----------------------------------------------------------------
+
+/// Closes the GitHub issue a finished task came from, with
+/// `state_reason: "completed"`. Best-effort: only for GitHub-sourced tasks with a
+/// real issue number, gated by the `close_issue_on_done` setting, and any failure
+/// is logged and swallowed so it never affects the completed task. Closing an
+/// already-closed issue is harmless.
+async fn close_linked_issue(
+    github: &octocrab::Octocrab,
+    settings: &crate::db::models::Settings,
+    task: &Task,
+    owner: &str,
+    repo_name: &str,
+) {
+    if !settings.close_issue_on_done
+        || task.source_kind != SourceKind::Github
+        || task.external_id.trim().is_empty()
+    {
+        return;
+    }
+
+    match git::set_issue_state(
+        github,
+        owner,
+        repo_name,
+        &task.external_id,
+        "closed",
+        Some("completed"),
+    )
+    .await
+    {
+        Ok(_) => info!(task_id = %task.id, issue = %task.external_id, "closed the linked issue"),
+        Err(error) => {
+            warn!(error = %error, task_id = %task.id, "failed to close the linked issue");
+        }
+    }
+}
 
 /// Records a task failure: captures the message and surfaces it in `In Review`.
 async fn fail(state: &AppState, task: &Task, message: &str) -> Result<()> {

--- a/api/src/orchestrator/network.rs
+++ b/api/src/orchestrator/network.rs
@@ -253,6 +253,7 @@ mod tests {
             usage_limit_threshold: 80,
             usage_paused_until: None,
             post_thoughts_enabled: false,
+            close_issue_on_done: true,
             jira_enabled: false,
             jira_deployment: crate::db::models::JiraDeployment::Cloud,
             jira_base_url: String::new(),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -199,6 +199,7 @@ export type UpdateSettingsRequest = {
   usage_limit_pause_enabled?: boolean
   usage_limit_threshold?: number
   post_thoughts_enabled?: boolean
+  close_issue_on_done?: boolean
   jira_enabled?: boolean
   jira_deployment?: JiraDeployment
   jira_base_url?: string

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -162,6 +162,9 @@ export type Settings = {
   usage_paused_until: string | null
   // Post a per-turn summary of the agent's reasoning back to the source issue.
   post_thoughts_enabled: boolean
+  // Close the linked GitHub issue (state_reason "completed") when a task
+  // auto-merges to Done. On by default.
+  close_issue_on_done: boolean
   // Jira connection. Cloud uses email + API token; Server/DC uses a PAT.
   jira_enabled: boolean
   jira_deployment: JiraDeployment

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -119,6 +119,7 @@
   let networkSavedAt = $state<string | null>(null)
   let usageSavedAt = $state<string | null>(null)
   let thoughtsSavedAt = $state<string | null>(null)
+  let closeIssueSavedAt = $state<string | null>(null)
 
   // Order and copy mirror the claude.ai network-access selector.
   const NETWORK_LEVELS: { value: NetworkAccessLevel; title: string; description: string }[] = [
@@ -392,6 +393,14 @@
     }
     settings = await updateSettings({ post_thoughts_enabled: settings.post_thoughts_enabled })
     thoughtsSavedAt = new Date().toLocaleTimeString()
+  }
+
+  async function saveCloseIssue() {
+    if (!settings) {
+      return
+    }
+    settings = await updateSettings({ close_issue_on_done: settings.close_issue_on_done })
+    closeIssueSavedAt = new Date().toLocaleTimeString()
   }
 
   function addEnvRow() {
@@ -1020,6 +1029,22 @@
         <div class="flex items-center gap-3">
           <Button onclick={saveThoughts}>Save</Button>
           {#if thoughtsSavedAt}<span class="text-sm text-muted-foreground">Saved at {thoughtsSavedAt}</span>{/if}
+        </div>
+
+        <div class="border-t border-border pt-5">
+          <div class="flex items-center gap-2">
+            <Switch id="close-issue-on-done" bind:checked={settings.close_issue_on_done} />
+            <Label for="close-issue-on-done">Close the linked issue when a task auto-merges to done</Label>
+          </div>
+          <p class="mt-1.5 text-sm text-muted-foreground">
+            On by default. The agent merges into <code class="rounded bg-secondary px-1 py-0.5">develop</code>, so
+            GitHub's own keyword-close (which fires only on the default branch) never triggers. Turn this off
+            to rely on that instead.
+          </p>
+          <div class="mt-3 flex items-center gap-3">
+            <Button onclick={saveCloseIssue}>Save</Button>
+            {#if closeIssueSavedAt}<span class="text-sm text-muted-foreground">Saved at {closeIssueSavedAt}</span>{/if}
+          </div>
         </div>
       </Card.Content>
     </Card.Root>


### PR DESCRIPTION
Closes #143.

## Problem
A task's board column was fully decoupled from its GitHub issue's open/closed state, so the Done column filled with issues still open on GitHub. The agent merges every PR into `develop`, so GitHub's own `Closes #X` keyword (which fires only on the default branch) stays dormant.

## Change
In `review_once`, immediately after a successful auto-merge marks the task `Done`, close the linked issue with `state_reason: "completed"`, via the existing `git::set_issue_state`. The work is a small best-effort helper, `close_linked_issue`:

- **GitHub source only.** Skips internal-source tasks and any task without a real external issue number.
- **Best-effort.** A failure is logged as a warning and swallowed; it never fails or rolls back the completed task (mirrors `thoughts::post_turn_thoughts`).
- **Idempotent.** Closing an already-closed issue is a no-op on GitHub.
- **Gated by a setting.** New `close_issue_on_done` flag, default `TRUE` (migration `0026`), so the stricter human-review deployment (MooreslabAI) can turn it off and keep relying on keyword-on-main. Wired through the model, `SETTINGS_COLUMNS`/`update_settings`, the settings request handler, config import/export, and a toggle on the Settings "Issue updates" page.

## Out of scope (per the issue)
Whether dragging a card to Done in the UI should also close the issue is a separate decision; this PR covers only the automatic completion path. The manual `POST /tasks/:id/issue/state` button is unchanged.

## Acceptance criteria
- [x] GitHub-sourced task auto-merges → Done → linked issue closed with `state_reason: "completed"`.
- [x] Failure to close logs a warning and does not affect the task outcome.
- [x] Internal-source tasks and tasks without an external issue are skipped.
- [x] Closing is idempotent.
- [x] Gated behind a settings flag defaulting to enabled.
- [x] No regression to the manual `POST /tasks/:id/issue/state` button.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (53 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass. The live close-on-merge path needs a real GitHub merge to observe end to end (the review loop has no CI integration test, as elsewhere in the repo); the guards (source/empty-id/flag) and wiring are exercised by the build and the existing settings tests.