### PR TITLE
Per-column kanban sorting with a cycling sort button (#117)

### DIFF
--- a/frontend/src/lib/columnSort.ts
+++ b/frontend/src/lib/columnSort.ts
@@ -1,0 +1,110 @@
+// Per-column kanban sorting: the sort levels, the cycle order the column header
+// button steps through, the comparators, and session persistence. Shared by the
+// board page and the `ColumnSort` button so both agree on the levels.
+import type { Task } from './types'
+
+export type SortKey =
+  | 'custom'
+  | 'id_asc'
+  | 'id_desc'
+  | 'created_asc'
+  | 'created_desc'
+  | 'updated_asc'
+  | 'updated_desc'
+
+// The order the button cycles through, looping back to the start. Left-click
+// steps forward, right-click steps backward.
+export const SORT_CYCLE: SortKey[] = [
+  'custom',
+  'id_asc',
+  'id_desc',
+  'created_asc',
+  'created_desc',
+  'updated_asc',
+  'updated_desc'
+]
+
+export type SortDirection = 'asc' | 'desc' | null
+
+// What the button shows: a short word and the direction (rendered as an arrow).
+// "custom" reads as "Auto" and carries no direction.
+export const SORT_META: Record<SortKey, { label: string; direction: SortDirection }> = {
+  custom: { label: 'Auto', direction: null },
+  id_asc: { label: 'Id', direction: 'asc' },
+  id_desc: { label: 'Id', direction: 'desc' },
+  created_asc: { label: 'Created', direction: 'asc' },
+  created_desc: { label: 'Created', direction: 'desc' },
+  updated_asc: { label: 'Updated', direction: 'asc' },
+  updated_desc: { label: 'Updated', direction: 'desc' }
+}
+
+export function nextSort(key: SortKey): SortKey {
+  const index = SORT_CYCLE.indexOf(key)
+  return SORT_CYCLE[(index + 1) % SORT_CYCLE.length]
+}
+
+export function prevSort(key: SortKey): SortKey {
+  const index = SORT_CYCLE.indexOf(key)
+  return SORT_CYCLE[(index - 1 + SORT_CYCLE.length) % SORT_CYCLE.length]
+}
+
+// External ids are ticket numbers ("42") or keys ("PROJ-123"); compare them
+// naturally so 2 < 10 and "PROJ-2" < "PROJ-10".
+function compareId(a: Task, b: Task): number {
+  return a.external_id.localeCompare(b.external_id, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+function compareDate(a: string, b: string): number {
+  return new Date(a).getTime() - new Date(b).getTime()
+}
+
+// Returns a new array sorted per `key`. "custom" restores the board's manual
+// order (ascending by fractional position). `Array.sort` is stable, so equal
+// keys keep their relative order.
+export function sortTasks(tasks: Task[], key: SortKey): Task[] {
+  const sorted = [...tasks]
+  switch (key) {
+    case 'custom':
+      sorted.sort((a, b) => a.position - b.position)
+      break
+    case 'id_asc':
+      sorted.sort((a, b) => compareId(a, b))
+      break
+    case 'id_desc':
+      sorted.sort((a, b) => compareId(b, a))
+      break
+    case 'created_asc':
+      sorted.sort((a, b) => compareDate(a.created_at, b.created_at))
+      break
+    case 'created_desc':
+      sorted.sort((a, b) => compareDate(b.created_at, a.created_at))
+      break
+    case 'updated_asc':
+      sorted.sort((a, b) => compareDate(a.updated_at, b.updated_at))
+      break
+    case 'updated_desc':
+      sorted.sort((a, b) => compareDate(b.updated_at, a.updated_at))
+      break
+  }
+  return sorted
+}
+
+// --- Session persistence -----------------------------------------------------
+// One entry per column, so a chosen sort survives a refresh (per the issue) but
+// not a new tab/session.
+const STORAGE_PREFIX = 'seraphim.columnSort.'
+
+export function loadSort(columnKey: string): SortKey {
+  if (typeof sessionStorage === 'undefined') {
+    return 'custom'
+  }
+  const stored = sessionStorage.getItem(STORAGE_PREFIX + columnKey)
+  return stored && (SORT_CYCLE as string[]).includes(stored) ? (stored as SortKey) : 'custom'
+}
+
+export function saveSort(columnKey: string, key: SortKey): void {
+  if (typeof sessionStorage === 'undefined') {
+    return
+  }
+  sessionStorage.setItem(STORAGE_PREFIX + columnKey, key)
+}

--- a/frontend/src/lib/components/ColumnSort.svelte
+++ b/frontend/src/lib/components/ColumnSort.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  // A very tiny per-column sort control for the kanban header. Left-click cycles
+  // the sort level forward, right-click cycles backward, and a press-and-hold
+  // opens a dropdown to pick a level directly. The label reads "Auto" / "Id" /
+  // "Created" / "Updated" with an arrow for direction, and the button is tinted
+  // when a real sort (not Auto) is active.
+  import { ArrowUp, ArrowDown, ArrowDownUp } from '@lucide/svelte'
+
+  import { SORT_CYCLE, SORT_META, nextSort, prevSort, type SortKey } from '$lib/columnSort'
+
+  let {
+    value,
+    onchange,
+    label = ''
+  }: {
+    value: SortKey
+    onchange: (next: SortKey) => void
+    label?: string
+  } = $props()
+
+  // How long the primary button must be held before the picker opens instead of
+  // the click cycling.
+  const LONG_PRESS_MS = 450
+
+  let menuOpen = $state(false)
+  let wrapper = $state<HTMLDivElement>()
+  let pressTimer: ReturnType<typeof setTimeout> | null = null
+  // Set when a hold opens the picker, so the trailing click doesn't also cycle.
+  let longPressed = false
+
+  const meta = $derived(SORT_META[value])
+  const active = $derived(value !== 'custom')
+
+  const tooltip = $derived(
+    `Sort: ${meta.label}${meta.direction ? ` ${meta.direction}` : ''}. ` +
+      'Click to cycle, right-click to reverse, hold to choose.'
+  )
+
+  function onClick() {
+    if (longPressed) {
+      longPressed = false
+      return
+    }
+    onchange(nextSort(value))
+  }
+
+  function onContextMenu(event: MouseEvent) {
+    // Right-click reverses the cycle instead of opening the native menu.
+    event.preventDefault()
+    onchange(prevSort(value))
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    // Only the primary button arms the hold-to-open; right-click is handled above.
+    if (event.button !== 0) {
+      return
+    }
+    longPressed = false
+    pressTimer = setTimeout(() => {
+      longPressed = true
+      menuOpen = true
+    }, LONG_PRESS_MS)
+  }
+
+  function clearPress() {
+    if (pressTimer) {
+      clearTimeout(pressTimer)
+      pressTimer = null
+    }
+  }
+
+  function pick(next: SortKey) {
+    onchange(next)
+    menuOpen = false
+  }
+
+  function onWindowPointerDown(event: MouseEvent) {
+    if (menuOpen && wrapper && !wrapper.contains(event.target as Node)) {
+      menuOpen = false
+    }
+  }
+
+  function onWindowKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      menuOpen = false
+    }
+  }
+</script>
+
+<svelte:window onpointerdown={onWindowPointerDown} onkeydown={onWindowKeydown} />
+
+<div bind:this={wrapper} class="relative">
+  <button
+    type="button"
+    onclick={onClick}
+    oncontextmenu={onContextMenu}
+    onpointerdown={onPointerDown}
+    onpointerup={clearPress}
+    onpointerleave={clearPress}
+    title={tooltip}
+    aria-label={`Sort ${label}`}
+    aria-haspopup="menu"
+    aria-expanded={menuOpen}
+    class="inline-flex select-none items-center gap-0.5 rounded px-1 py-0.5 text-[10px] font-semibold normal-case leading-none transition-colors {active
+      ? 'bg-primary/15 text-primary hover:bg-primary/25'
+      : 'text-muted-foreground hover:bg-secondary hover:text-foreground'}"
+  >
+    {meta.label}
+    {#if meta.direction === 'asc'}
+      <ArrowUp class="size-3" />
+    {:else if meta.direction === 'desc'}
+      <ArrowDown class="size-3" />
+    {:else}
+      <ArrowDownUp class="size-3 opacity-60" />
+    {/if}
+  </button>
+
+  {#if menuOpen}
+    <div
+      role="menu"
+      aria-label={`Sort ${label}`}
+      class="absolute right-0 top-full z-50 mt-1 min-w-[9rem] overflow-hidden rounded-md border border-border bg-card py-1 text-xs font-normal normal-case shadow-lg"
+    >
+      {#each SORT_CYCLE as option (option)}
+        <button
+          type="button"
+          role="menuitemradio"
+          aria-checked={option === value}
+          onclick={() => pick(option)}
+          class="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-secondary {option ===
+          value
+            ? 'font-medium text-primary'
+            : 'text-foreground'}"
+        >
+          <span>{SORT_META[option].label}</span>
+          {#if SORT_META[option].direction === 'asc'}
+            <ArrowUp class="size-3" />
+          {:else if SORT_META[option].direction === 'desc'}
+            <ArrowDown class="size-3" />
+          {/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,7 +19,9 @@
     syncNow
   } from '$lib/api'
   import { isWithinSchedule } from '$lib/schedule'
+  import { type SortKey, sortTasks, loadSort, saveSort } from '$lib/columnSort'
   import Card from '$lib/components/Card.svelte'
+  import ColumnSort from '$lib/components/ColumnSort.svelte'
   import Stats from '$lib/components/Stats.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Textarea } from '$lib/components/ui/textarea'
@@ -43,6 +45,26 @@
   let eventSource: EventSource | null = null
   // Maps a task's repo_id to its full name, so each card can show its source repo.
   let repoNames = $state<Record<string, string>>({})
+
+  // Per-column sort level (default "custom" = the board's manual order). Hydrated
+  // from session storage on mount; the header sort button changes it.
+  let sortState = $state<Record<TaskColumn, SortKey>>({
+    available: 'custom',
+    todo: 'custom',
+    in_progress: 'custom',
+    in_review: 'custom',
+    done: 'custom',
+    ignored: 'custom'
+  })
+
+  // Re-sorts a column when its sort level changes, and persists the choice. The
+  // sort is applied imperatively (here and in `load`), never reactively, so it
+  // never fights svelte-dnd-action mid-drag.
+  function changeSort(column: TaskColumn, next: SortKey) {
+    sortState[column] = next
+    saveSort(column, next)
+    columns[column] = sortTasks(columns[column], next)
+  }
 
   // The Done column hides older items by default so it doesn't grow without
   // bound: only tasks finished today are shown until the user reveals the rest
@@ -122,7 +144,10 @@
       grouped[task.board_column].push(task)
     }
     for (const key of Object.keys(grouped) as TaskColumn[]) {
+      // Base order is the manual (position) order; then apply the column's sort
+      // on top (a no-op for "custom").
       grouped[key].sort((left, right) => left.position - right.position)
+      grouped[key] = sortTasks(grouped[key], sortState[key])
     }
     columns = grouped
   }
@@ -204,6 +229,10 @@
   }
 
   onMount(() => {
+    // Hydrate each column's saved sort before the first load so it applies at once.
+    for (const column of COLUMNS) {
+      sortState[column.key] = loadSort(column.key)
+    }
     load()
     // The notepad loads once, separately from the board: the board stream below
     // reloads on every change, which must never clobber an in-progress edit.
@@ -336,7 +365,14 @@
               </button>
             {/if}
           </div>
-          <span>{collapsed ? doneTodayCount : columns[column.key].length}</span>
+          <div class="flex items-center gap-1.5">
+            <ColumnSort
+              value={sortState[column.key]}
+              onchange={(next) => changeSort(column.key, next)}
+              label={column.label}
+            />
+            <span>{collapsed ? doneTodayCount : columns[column.key].length}</span>
+          </div>
         </header>
         <div
           class="flex min-h-[120px] flex-1 flex-col gap-2 overflow-y-auto rounded-b-lg p-3"


### PR DESCRIPTION
Closes #117.

## What
Every kanban column header gains a very tiny sort button on the title row, just to the left of the task count. It sorts that column independently.

**Levels & cycle order** (loops):
`Auto` (custom) → `Id` asc → `Id` desc → `Created` asc → `Created` desc → `Updated` asc → `Updated` desc → back to `Auto`.

**Interactions:**
- **Left-click** cycles forward.
- **Right-click** cycles backward (suppresses the native context menu).
- **Press-and-hold** (~450ms) opens a dropdown to pick a level directly.

**Appearance:**
- Shows the word `Auto` / `Id` / `Created` / `Updated` with an up/down arrow icon for direction (a faint neutral icon for Auto).
- Tinted in the primary color whenever a real sort (anything but Auto) is active, so it's obvious the column isn't in its default order.

**Persistence:** each column's choice is saved in `sessionStorage`, so it survives a refresh (but not a new session), per the issue.

## How
- `frontend/src/lib/columnSort.ts` (new): the `SortKey` levels, the `SORT_CYCLE` order, labels/direction metadata, the comparators (`Id` compares external ids naturally so `2 < 10` and `PROJ-2 < PROJ-10`; created/updated by timestamp; `custom` restores the manual fractional-position order), and the session load/save helpers.
- `frontend/src/lib/components/ColumnSort.svelte` (new): the self-contained tiny button + hold-to-open picker, with the cycle / reverse / long-press handling.
- `frontend/src/routes/+page.svelte`: per-column sort state hydrated from session on mount, the button placed in each header, and the sort applied in `load()` and on change.

### Drag-and-drop safety
The sort is applied **imperatively** (only in `load()` and when the level changes), never reactively, so it never re-orders the array `svelte-dnd-action` is mutating mid-drag (which would desync the drag model, as seen with the Done-column filter). "custom" restores the manual position order; a non-custom sort simply re-applies on the next board reload, so dragging between columns still works and dragging within a sorted column just re-sorts.

## Scope
Frontend-only; no backend/API changes (sorting uses fields already on the task).

## Verification
`yarn check` (0 errors, 0 warnings) and `yarn build` pass.