### PR TITLE
Show our prompt to Claude in the activity log (#136)

### DIFF
--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -739,6 +739,16 @@ async fn stream_turn(
     // persisted or streamed, so a secret the agent echoes never leaks.
     let scrubber = Scrubber::new(queries::list_secret_values(&state.db).await?);
 
+    // Record the exact brief we hand Claude as the first event of the turn, so the
+    // activity log shows our own instructions (secrets scrubbed) right alongside
+    // the agent's response, for full transparency.
+    let prompt_event = serde_json::json!({ "text": scrubber.scrub_text(&prompt) });
+    queries::append_event(&state.db, turn.id, 0, "prompt", prompt_event.clone()).await?;
+    state.notify_task(
+        task.id,
+        serde_json::json!({ "type": "prompt", "payload": prompt_event, "created_at": Utc::now() }),
+    );
+
     let args = TurnArgs {
         container: state.workspace.container().to_string(),
         working_dir,
@@ -770,7 +780,8 @@ async fn stream_turn(
         .await;
 
     let mut stream = Box::pin(run_turn(state.workspace.docker(), args));
-    let mut seq = 0_i32;
+    // seq 0 is the prompt event recorded above; the stream's events follow.
+    let mut seq = 1_i32;
     let mut session_id = settings.current_session_id.clone();
     let mut result_text: Option<String> = None;
     let mut total_cost: Option<f64> = None;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -35,6 +35,9 @@
   /* A poppy cyan for informational log markers (e.g. rate-limit notices). */
   --info: #22d3ee;
   --info-foreground: #0b1020;
+  /* A violet reserved for our own prompts to the agent in the activity log. */
+  --prompt: #a78bfa;
+  --prompt-foreground: #0b1020;
 
   /* Legacy variables kept so any not-yet-migrated style still resolves. */
   --bg: var(--background);
@@ -75,6 +78,8 @@
   --color-warning-foreground: var(--warning-foreground);
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
+  --color-prompt: var(--prompt);
+  --color-prompt-foreground: var(--prompt-foreground);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -143,6 +143,7 @@
   // Leading glyph per event type, modeled on Claude Code's transcript: a filled
   // dot for the agent's own actions, a corner connector for their output.
   const MARKERS = {
+    prompt: '●',
     assistant_text: '●',
     tool_use: '●',
     result: '●',
@@ -153,6 +154,7 @@
   } as const satisfies Record<string, string>
 
   const MARKER_COLORS = {
+    prompt: 'text-prompt',
     assistant_text: 'text-foreground',
     tool_use: 'text-primary',
     result: 'text-success',
@@ -352,6 +354,9 @@
 
   function describe(event: StreamEvent): string {
     const payload = event.payload as Record<string, unknown>
+    if (event.type === 'prompt') {
+      return String(payload?.text ?? '')
+    }
     if (event.type === 'thinking') {
       return String(payload?.thinking ?? '')
     }
@@ -593,6 +598,25 @@
                       <DiffView lines={diff.lines} added={diff.added} removed={diff.removed} />
                     </div>
                   </div>
+                {:else if event.type === 'prompt'}
+                  <!-- Our own brief to the agent: a violet dot + light wash, with
+                       up to ~3 lines shown until clicked open, for transparency. -->
+                  <button
+                    type="button"
+                    onclick={() => toggle(index)}
+                    title={open ? 'Click to collapse' : 'Click to expand'}
+                    class="my-0.5 flex w-full gap-2 rounded-md border border-prompt/30 bg-prompt/5 px-2 py-1.5 text-left transition-colors hover:bg-prompt/10"
+                  >
+                    <span class="w-[1ch] flex-none text-prompt">●</span>
+                    <span class="min-w-0 flex-1">
+                      <span class="mb-0.5 block text-[10px] font-semibold uppercase tracking-wide text-prompt">
+                        Seraphim prompt
+                      </span>
+                      <span
+                        class="block whitespace-pre-wrap break-words text-foreground/90 {open ? '' : 'line-clamp-3'}"
+                      >{describe(event)}</span>
+                    </span>
+                  </button>
                 {:else if collapsible}
                   <button
                     type="button"


### PR DESCRIPTION
Closes #136.

## What
When Seraphim tells Claude Code what to do, that brief now appears in the task's activity log, so the feed shows exactly what we asked for alongside the agent's response.

## How
- **Backend** (`orchestrator/mod.rs`): at the start of every turn, the prompt we send is recorded as the turn's first event (`type: "prompt"`, seq 0) and streamed live like any other event. Secrets are scrubbed out first (same `Scrubber` used for all persisted/streamed output), so nothing sensitive leaks. This covers every brief: fresh work, CI-fix, revisit, and resume.
- **Frontend** (`task/[id]/+page.svelte`, `app.css`): the prompt event gets its own treatment per the issue:
  - its **own color dot** and a **light color background highlight** (a new `--prompt` violet theme token), plus a small "Seraphim prompt" label so it's unmistakable;
  - **collapsible**: shows ~3 lines by default (`line-clamp-3`) and expands to the full text on click, like the other collapsible log entries.

The prompt text is rendered raw (whitespace preserved), so you see precisely what was sent.

## Scope
No DB schema change (`events.type` is a free-text label); no API surface change. The new event flows through the existing persist + SSE path, so it shows both live and on reload.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (58 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass.