### PR TITLE
Reflect external issue state changes onto the board (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,14 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    upsert the instant an issue changes, authenticated by a per-provider shared
    secret on the settings row (GitHub HMAC-signs the body; Jira signs or carries
    `?secret=`). Both poll and webhook share `orchestrator::upsert_{github,jira}_issue`.
+   Sync also **reflects external state changes** onto the board: a GitHub issue
+   closed outside Seraphim moves its card to **Done**, a reopened one back to
+   **Available**, and a Jira status change moves the card to its newly mapped
+   column. This fires only on a genuine transition (via `queries::apply_external_
+   state`, guarded by `external_state IS DISTINCT FROM`), so steady-state syncs
+   never clobber human curation, and a card the agent is mid-work on
+   (`in_progress`) is left alone. The poll also pulls recently-closed issues
+   (`git::list_recently_closed_issues`) since the open list can't reveal a closure.
 2. **agent** — single-threaded: when not paused, the config repo is healthy, and
    inside the availability schedule, it picks work by priority — (a) **resume** a
    task whose question the user just answered (`waiting_for_input` → deliver the

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -765,6 +765,67 @@ pub async fn min_position_in_column(
         .await
 }
 
+/// Reflects an external state change onto the board: when a tracked issue's
+/// source state actually changes (e.g. a human closes or reopens it on
+/// GitHub/Jira), record the new state and move the card to `target_column` at
+/// `target_position`, applying the same fresh-start resets `move_task` /
+/// `finish_task` do for that column.
+///
+/// Update-only (never inserts), so a closed issue we don't track creates nothing.
+/// Idempotent: the `external_state IS DISTINCT FROM` guard makes this a no-op
+/// unless the state genuinely transitioned, so steady-state syncs never clobber a
+/// human-curated column. A card the agent is actively working (`in_progress`) is
+/// left untouched so the move doesn't fight the agent loop; the next sync (once it
+/// leaves `in_progress`) reconciles it. Pass `repo_id = None` to match on
+/// `external_id` alone (Jira keys are globally unique; GitHub numbers need the
+/// repo). Returns whether a row changed.
+pub async fn apply_external_state(
+    pool: &PgPool,
+    source_kind: SourceKind,
+    repo_id: Option<Uuid>,
+    external_id: &str,
+    external_state: &str,
+    target_column: TaskColumn,
+    target_position: f64,
+) -> sqlx::Result<bool> {
+    let result = sqlx::query(
+        "UPDATE tasks SET \
+         external_state = $4, \
+         board_column = $5, \
+         position = CASE WHEN board_column IS DISTINCT FROM $5 THEN $6 ELSE position END, \
+         status = CASE \
+             WHEN board_column IS NOT DISTINCT FROM $5 THEN status \
+             WHEN $5 IN ('available'::task_column, 'todo'::task_column) THEN 'queued'::task_status \
+             WHEN $5 = 'done'::task_column THEN 'done'::task_status \
+             ELSE status END, \
+         error = CASE WHEN board_column IS DISTINCT FROM $5 \
+                      AND $5 IN ('available'::task_column, 'todo'::task_column) \
+                      THEN NULL ELSE error END, \
+         ci_fix_attempts = CASE WHEN board_column IS DISTINCT FROM $5 \
+                                AND $5 IN ('available'::task_column, 'todo'::task_column) \
+                                THEN 0 ELSE ci_fix_attempts END, \
+         finished_at = CASE WHEN board_column IS DISTINCT FROM $5 AND $5 = 'done'::task_column \
+                            THEN now() ELSE finished_at END, \
+         stats_reset_at = CASE WHEN board_column IS DISTINCT FROM $5 \
+                               AND $5 IN ('available'::task_column, 'todo'::task_column) \
+                               THEN now() ELSE stats_reset_at END, \
+         updated_at = now() \
+         WHERE source_kind = $1 AND external_id = $3 \
+         AND ($2::uuid IS NULL OR repo_id IS NOT DISTINCT FROM $2::uuid) \
+         AND external_state IS DISTINCT FROM $4 \
+         AND board_column <> 'in_progress'::task_column",
+    )
+    .bind(source_kind)
+    .bind(repo_id)
+    .bind(external_id)
+    .bind(external_state)
+    .bind(target_column)
+    .bind(target_position)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
 /// Refreshes the source-ticket state (e.g. `open` -> `closed`) of an already
 /// tracked issue, identified the way sync dedupes it. Returns whether a row
 /// changed; never inserts, so a webhook for an untracked issue is a no-op.

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -60,6 +60,39 @@ pub async fn list_open_issues(
         .collect())
 }
 
+/// The numbers of recently-updated closed issues (excluding PRs), most-recent
+/// first, optionally label-filtered. One page is enough to catch issues closed
+/// outside Seraphim since the last poll, so the board can move them to Done.
+pub async fn list_recently_closed_issues(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    labels: &[String],
+) -> Result<Vec<u64>> {
+    let handler = octo.issues(owner, repo);
+    let mut request = handler
+        .list()
+        .state(State::Closed)
+        .sort(octocrab::params::issues::Sort::Updated)
+        .direction(octocrab::params::Direction::Descending)
+        .per_page(PER_PAGE);
+    if !labels.is_empty() {
+        request = request.labels(labels);
+    }
+
+    let page = request
+        .send()
+        .await
+        .wrap_err_with(|| format!("failed to list closed issues for {owner}/{repo}"))?;
+
+    Ok(page
+        .items
+        .into_iter()
+        .filter(|issue| issue.pull_request.is_none())
+        .map(|issue| issue.number)
+        .collect())
+}
+
 /// A repo discovered when importing an org.
 #[derive(Debug, Clone)]
 pub struct DiscoveredRepo {

--- a/api/src/http/webhooks.rs
+++ b/api/src/http/webhooks.rs
@@ -116,9 +116,16 @@ async fn apply_github_event(state: &AppState, event: GithubIssueEvent) -> Result
             author_login: event.issue.user.login,
             author_avatar_url: event.issue.user.avatar_url,
         };
+        // upsert_github_issue also reflects a reopen (closed -> open) by returning
+        // the card to Available.
         orchestrator::upsert_github_issue(state, repo.id, &issue, "open").await?;
         Ok(true)
+    } else if event.issue.state == "closed" {
+        // Closed outside Seraphim: move the tracked card to Done.
+        Ok(orchestrator::reflect_closed_github_issue(state, repo.id, &external_id).await?)
     } else {
+        // Open but filtered out by the repo's labels: keep the cached state
+        // current without moving a card we may not even track.
         Ok(queries::refresh_issue_external_state(
             &state.db,
             SourceKind::Github,

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -168,6 +168,22 @@ pub async fn sync_once(state: &AppState) -> Result<()> {
             upsert_github_issue(state, repo.id, &issue, "open").await?;
             changed = true;
         }
+
+        // The open list above can't reveal an issue closed outside Seraphim (it
+        // simply drops out), so reconcile recently-closed issues separately and
+        // move any we still track to Done.
+        match git::list_recently_closed_issues(&github, owner, name, &repo.issue_labels).await {
+            Ok(numbers) => {
+                for number in numbers {
+                    if reflect_closed_github_issue(state, repo.id, &number.to_string()).await? {
+                        changed = true;
+                    }
+                }
+            }
+            Err(error) => {
+                warn!(error = %error, repo = %repo.full_name, "failed to list closed issues");
+            }
+        }
     }
 
     // Jira: pull tickets from each followed board, mapping the Jira status to one
@@ -214,11 +230,28 @@ pub async fn upsert_github_issue(
     issue: &git::OpenIssue,
     external_state: &str,
 ) -> Result<()> {
+    let external_id = issue.number.to_string();
     let position = top_of_column_position(state, TaskColumn::Available).await?;
+
+    // Reflect an external reopen (the issue flipped back to open) by returning the
+    // card to Available, *before* the upsert refreshes the cached state. Update-
+    // only and a no-op unless the state actually changed, so it never disturbs a
+    // steady open issue or its human-curated column.
+    queries::apply_external_state(
+        &state.db,
+        SourceKind::Github,
+        Some(repo_id),
+        &external_id,
+        external_state,
+        TaskColumn::Available,
+        position,
+    )
+    .await?;
+
     queries::upsert_issue_task(
         &state.db,
         SourceKind::Github,
-        &issue.number.to_string(),
+        &external_id,
         Some(repo_id),
         &issue.title,
         &issue.body,
@@ -232,6 +265,28 @@ pub async fn upsert_github_issue(
     Ok(())
 }
 
+/// Reflects an issue closed outside Seraphim by moving its tracked task to Done.
+/// Update-only and idempotent (see [`queries::apply_external_state`]); does
+/// nothing for an issue we don't track. Returns whether the board changed.
+pub async fn reflect_closed_github_issue(
+    state: &AppState,
+    repo_id: uuid::Uuid,
+    external_id: &str,
+) -> Result<bool> {
+    let position = top_of_column_position(state, TaskColumn::Done).await?;
+    queries::apply_external_state(
+        &state.db,
+        SourceKind::Github,
+        Some(repo_id),
+        external_id,
+        "closed",
+        TaskColumn::Done,
+        position,
+    )
+    .await
+    .map_err(Into::into)
+}
+
 /// Upserts a Jira ticket as a task, placing a brand-new one at the top of the
 /// column its mapped status implies. Shared by the poll sync and the webhook.
 pub async fn upsert_jira_issue(
@@ -241,6 +296,22 @@ pub async fn upsert_jira_issue(
 ) -> Result<()> {
     let column = crate::jira::column_for_status(&board.status_map.0, &issue.status);
     let position = top_of_column_position(state, column).await?;
+
+    // Reflect an external Jira status change by moving the card to the column its
+    // new status maps to, before the upsert refreshes the cached status. Jira keys
+    // are globally unique, so match on the key alone (repo_id = None). Update-only
+    // and a no-op unless the status actually changed.
+    queries::apply_external_state(
+        &state.db,
+        SourceKind::Jira,
+        None,
+        &issue.key,
+        &issue.status,
+        column,
+        position,
+    )
+    .await?;
+
     // A ticket can target several repos; the first is the primary one the agent
     // would branch in (multi-repo execution is a follow-up).
     let primary_repo = board.repo_ids.0.first().copied();


### PR DESCRIPTION
Closes #114.

## What
When a ticket is updated outside Seraphim, the board now follows it:

- **GitHub closed elsewhere** -> the card moves to **Done**.
- **GitHub reopened elsewhere** -> the card returns to **Available**.
- **Jira status changed elsewhere** -> the card moves to the column its new status maps to (the board's existing status->column map, i.e. "the relevant + important Jira mapping").

## How
A single atomic, update-only query, `queries::apply_external_state`, performs the move. Key properties:

- **Transition-gated.** It runs only when the stored `external_state` actually differs from the incoming one (`external_state IS DISTINCT FROM` guard), so a steady-state sync never clobbers a human-curated column. (The board's curation guarantee is preserved; only a genuine external change moves a card.)
- **Right resets.** Moving to Available/To Do re-queues the card (status `queued`, clears error / CI counter, stamps the stats reset) exactly like `move_task`; moving to Done marks it done with `finished_at`, like `finish_task`.
- **Does not fight the agent.** A card the agent is mid-work on (`in_progress`) is left untouched; the next sync reconciles it once it leaves `in_progress`.
- **Never invents cards.** Update-only, so an issue we don't track (e.g. a closed issue that was never on the board) creates nothing.
- **Idempotent**, so it composes cleanly with #143 (close-on-done): the resulting closed webhook is a no-op move.

Both the poll and the realtime webhook reuse it:

- **Poll sync** (`sync_once`): open issues reflect reopens through the shared `upsert_github_issue`; a new `git::list_recently_closed_issues` pass moves issues closed outside Seraphim to Done (the open-issues list can't reveal a closure, since a closed issue simply drops out). Jira sync reflects status changes through `upsert_jira_issue`.
- **Webhooks** (`http/webhooks.rs`): the GitHub `closed` event moves the card to Done and `reopened`/`opened` returns it to Available; the Jira webhook reflects status changes through the same upsert path.

## Scope
Backend only. The board already reflects the column moves live over the existing board SSE (`notify_board`), so no frontend change is needed. The manual open/close button in the issue panel is unchanged.

## Acceptance criteria
- [x] GitHub close (external) -> Done.
- [x] GitHub reopen (external) -> Available.
- [x] Jira status change (external) -> mapped column.
- [x] Works via both poll and webhook; idempotent; never clobbers human curation on steady-state syncs; never creates cards for untracked issues.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (58 passed). The state-transition logic lives in SQL + sync wiring, which (like the rest of the sync/agent path) needs a live DB + GitHub/Jira to exercise end to end; there is no CI integration harness for it in this repo.