### PR TITLE
Add a hard reset for the agent (#73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,12 @@ fail-fast) on every PR and on `main`/`develop`.
   so the crate builds without a live DB. Keep it that way.
 - **Claude must run as non-root** for `bypassPermissions`; both exec sites set
   `user: "codespace"`. Don't remove that.
+- **Hard reset** (`POST /api/v1/agent/reset`, `orchestrator::hard_reset`) wipes
+  history + the Claude session and requeues the in-progress task for a clean-slate
+  restart. It bumps an in-memory `AppState::reset_epoch`; a turn snapshots that
+  epoch at its start and abandons its post-turn handling (session persist, task
+  move) if it changed, so a reset landing mid-turn is never undone by the turn it
+  interrupted. Keep that guard if you touch the turn-completion path.
 - **stream-json schema can drift** across Claude Code versions; the parser keeps
   unknown shapes as `Other` rather than failing. Verify against the installed
   version when touching `claude/events.rs`.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1337,6 +1337,14 @@ pub async fn reset_global_stats(pool: &PgPool) -> sqlx::Result<()> {
     Ok(())
 }
 
+/// Purges all conversation history: every turn and its events (events cascade
+/// from turns). Used by the hard reset to wipe the agent's recorded history,
+/// which also zeroes the turn-derived statistics.
+pub async fn purge_history(pool: &PgPool) -> sqlx::Result<u64> {
+    let result = sqlx::query("DELETE FROM turns").execute(pool).await?;
+    Ok(result.rows_affected())
+}
+
 // --- Events ------------------------------------------------------------------
 
 pub async fn append_event(

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -108,6 +108,7 @@ pub fn router(state: AppState) -> Router {
         .route("/workspace/restart", post(workspace::restart))
         .route("/workspace/recreate", post(workspace::recreate))
         .route("/workspace/provision", post(workspace::provision))
+        .route("/agent/reset", post(workspace::reset))
         .route("/export", get(data::export))
         .route("/import", post(data::import))
         .with_state(state);

--- a/api/src/http/workspace.rs
+++ b/api/src/http/workspace.rs
@@ -1,7 +1,9 @@
-//! Workspace container control: restart and full recreate.
+//! Workspace container control: restart and full recreate, plus the agent's
+//! hard reset.
 
 use axum::extract::State;
 use axum::Json;
+use serde::Deserialize;
 use serde_json::json;
 use tracing::info;
 
@@ -32,4 +34,22 @@ pub async fn provision(State(state): State<AppState>) -> ApiResult<Json<serde_js
     info!("provisioning workspace");
     crate::orchestrator::provision_workspace(&state).await?;
     Ok(Json(json!({ "status": "provisioned" })))
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ResetRequest {
+    /// Also delete the agent's accumulated memory files. Off by default.
+    #[serde(default)]
+    pub purge_memories: bool,
+}
+
+/// `POST /api/v1/agent/reset` - hard-reset the agent: stop the current turn, wipe
+/// its history and session, requeue the in-progress task, and optionally purge
+/// memories. The next turn spawns a brand-new, context-free Claude session.
+pub async fn reset(
+    State(state): State<AppState>,
+    Json(body): Json<ResetRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    crate::orchestrator::hard_reset(&state, body.purge_memories).await?;
+    Ok(Json(json!({ "status": "reset" })))
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -331,6 +331,58 @@ pub async fn upsert_jira_issue(
     Ok(())
 }
 
+/// Hard-resets the agent to a clean slate: stops any running turn, wipes the
+/// conversation history and the persisted Claude session, requeues whatever task
+/// was being worked, and (when `purge_memories`) deletes the agent's memory files.
+/// The next turn the loop runs then spawns a brand-new, context-free session.
+pub async fn hard_reset(state: &AppState, purge_memories: bool) -> Result<()> {
+    info!(purge_memories, "hard reset requested");
+
+    // Bump first, so an in-flight turn (about to be killed) abandons its post-turn
+    // handling and never revives the session or its task after we wipe them.
+    state.bump_reset_epoch();
+
+    // Stop the running Claude process and wipe its on-disk session (and memories,
+    // when asked). Best-effort: workspace cleanup must not abort the reset.
+    let mut script = String::from(
+        ": \"${CLAUDE_CONFIG_DIR:=/workspace/.claude}\"\n\
+         pkill -9 -f '[c]laude -p' || true\n\
+         find \"$CLAUDE_CONFIG_DIR/projects\" -type f -name '*.jsonl' -delete 2>/dev/null || true\n",
+    );
+    if purge_memories {
+        script.push_str(
+            "find \"$CLAUDE_CONFIG_DIR/projects\" -type d -name memory -exec rm -rf {} + 2>/dev/null || true\n\
+             find \"$CLAUDE_CONFIG_DIR/projects\" -type f -name 'MEMORY.md' -delete 2>/dev/null || true\n",
+        );
+    }
+    if let Err(error) = state
+        .workspace
+        .exec_capture(
+            "/workspace",
+            vec!["bash".to_string(), "-lc".to_string(), script],
+            vec![],
+        )
+        .await
+    {
+        warn!(error = %error, "hard reset: workspace cleanup failed (continuing)");
+    }
+
+    // Clear the shared session so the next turn starts blank, purge the recorded
+    // history (which also zeroes the turn-derived stats), and requeue the task the
+    // agent was mid-work on so a fresh session can redo it cleanly.
+    queries::set_current_session_id(&state.db, None).await?;
+    let turns_purged = queries::purge_history(&state.db).await?;
+    let tasks_requeued = queries::reclaim_orphaned_tasks(&state.db).await?;
+
+    // Drop the ephemeral in-memory signals so the UI doesn't show stale gauges.
+    state.set_live_usage(None);
+    state.set_cooldown_until(None);
+
+    state.notify_board();
+    info!(turns_purged, tasks_requeued, "agent hard reset complete");
+    Ok(())
+}
+
 // --- Agent loop --------------------------------------------------------------
 
 async fn agent_loop(state: AppState) {
@@ -474,6 +526,12 @@ async fn work_fresh(state: &AppState, task: Task, resume: bool) -> Result<()> {
     };
     let outcome = run_agent_turn(state, &settings, &task, prompt).await?;
     persist_session(state, &settings, &outcome).await?;
+    // A hard reset during the turn has already reclaimed this task and wiped the
+    // session; don't fail it or move it, just yield to the reset.
+    if state.reset_epoch() != outcome.epoch {
+        info!(task_id = %task.id, "hard reset during turn; leaving the task to the reset");
+        return Ok(());
+    }
     // Surface a turn failure (e.g. "Not logged in") on the task itself, instead
     // of letting it fall through to the generic "no pull request" message.
     if let Some(message) = outcome.error {
@@ -589,6 +647,11 @@ async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> 
     let attempt = queries::bump_ci_fix_attempt(&state.db, task.id).await?;
     let outcome = run_agent_turn(state, &settings, &task, prompt).await?;
     persist_session(state, &settings, &outcome).await?;
+    // A hard reset during the turn owns this task now; yield to it.
+    if state.reset_epoch() != outcome.epoch {
+        info!(task_id = %task.id, "hard reset during turn; leaving the task to the reset");
+        return Ok(());
+    }
     if let Some(message) = outcome.error {
         return fail(state, &task, &message).await;
     }
@@ -622,12 +685,16 @@ async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> 
     Ok(())
 }
 
-/// Persists a turn's session id when it differs from the stored one.
+/// Persists a turn's session id when it differs from the stored one. Skipped if a
+/// hard reset happened during the turn, so the just-cleared session isn't revived.
 async fn persist_session(
     state: &AppState,
     settings: &crate::db::models::Settings,
     outcome: &TurnOutcome,
 ) -> Result<()> {
+    if state.reset_epoch() != outcome.epoch {
+        return Ok(());
+    }
     if let Some(session_id) = &outcome.session_id {
         if settings.current_session_id.as_deref() != Some(session_id.as_str()) {
             queries::set_current_session_id(&state.db, Some(session_id)).await?;
@@ -642,6 +709,9 @@ struct TurnOutcome {
     session_id: Option<String>,
     /// A failure message to surface on the task, if the turn errored.
     error: Option<String>,
+    /// The hard-reset epoch captured when the turn started, so the caller can tell
+    /// whether a reset interrupted it.
+    epoch: u64,
 }
 
 /// Runs one Claude turn, transparently retrying through a brief cooldown when it
@@ -716,6 +786,10 @@ async fn stream_turn(
     task: &Task,
     prompt: String,
 ) -> Result<TurnOutcome> {
+    // Snapshot the hard-reset epoch so the caller can tell if a reset lands while
+    // this turn runs (and then skip reviving its session / moving its task).
+    let reset_epoch = state.reset_epoch();
+
     // Claude runs at the workspace root so it can work across all cloned repos.
     let working_dir = "/workspace".to_string();
 
@@ -943,6 +1017,7 @@ async fn stream_turn(
     Ok(TurnOutcome {
         session_id,
         error: error_message,
+        epoch: reset_epoch,
     })
 }
 

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -1,5 +1,6 @@
 //! Shared application state and the server-sent-event broadcast bus.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, Utc};
@@ -76,6 +77,10 @@ pub struct AppState {
     /// Ephemeral (like [`Self::cooldown_until`]); the stats endpoints overlay it on
     /// the persisted totals so the counter ticks during generation.
     live_usage: Arc<RwLock<Option<LiveUsage>>>,
+    /// Bumped by a hard reset. A turn captures it at the start and abandons its
+    /// post-turn handling (session persist, task move) if it changed, so a reset
+    /// that lands mid-turn is never undone by the turn it interrupted.
+    reset_epoch: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -88,7 +93,19 @@ impl AppState {
             internal_api_url,
             cooldown_until: Arc::new(RwLock::new(None)),
             live_usage: Arc::new(RwLock::new(None)),
+            reset_epoch: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// The current hard-reset generation. A turn captures this at its start and
+    /// compares it later; a change means a reset happened during the turn.
+    pub fn reset_epoch(&self) -> u64 {
+        self.reset_epoch.load(Ordering::SeqCst)
+    }
+
+    /// Marks a hard reset, so any in-flight turn yields its post-turn handling.
+    pub fn bump_reset_epoch(&self) {
+        self.reset_epoch.fetch_add(1, Ordering::SeqCst);
     }
 
     /// The active rate-limit cooldown deadline, if one is set.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -289,6 +289,10 @@ export function provisionWorkspace() {
   return apiClient.post('workspace/provision').json()
 }
 
+export function resetAgent(purgeMemories: boolean) {
+  return apiClient.post('agent/reset', { json: { purge_memories: purgeMemories } }).json()
+}
+
 // --- Config export / import --------------------------------------------------
 
 export function exportConfig() {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -27,6 +27,7 @@
     listJiraBoards,
     listRepos,
     recreateWorkspace,
+    resetAgent,
     resetStats,
     restartWorkspace,
     setEnvVars,
@@ -37,6 +38,7 @@
   } from '$lib/api'
   import * as Card from '$lib/components/ui/card'
   import * as Select from '$lib/components/ui/select'
+  import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import { Button, buttonVariants } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
@@ -486,6 +488,26 @@
     workspaceMessage = 'Recreating + provisioning…'
     await recreateWorkspace()
     workspaceMessage = 'Workspace recreated; repos + config reprovisioned.'
+  }
+
+  // Hard reset: purge the agent's history/session (and optionally memories), then
+  // it spins up a brand-new, context-free session on its next turn.
+  let resetDialogOpen = $state(false)
+  let resetMemories = $state(false)
+  let resetting = $state(false)
+  async function runReset() {
+    resetting = true
+    try {
+      await resetAgent(resetMemories)
+      resetDialogOpen = false
+      // Everything (history, session, stats) is gone; reload to a clean slate.
+      window.location.reload()
+    } catch (error) {
+      console.error('hard reset failed', error)
+      workspaceMessage = 'Hard reset failed; see logs.'
+    } finally {
+      resetting = false
+    }
   }
 
   let statsMessage = $state<string | null>(null)
@@ -1289,6 +1311,48 @@
           <Button variant="outline" onclick={runRecreate}>Recreate</Button>
           {#if workspaceMessage}<span class="text-sm text-muted-foreground">{workspaceMessage}</span>{/if}
         </div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root class="mt-6 border-destructive/40">
+      <Card.Header>
+        <Card.Title class="text-destructive">Hard reset the agent</Card.Title>
+        <Card.Description>
+          Wipes the agent's conversation history, statistics, and the current Claude session, and
+          requeues whatever it was working on. The next turn starts a brand-new, context-free
+          session. This cannot be undone.
+        </Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <AlertDialog.Root bind:open={resetDialogOpen}>
+          <AlertDialog.Trigger class={buttonVariants({ variant: 'destructive' })}>
+            Hard reset
+          </AlertDialog.Trigger>
+          <AlertDialog.Content>
+            <AlertDialog.Header>
+              <AlertDialog.Title>Hard reset the agent?</AlertDialog.Title>
+              <AlertDialog.Description>
+                This purges the agent's history and current session and requeues its in-progress
+                task, then starts a fresh session with no context. This cannot be undone.
+              </AlertDialog.Description>
+            </AlertDialog.Header>
+            <label class="flex items-center gap-3 rounded-md border border-border p-3">
+              <Switch id="reset-memories" bind:checked={resetMemories} />
+              <span class="text-sm">
+                <span class="font-medium">Also purge memories</span>
+                <span class="block text-muted-foreground">
+                  Delete the agent's accumulated memory files too.
+                </span>
+              </span>
+            </label>
+            <AlertDialog.Footer>
+              <AlertDialog.Cancel disabled={resetting}>Cancel</AlertDialog.Cancel>
+              <Button variant="destructive" disabled={resetting} onclick={runReset}>
+                {resetting ? 'Resetting…' : resetMemories ? 'Reset + purge memories' : 'Reset'}
+              </Button>
+            </AlertDialog.Footer>
+          </AlertDialog.Content>
+        </AlertDialog.Root>
       </Card.Content>
     </Card.Root>
     {/if}


### PR DESCRIPTION
Closes #73.

## What
A way to hard-reset the agent from the UI: purge its history, current thread/task, and (optionally) memories, then restart the Claude session on a fully clean slate, a brand-new session with no context or history.

## How
New `POST /api/v1/agent/reset` -> `orchestrator::hard_reset(purge_memories)`:

1. **Stops the running turn** (`pkill` the workspace's `claude -p`).
2. **Clears the shared Claude session** (`current_session_id = NULL`) and **deletes its on-disk transcripts** (`projects/**/*.jsonl`), so the next turn spawns a fresh, context-free session.
3. **Purges all history** (`DELETE FROM turns`; events cascade), which also zeroes the turn-derived statistics.
4. **Requeues the in-progress task** (back to To Do) so a fresh session can redo it cleanly.
5. **Optionally purges memories** (`projects/**/memory/` + `MEMORY.md`) when the request asks.
6. Drops the ephemeral gauges (live usage, cooldown) and notifies the board.

### Race-safety (reset landing mid-turn)
If the operator resets while a turn is running, the dying turn must not revive the session or move the card the reset just wiped. `AppState` gains an in-memory `reset_epoch`: a turn snapshots it at the start, and the completion path (`persist_session`, and the post-turn handling in `work_fresh` / `work_ci_fix`) bails if it changed. `hard_reset` bumps the epoch first, so the interrupted turn yields cleanly and the agent loop then picks the requeued task up on a brand-new session.

### UI
**Settings -> Workspace** gains a destructive **"Hard reset"** button that opens an are-you-sure dialog containing a **toggle to also purge memories** (off by default). On confirm it calls the endpoint and reloads the page to the clean slate.

## Notes
- "Memories" = the agent's Claude memory files (`projects/**/memory/`, `MEMORY.md`), kept by default; the session transcripts are always cleared. File cleanup is best-effort (a failure there never aborts the DB reset).
- No container recreate needed: the clean slate comes from clearing the session + transcripts, which is faster and leaves repos/config intact.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (58 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass. The actual workspace file cleanup + session respawn need a live workspace container to observe end to end (no CI harness for that here); the DB/state/race logic and the UI build green.