### PR TITLE
Add a full-screen live "watch" page for the agent (#137)

### DIFF
--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -60,6 +60,7 @@ pub fn router(state: AppState) -> Router {
         .route("/ping", get(|| async { Json(json!({ "status": "ok" })) }))
         .route("/board", get(board::get_board))
         .route("/board/stream", get(sse::board_stream))
+        .route("/activity/stream", get(sse::activity_stream))
         .route("/tasks", post(tasks::create))
         .route("/tasks/:id", get(tasks::get_task))
         .route("/tasks/:id/issue", get(tasks::get_issue))

--- a/api/src/http/sse.rs
+++ b/api/src/http/sse.rs
@@ -69,6 +69,30 @@ pub async fn notification_stream(
     Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
+/// `GET /api/v1/activity/stream` - the live agent event feed across *every* task,
+/// each line tagged with its `task_id`. Powers the full-screen watch page's
+/// combined activity view.
+pub async fn activity_stream(
+    State(state): State<AppState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut receiver = state.events.subscribe();
+    let stream = async_stream::stream! {
+        loop {
+            match receiver.recv().await {
+                Ok(ServerEvent::Task { task_id, payload }) => {
+                    let envelope = serde_json::json!({ "task_id": task_id, "event": payload });
+                    let data = serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string());
+                    yield Ok(Event::default().event("activity").data(data));
+                }
+                Ok(_) => {}
+                Err(RecvError::Lagged(_)) => continue,
+                Err(RecvError::Closed) => break,
+            }
+        }
+    };
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
 /// `GET /api/v1/tasks/:id/stream` - the live agent event feed for one task.
 pub async fn task_stream(
     State(state): State<AppState>,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -18,9 +18,14 @@
 
   const links = [
     { href: '/', label: 'Board' },
+    { href: '/watch', label: 'Watch' },
     { href: '/repos', label: 'Repositories' },
     { href: '/settings', label: 'Settings' }
   ]
+
+  // The watch page is a full-screen, kiosk-style monitor: it owns the whole
+  // viewport, so the app chrome (navbar) gets out of its way.
+  const fullscreen = $derived($page.url.pathname === '/watch')
 
   // The board (settings + tasks) drives the navbar status. The board SSE stream
   // ticks on every change (including pause/resume), keeping the badge live.
@@ -93,6 +98,11 @@
   onDestroy(() => eventSource?.close())
 </script>
 
+{#if fullscreen}
+  <main class="h-screen w-screen overflow-hidden">
+    {@render children()}
+  </main>
+{:else}
 <div class="flex h-screen flex-col">
   <header class="flex items-center gap-4 border-b border-border bg-card px-6 py-3">
     <a href="/" class="flex items-center gap-2 text-lg font-bold tracking-tight text-foreground">
@@ -152,5 +162,6 @@
     {@render children()}
   </main>
 </div>
+{/if}
 
 <Toaster theme="dark" richColors />

--- a/frontend/src/routes/watch/+page.svelte
+++ b/frontend/src/routes/watch/+page.svelte
@@ -1,0 +1,486 @@
+<script lang="ts">
+  // The "watch" page: a full-screen, kiosk-style monitor of the whole agent.
+  // Stats bar on top; a big remaining count, a huge live ring for the task being
+  // worked, and a big completed count in the middle; and a combined live activity
+  // feed across every task along the bottom. Built to be left running on a TV.
+  import type { BoardResponse, Task, TaskStatus } from '$lib/types'
+
+  import { onMount, onDestroy, tick } from 'svelte'
+  import { Tween } from 'svelte/motion'
+  import { cubicOut } from 'svelte/easing'
+  import { fly } from 'svelte/transition'
+
+  import { getBoard } from '$lib/api'
+  import { STATUS_LABELS } from '$lib/types'
+  import { isWithinSchedule } from '$lib/schedule'
+  import Stats from '$lib/components/Stats.svelte'
+
+  let board = $state<BoardResponse | null>(null)
+  let boardStream: EventSource | null = null
+  let activityStream: EventSource | null = null
+  let now = $state(Date.now())
+  let clock: ReturnType<typeof setInterval> | null = null
+
+  // The rolling activity feed: one entry per meaningful agent action, newest last.
+  type FeedEntry = {
+    id: number
+    taskId: string
+    type: string
+    text: string
+    at: number
+  }
+  let feed = $state<FeedEntry[]>([])
+  let feedSeq = 0
+  const MAX_FEED = 60
+  let feedEl = $state<HTMLDivElement>()
+
+  const tasks = $derived(board?.tasks ?? [])
+  const titleById = $derived(new Map(tasks.map((task) => [task.id, task.title])))
+
+  // Remaining = everything still in the pipeline (backlog through review);
+  // completed = the Done lane. Ignored tasks count as neither.
+  const remainingCount = $derived(
+    tasks.filter((task) =>
+      ['available', 'todo', 'in_progress', 'in_review'].includes(task.board_column)
+    ).length
+  )
+  const completedCount = $derived(tasks.filter((task) => task.board_column === 'done').length)
+  const inReviewCount = $derived(tasks.filter((task) => task.board_column === 'in_review').length)
+  const queuedCount = $derived(tasks.filter((task) => task.board_column === 'todo').length)
+  const trackedCount = $derived(remainingCount + completedCount)
+  const completionPct = $derived(trackedCount ? (completedCount / trackedCount) * 100 : 0)
+
+  // Smoothly animate the big numbers when they change.
+  const remainingShown = new Tween(0, { duration: 800, easing: cubicOut })
+  const completedShown = new Tween(0, { duration: 800, easing: cubicOut })
+  $effect(() => {
+    remainingShown.target = remainingCount
+  })
+  $effect(() => {
+    completedShown.target = completedCount
+  })
+
+  // The single task the agent is actively working (single-threaded), if any.
+  const WORKING_STATUSES: TaskStatus[] = ['preparing', 'working', 'opening_pr', 'merging']
+  const current = $derived(
+    tasks.find(
+      (task) => task.board_column === 'in_progress' || WORKING_STATUSES.includes(task.status)
+    ) ?? null
+  )
+
+  // Overall agent state, mirroring the navbar's logic, used to theme the page.
+  type StateKey = 'working' | 'paused' | 'halted' | 'cooldown' | 'offhours' | 'idle'
+  const agentState = $derived.by<{ key: StateKey; label: string }>(() => {
+    const settings = board?.settings
+    if (!settings) return { key: 'idle', label: 'Connecting' }
+    if (settings.agent_paused) return { key: 'paused', label: 'Paused' }
+    if (settings.config_repo_url && settings.config_repo_error)
+      return { key: 'halted', label: 'Halted' }
+    if (settings.cooldown_until && new Date(settings.cooldown_until) > new Date(now))
+      return { key: 'cooldown', label: 'Cooling down' }
+    if (current) return { key: 'working', label: 'Working' }
+    if (settings.availability_enabled && !isWithinSchedule(settings, new Date(now)))
+      return { key: 'offhours', label: 'Off hours' }
+    return { key: 'idle', label: 'Idle' }
+  })
+
+  // Accent color per state: green when working, amber/red when stopped, calm blue
+  // when idle. Drives the ring, the aura, and the status glow.
+  const ACCENTS: Record<StateKey, string> = {
+    working: '#3fb950',
+    paused: '#d29922',
+    halted: '#f85149',
+    cooldown: '#d29922',
+    offhours: '#8b97a6',
+    idle: '#6e8bff'
+  }
+  const accent = $derived(ACCENTS[agentState.key])
+  const isWorking = $derived(agentState.key === 'working')
+
+  // --- Activity feed wiring ---------------------------------------------------
+
+  // Only the "pure agentic" signals make the cut; tool results and infra noise
+  // are dropped so the feed reads like a clean session transcript.
+  const GLYPHS: Record<string, { glyph: string; color: string }> = {
+    prompt: { glyph: '◆', color: 'text-prompt' },
+    thinking: { glyph: '✻', color: 'text-warning' },
+    assistant_text: { glyph: '▸', color: 'text-foreground' },
+    tool_use: { glyph: '⚙', color: 'text-primary' },
+    result: { glyph: '✓', color: 'text-success' },
+    rate_limit: { glyph: '◷', color: 'text-info' }
+  }
+
+  function firstLine(text: unknown, max = 120): string {
+    const line = String(text ?? '')
+      .split('\n')
+      .map((part) => part.trim())
+      .find((part) => part.length > 0)
+    if (!line) return ''
+    return line.length > max ? `${line.slice(0, max - 1)}…` : line
+  }
+
+  function toolLine(payload: Record<string, unknown>): string {
+    const name = String(payload?.name ?? 'tool')
+    const input = (payload?.input ?? {}) as Record<string, unknown>
+    const arg =
+      input.path ?? input.file_path ?? input.command ?? input.pattern ?? input.url ?? input.description
+    return arg ? `${name} · ${firstLine(arg, 64)}` : name
+  }
+
+  // Turns one streamed event into a feed line, or null to drop it.
+  function summarize(type: string, payload: Record<string, unknown>): string | null {
+    switch (type) {
+      case 'prompt':
+        return 'new briefing'
+      case 'thinking':
+        return firstLine(payload?.thinking) || 'thinking…'
+      case 'assistant_text':
+        return firstLine(payload?.text)
+      case 'tool_use':
+        return toolLine(payload)
+      case 'result':
+        return 'turn complete'
+      case 'rate_limit':
+        return 'rate-limit notice'
+      default:
+        return null
+    }
+  }
+
+  async function pushFeed(taskId: string, type: string, payload: Record<string, unknown>, at: number) {
+    const text = summarize(type, payload)
+    if (!text) return
+    const entry: FeedEntry = { id: feedSeq++, taskId, type, text, at }
+    feed = [...feed, entry].slice(-MAX_FEED)
+    // Keep the newest line in view (terminal-style autoscroll).
+    await tick()
+    feedEl?.scrollTo({ top: feedEl.scrollHeight, behavior: 'smooth' })
+  }
+
+  // A stable hue per task, so each task's lines share a recognizable color.
+  function taskHue(taskId: string): number {
+    let hash = 0
+    for (let i = 0; i < taskId.length; i++) {
+      hash = (hash * 31 + taskId.charCodeAt(i)) % 360
+    }
+    return hash
+  }
+
+  function taskLabel(taskId: string): string {
+    const title = titleById.get(taskId)
+    if (!title) return 'task'
+    return title.length > 28 ? `${title.slice(0, 27)}…` : title
+  }
+
+  function clockLabel(at: number): string {
+    return new Date(at).toLocaleTimeString([], { hour12: false })
+  }
+
+  async function loadBoard() {
+    try {
+      board = await getBoard()
+    } catch {
+      // Transient; the next stream tick retries.
+    }
+  }
+
+  onMount(() => {
+    loadBoard()
+    clock = setInterval(() => (now = Date.now()), 1000)
+
+    boardStream = new EventSource('/api/v1/board/stream')
+    boardStream.addEventListener('board', () => loadBoard())
+
+    activityStream = new EventSource('/api/v1/activity/stream')
+    activityStream.addEventListener('activity', (message) => {
+      try {
+        const data = JSON.parse((message as MessageEvent).data) as {
+          task_id: string
+          event: { type: string; payload: Record<string, unknown>; created_at?: string }
+        }
+        const at = data.event.created_at ? new Date(data.event.created_at).getTime() : Date.now()
+        void pushFeed(data.task_id, data.event.type, data.event.payload ?? {}, at)
+      } catch {
+        // Ignore malformed frames.
+      }
+    })
+  })
+
+  onDestroy(() => {
+    if (clock) clearInterval(clock)
+    boardStream?.close()
+    activityStream?.close()
+  })
+</script>
+
+<div class="watch relative h-full w-full overflow-hidden bg-[#070a12] text-foreground" style="--accent: {accent}">
+  <!-- Drifting aura + grid give the static page some life. -->
+  <div class="aura aura-1" aria-hidden="true"></div>
+  <div class="aura aura-2" aria-hidden="true"></div>
+  <div class="grid-overlay pointer-events-none absolute inset-0" aria-hidden="true"></div>
+
+  <div class="relative z-10 flex h-full flex-col gap-5 p-6 xl:p-8">
+    <!-- Stats bar -->
+    <header class="flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-2 text-lg font-bold tracking-tight">
+        <img
+          src="/favicon.png"
+          alt=""
+          class="h-7 w-7"
+          onerror={(event) => ((event.currentTarget as HTMLImageElement).style.display = 'none')}
+        />
+        Seraphim <span class="text-muted-foreground">· Watch</span>
+      </a>
+      <span
+        class="status-pill inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-semibold"
+        style="border-color: color-mix(in srgb, var(--accent) 45%, transparent); color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent)"
+      >
+        <span class="size-2.5 rounded-full {isWorking ? 'animate-ping-slow' : ''}" style="background: var(--accent)"></span>
+        {agentState.label}
+        <span class="font-normal text-muted-foreground">· {clockLabel(now)}</span>
+      </span>
+    </header>
+
+    <div class="shrink-0"><Stats /></div>
+
+    <!-- Big trio: remaining · live ring · completed -->
+    <section class="grid grid-cols-1 items-center gap-6 lg:grid-cols-3">
+      <!-- Remaining -->
+      <div class="flex flex-col items-center lg:items-end lg:pr-4 lg:text-right">
+        <div
+          class="text-[clamp(3.5rem,9vw,8rem)] font-black leading-none tabular-nums text-warning [text-shadow:0_0_40px_color-mix(in_srgb,var(--warning)_45%,transparent)]"
+        >
+          {Math.round(remainingShown.current)}
+        </div>
+        <div class="mt-1 text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Remaining
+        </div>
+        <div class="mt-1 text-xs text-muted-foreground">
+          {queuedCount} queued · {inReviewCount} in review
+        </div>
+      </div>
+
+      <!-- Live ring -->
+      <div class="grid place-items-center py-2">
+        <div class="relative grid size-[clamp(15rem,26vw,24rem)] place-items-center">
+          <!-- pulsing aura behind the ring -->
+          <div
+            class="absolute inset-0 rounded-full blur-2xl {isWorking ? 'animate-breathe' : 'opacity-20'}"
+            style="background: radial-gradient(circle, color-mix(in srgb, var(--accent) 55%, transparent), transparent 70%)"
+          ></div>
+          <!-- rotating gradient ring -->
+          <div
+            class="absolute inset-0 rounded-full {isWorking ? 'animate-spin-slow' : ''}"
+            style="background: conic-gradient(from 0deg, transparent 0%, var(--accent) 18%, transparent 38%, color-mix(in srgb, var(--accent) 60%, transparent) 60%, transparent 80%, var(--accent) 100%)"
+          ></div>
+          <!-- a comet dot orbiting the ring while working -->
+          {#if isWorking}
+            <div class="animate-orbit absolute inset-0" aria-hidden="true">
+              <span
+                class="absolute left-1/2 top-0 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full"
+                style="background: var(--accent); box-shadow: 0 0 14px 2px var(--accent)"
+              ></span>
+            </div>
+          {/if}
+          <!-- inner face -->
+          <div
+            class="absolute inset-[14px] grid place-items-center rounded-full border border-white/5 bg-[#0a0e1a]/90 p-6 text-center backdrop-blur"
+          >
+            {#if current}
+              {#key current.id}
+                <div class="flex flex-col items-center gap-2" in:fly={{ y: 10, duration: 350 }}>
+                  <span class="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-success">
+                    Now working
+                  </span>
+                  <span class="line-clamp-3 text-balance text-lg font-semibold leading-snug xl:text-xl">
+                    {current.title}
+                  </span>
+                  <span class="text-xs text-muted-foreground">#{current.external_id}</span>
+                  <span
+                    class="mt-1 inline-flex items-center gap-1.5 rounded-full bg-success/10 px-3 py-1 text-xs font-medium text-success"
+                  >
+                    <span class="size-1.5 animate-pulse rounded-full bg-success"></span>
+                    {STATUS_LABELS[current.status] ?? current.status}
+                  </span>
+                </div>
+              {/key}
+            {:else}
+              <div class="flex flex-col items-center gap-2 text-muted-foreground">
+                <span class="text-4xl">{agentState.key === 'paused' ? '⏸' : '✦'}</span>
+                <span class="text-sm font-semibold uppercase tracking-[0.3em]">{agentState.label}</span>
+                <span class="max-w-[12rem] text-xs">
+                  {agentState.key === 'paused'
+                    ? 'The agent is paused.'
+                    : agentState.key === 'halted'
+                      ? 'Needs attention to resume.'
+                      : 'Standing by for the next task.'}
+                </span>
+              </div>
+            {/if}
+          </div>
+        </div>
+      </div>
+
+      <!-- Completed -->
+      <div class="flex flex-col items-center lg:items-start lg:pl-4 lg:text-left">
+        <div
+          class="text-[clamp(3.5rem,9vw,8rem)] font-black leading-none tabular-nums text-success [text-shadow:0_0_40px_color-mix(in_srgb,var(--success)_45%,transparent)]"
+        >
+          {Math.round(completedShown.current)}
+        </div>
+        <div class="mt-1 text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Completed
+        </div>
+        <div class="mt-1 text-xs text-muted-foreground">shipped to done</div>
+      </div>
+    </section>
+
+    <!-- Overall completion progress -->
+    <div class="flex items-center gap-3 px-1">
+      <span class="w-16 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+        {completedCount}/{trackedCount}
+      </span>
+      <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-white/5">
+        <div
+          class="h-full rounded-full transition-[width] duration-700 ease-out"
+          style="width: {completionPct}%; background: linear-gradient(90deg, var(--primary), var(--success)); box-shadow: 0 0 12px color-mix(in srgb, var(--success) 55%, transparent)"
+        ></div>
+      </div>
+      <span class="w-10 shrink-0 text-xs tabular-nums text-muted-foreground">
+        {Math.round(completionPct)}%
+      </span>
+    </div>
+
+    <!-- Live activity across every task -->
+    <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/60 bg-black/30 backdrop-blur">
+      <div class="flex items-center gap-2 border-b border-border/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+        <span class="size-2 rounded-full bg-primary {feed.length ? 'animate-pulse' : ''}"></span>
+        Live activity
+      </div>
+      <div bind:this={feedEl} class="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-4 py-3 font-mono text-sm">
+        {#if feed.length === 0}
+          <p class="text-muted-foreground">Waiting for the agent to act…</p>
+        {/if}
+        {#each feed as entry (entry.id)}
+          {@const meta = GLYPHS[entry.type] ?? { glyph: '·', color: 'text-muted-foreground' }}
+          {@const hue = taskHue(entry.taskId)}
+          <div class="flex items-center gap-3 py-0.5" in:fly={{ y: 8, duration: 250, easing: cubicOut }}>
+            <span class="w-[4.5rem] shrink-0 text-xs tabular-nums text-muted-foreground/60">
+              {clockLabel(entry.at)}
+            </span>
+            <span
+              class="w-44 shrink-0 truncate rounded px-1.5 py-0.5 text-xs font-medium"
+              style="color: hsl({hue} 75% 72%); background: hsl({hue} 75% 55% / 0.12)"
+              title={titleById.get(entry.taskId) ?? entry.taskId}
+            >
+              {taskLabel(entry.taskId)}
+            </span>
+            <span class="w-[1ch] shrink-0 text-center {meta.color}">{meta.glyph}</span>
+            <span class="min-w-0 flex-1 truncate text-foreground/90">{entry.text}</span>
+          </div>
+        {/each}
+      </div>
+    </section>
+  </div>
+</div>
+
+<style>
+  .aura {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(90px);
+    opacity: 0.22;
+    pointer-events: none;
+  }
+  .aura-1 {
+    width: 42vw;
+    height: 42vw;
+    left: -6vw;
+    top: -8vw;
+    background: radial-gradient(circle, var(--accent), transparent 70%);
+    animation: drift1 20s ease-in-out infinite;
+  }
+  .aura-2 {
+    width: 38vw;
+    height: 38vw;
+    right: -8vw;
+    bottom: -12vw;
+    background: radial-gradient(circle, var(--primary), transparent 70%);
+    animation: drift2 26s ease-in-out infinite;
+  }
+  .grid-overlay {
+    opacity: 0.05;
+    background-image:
+      linear-gradient(var(--foreground) 1px, transparent 1px),
+      linear-gradient(90deg, var(--foreground) 1px, transparent 1px);
+    background-size: 44px 44px;
+    mask-image: radial-gradient(ellipse at center, black 30%, transparent 85%);
+  }
+
+  :global(.watch) .animate-spin-slow {
+    animation: spin 5s linear infinite;
+  }
+  :global(.watch) .animate-breathe {
+    animation: breathe 3.5s ease-in-out infinite;
+  }
+  :global(.watch) .animate-ping-slow {
+    animation: ping-slow 2s cubic-bezier(0, 0, 0.2, 1) infinite;
+  }
+  :global(.watch) .animate-orbit {
+    animation: spin 8s linear infinite;
+  }
+
+  @keyframes drift1 {
+    0%,
+    100% {
+      transform: translate(0, 0);
+    }
+    50% {
+      transform: translate(6vw, 4vh);
+    }
+  }
+  @keyframes drift2 {
+    0%,
+    100% {
+      transform: translate(0, 0);
+    }
+    50% {
+      transform: translate(-5vw, -3vh);
+    }
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  @keyframes breathe {
+    0%,
+    100% {
+      opacity: 0.3;
+      transform: scale(0.96);
+    }
+    50% {
+      opacity: 0.6;
+      transform: scale(1.04);
+    }
+  }
+  @keyframes ping-slow {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 60%, transparent);
+    }
+    70%,
+    100% {
+      box-shadow: 0 0 0 8px transparent;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .aura,
+    :global(.watch) .animate-spin-slow,
+    :global(.watch) .animate-breathe,
+    :global(.watch) .animate-ping-slow,
+    :global(.watch) .animate-orbit {
+      animation: none;
+    }
+  }
+</style>


### PR DESCRIPTION
Closes #137.

## What
A dedicated, full-screen, kiosk-style monitor of the whole agent, meant to be left running on a TV or side monitor. Layout matches the issue's sketch:

- **Stats bar up top** (reuses the live `Stats` panel) plus a state pill + clock.
- **Big trio in the middle:** a large **Remaining** count, a **huge live ring** for the task being worked, and a large **Completed** count, with an overall completion progress bar beneath.
- **Live activity feed across every task** along the bottom: just the pure agentic signals.

## Make it fun (multiple passes)
- The whole page is **themed by the agent's live state** (working = green, paused / cooling down = amber, halted = red, idle = blue): the ring, the aura glow, the status pill, and the live dot all shift color.
- The central ring has a **rotating gradient**, an **orbiting comet**, and a **breathing glow** while working; the worked task's title/number/status animate in when it changes, and an idle/paused/halted standby face shows otherwise.
- Drifting **aura blobs** + a masked **grid overlay** give the static page life; the big numbers **count up smoothly** (`svelte/motion` `Tween`) and glow.
- The feed is a **terminal-style** stream: only briefings, thinking, prose, tool calls, results, and rate-limit notices (tool-result/infra noise dropped), each line tagged with a **stable per-task color** and slid in newest-last.
- Respects **`prefers-reduced-motion`** (all the custom animations switch off).

## How
- **Backend:** a new `GET /api/v1/activity/stream` SSE that fans out *every* task's events (each frame tagged with its `task_id`), reusing the existing broadcast bus, so one page can watch all tasks at once. (The per-task `/tasks/:id/stream` only carries one task.)
- **Frontend:** new `/watch` route. The root layout drops its navbar for `/watch` so the page owns the full viewport, and gains a "Watch" nav link. Counts and the current task come from the existing board + board SSE; the feed comes from the new activity stream.

## Scope
Additive: no schema or existing-endpoint changes. The new SSE is read-only over the current event bus.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (the one new lint is the same pedantic `needless_continue` the sibling SSE handlers already use, intentionally matched; CI does not deny warnings) / `test` (58 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass.