### PR TITLE
Automation rules: react to issue events and queue work (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,17 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and
   surfaced as toasts + native notifications + a sidebar.
+- **`automation_rules`** — user-defined rules (Automation page). When a GitHub
+  webhook delivers an issue `created`/`updated`/`comment` event, each enabled
+  rule whose source + trigger match is checked against the event; if its
+  condition group (AND/OR of `{field, operator, values}`, operators
+  exactly/contains/has_one_of/is_empty/is_not_empty over labels/author/repo/
+  title/body/comment/state) matches, its action runs (move the card to top/bottom
+  of To Do). The rule shape + the pure matcher live in `src/automation/`
+  (unit-tested, I/O-free); firing lives in `orchestrator::run_github_automation`
+  (called from `http/webhooks.rs`). Source-agnostic (rules can target `any`), but
+  only GitHub events are wired so far; it's webhook-driven (the poll sync does not
+  fire rules, to avoid re-firing every cycle).
 
 ## How the agent runtime works (the workspace)
 

--- a/api/migrations/0027_automation_rules.sql
+++ b/api/migrations/0027_automation_rules.sql
@@ -1,0 +1,25 @@
+-- User-defined automation rules. When an issue is created, updated, or commented
+-- on (delivered by the realtime webhooks), each enabled rule whose source and
+-- trigger match is evaluated against the event; if its condition group matches,
+-- its action runs (e.g. move the card to the top/bottom of To Do).
+--
+-- The trigger list, condition group, and action are stored as JSON so the rule
+-- shape can grow without migrations; the API validates them against typed structs
+-- on read and write.
+CREATE TABLE automation_rules (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT    NOT NULL DEFAULT '',
+    enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Which source the rule applies to: 'github', 'jira', 'internal', or 'any'.
+    source_kind TEXT    NOT NULL DEFAULT 'github',
+    -- Events that fire the rule: any of 'created', 'updated', 'comment'.
+    triggers    JSONB   NOT NULL DEFAULT '[]'::jsonb,
+    -- The match group: {"combinator":"and"|"or","conditions":[{field,operator,values}]}.
+    criteria    JSONB   NOT NULL DEFAULT '{"combinator":"and","conditions":[]}'::jsonb,
+    -- The action: {"type":"move_to_todo","position":"top"|"bottom"}.
+    action      JSONB   NOT NULL DEFAULT '{"type":"move_to_todo","position":"top"}'::jsonb,
+    -- Fractional rank for ordering rules in the UI and evaluation (first match wins).
+    position    DOUBLE PRECISION NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/api/src/automation/mod.rs
+++ b/api/src/automation/mod.rs
@@ -1,0 +1,296 @@
+//! The automation rules engine: the rule shape (triggers, condition group,
+//! action) and the pure matcher that decides whether an issue event satisfies a
+//! rule. Storage (the `automation_rules` row) and firing (querying rules, running
+//! the action) live elsewhere; this module is deliberately free of I/O so the
+//! matching logic is unit-tested in isolation.
+
+use serde::{Deserialize, Serialize};
+
+/// What kind of event fires a rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Trigger {
+    /// The issue was just opened.
+    Created,
+    /// The issue changed (edited, labeled, reopened, ...).
+    Updated,
+    /// A comment was posted on the issue.
+    Comment,
+}
+
+/// How a group's conditions combine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Combinator {
+    And,
+    Or,
+}
+
+/// The issue attribute a condition tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Field {
+    /// The issue's labels (a list).
+    Labels,
+    /// The issue author's login.
+    Author,
+    /// The repository full name (`owner/repo`).
+    Repo,
+    Title,
+    Body,
+    /// The triggering comment's body (empty unless this is a comment event).
+    Comment,
+    /// The triggering comment's author login.
+    CommentAuthor,
+    /// The issue state (`open` / `closed`).
+    State,
+}
+
+/// How a condition compares the field to its values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operator {
+    /// Equals one of the values (case-insensitive).
+    Exactly,
+    /// Contains one of the values as a substring (case-insensitive).
+    Contains,
+    /// For a list field: shares at least one value. For a scalar: same as `exactly`.
+    HasOneOf,
+    /// The field is empty.
+    IsEmpty,
+    /// The field is non-empty.
+    IsNotEmpty,
+}
+
+/// One condition: a field tested by an operator against zero or more values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Condition {
+    pub field: Field,
+    pub operator: Operator,
+    #[serde(default)]
+    pub values: Vec<String>,
+}
+
+/// A group of conditions combined with AND / OR. An empty group always matches
+/// (the trigger and source gates still apply), so a rule can fire on every event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleGroup {
+    pub combinator: Combinator,
+    #[serde(default)]
+    pub conditions: Vec<Condition>,
+}
+
+/// Where in To Do a matched card lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueuePosition {
+    Top,
+    Bottom,
+}
+
+/// What a matched rule does. Tagged so new actions can be added later.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RuleAction {
+    /// Move the card to To Do, at the top or bottom of the queue.
+    MoveToTodo { position: QueuePosition },
+}
+
+/// The event being matched, gathered from a webhook payload. Scalar fields that
+/// don't apply to a given event (e.g. the comment on a non-comment event) are
+/// empty strings.
+#[derive(Debug, Clone, Copy)]
+pub struct RuleContext<'a> {
+    pub trigger: Trigger,
+    pub repo: &'a str,
+    pub author: &'a str,
+    pub labels: &'a [String],
+    pub title: &'a str,
+    pub body: &'a str,
+    pub state: &'a str,
+    pub comment: &'a str,
+    pub comment_author: &'a str,
+}
+
+impl RuleGroup {
+    /// Whether this group matches the event.
+    pub fn matches(&self, ctx: &RuleContext) -> bool {
+        if self.conditions.is_empty() {
+            return true;
+        }
+        match self.combinator {
+            Combinator::And => self.conditions.iter().all(|c| c.matches(ctx)),
+            Combinator::Or => self.conditions.iter().any(|c| c.matches(ctx)),
+        }
+    }
+}
+
+impl Condition {
+    fn matches(&self, ctx: &RuleContext) -> bool {
+        match self.field {
+            Field::Labels => self.eval_list(ctx.labels),
+            Field::Author => self.eval_scalar(ctx.author),
+            Field::Repo => self.eval_scalar(ctx.repo),
+            Field::Title => self.eval_scalar(ctx.title),
+            Field::Body => self.eval_scalar(ctx.body),
+            Field::Comment => self.eval_scalar(ctx.comment),
+            Field::CommentAuthor => self.eval_scalar(ctx.comment_author),
+            Field::State => self.eval_scalar(ctx.state),
+        }
+    }
+
+    /// Non-empty values, trimmed and lowercased, for case-insensitive matching.
+    fn needles(&self) -> impl Iterator<Item = String> + '_ {
+        self.values
+            .iter()
+            .map(|value| value.trim().to_ascii_lowercase())
+            .filter(|value| !value.is_empty())
+    }
+
+    fn eval_scalar(&self, value: &str) -> bool {
+        let value = value.trim().to_ascii_lowercase();
+        match self.operator {
+            Operator::IsEmpty => value.is_empty(),
+            Operator::IsNotEmpty => !value.is_empty(),
+            Operator::Exactly | Operator::HasOneOf => self.needles().any(|needle| needle == value),
+            Operator::Contains => self.needles().any(|needle| value.contains(&needle)),
+        }
+    }
+
+    fn eval_list(&self, items: &[String]) -> bool {
+        let present: Vec<String> = items
+            .iter()
+            .map(|item| item.trim().to_ascii_lowercase())
+            .filter(|item| !item.is_empty())
+            .collect();
+        match self.operator {
+            Operator::IsEmpty => present.is_empty(),
+            Operator::IsNotEmpty => !present.is_empty(),
+            Operator::Exactly | Operator::HasOneOf => self
+                .needles()
+                .any(|needle| present.iter().any(|item| item == &needle)),
+            Operator::Contains => self
+                .needles()
+                .any(|needle| present.iter().any(|item| item.contains(&needle))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(trigger: Trigger, labels: &[String]) -> RuleContext<'_> {
+        RuleContext {
+            trigger,
+            repo: "navarrotech/seraphim",
+            author: "navarrotech",
+            labels,
+            title: "Fix the thing",
+            body: "It is broken",
+            state: "open",
+            comment: "",
+            comment_author: "",
+        }
+    }
+
+    fn condition(field: Field, operator: Operator, values: &[&str]) -> Condition {
+        Condition {
+            field,
+            operator,
+            values: values.iter().map(|&value| value.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn empty_group_always_matches() {
+        let group = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![],
+        };
+        assert!(group.matches(&ctx(Trigger::Created, &[])));
+    }
+
+    #[test]
+    fn labels_has_one_of_and_author_exactly_with_and() {
+        // Mirrors the issue's example: labels has one of {automation,bug} AND
+        // author is exactly navarrotech.
+        let labels = vec!["bug".to_string(), "ux".to_string()];
+        let group = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![
+                condition(Field::Labels, Operator::HasOneOf, &["automation", "bug"]),
+                condition(Field::Author, Operator::Exactly, &["navarrotech"]),
+            ],
+        };
+        assert!(group.matches(&ctx(Trigger::Created, &labels)));
+
+        // Wrong author fails the AND.
+        let mut wrong = ctx(Trigger::Created, &labels);
+        wrong.author = "someone-else";
+        assert!(!group.matches(&wrong));
+
+        // A label outside the set fails has-one-of.
+        let other = vec!["docs".to_string()];
+        assert!(!group.matches(&ctx(Trigger::Created, &other)));
+    }
+
+    #[test]
+    fn or_combinator_needs_only_one() {
+        let labels: Vec<String> = vec![];
+        let group = RuleGroup {
+            combinator: Combinator::Or,
+            conditions: vec![
+                condition(Field::Author, Operator::Exactly, &["nobody"]),
+                condition(Field::Title, Operator::Contains, &["thing"]),
+            ],
+        };
+        assert!(group.matches(&ctx(Trigger::Updated, &labels)));
+    }
+
+    #[test]
+    fn comment_contains_trigger_phrase() {
+        // The "Jarvis, can you take this on?" flow.
+        let mut context = ctx(Trigger::Comment, &[]);
+        context.comment = "Hey Jarvis, can you take this on? thanks";
+        let group = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(
+                Field::Comment,
+                Operator::Contains,
+                &["jarvis, can you take this on?"],
+            )],
+        };
+        assert!(group.matches(&context));
+    }
+
+    #[test]
+    fn is_empty_and_is_not_empty() {
+        let labels: Vec<String> = vec![];
+        let empty_labels = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(Field::Labels, Operator::IsEmpty, &[])],
+        };
+        assert!(empty_labels.matches(&ctx(Trigger::Created, &labels)));
+
+        let has_labels = vec!["bug".to_string()];
+        assert!(!empty_labels.matches(&ctx(Trigger::Created, &has_labels)));
+
+        let not_empty_body = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(Field::Body, Operator::IsNotEmpty, &[])],
+        };
+        assert!(not_empty_body.matches(&ctx(Trigger::Created, &labels)));
+    }
+
+    #[test]
+    fn action_round_trips_through_json() {
+        let action = RuleAction::MoveToTodo {
+            position: QueuePosition::Bottom,
+        };
+        let json = serde_json::to_string(&action).unwrap();
+        assert_eq!(json, r#"{"type":"move_to_todo","position":"bottom"}"#);
+        let parsed: RuleAction = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, action);
+    }
+}

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -333,6 +333,25 @@ pub struct JiraBoard {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A user-defined automation rule. When an issue event matches, the action runs.
+/// The trigger list, condition group, and action are stored as JSON, validated
+/// against the typed `automation` structs on read/write.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct AutomationRule {
+    pub id: Uuid,
+    pub name: String,
+    pub enabled: bool,
+    /// `github` / `jira` / `internal` / `any`.
+    pub source_kind: String,
+    pub triggers: Json<Vec<crate::automation::Trigger>>,
+    pub criteria: Json<crate::automation::RuleGroup>,
+    pub action: Json<crate::automation::RuleAction>,
+    /// Fractional rank: rules are evaluated in this order and the first match wins.
+    pub position: f64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// A kanban card: one issue the agent may work.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
 pub struct Task {

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,11 +12,12 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnswerKind, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite, InternalComment, JiraBoard,
-    JiraDeployment, NetworkAccessLevel, PendingQuestion, Question, QuestionOption, QuestionStatus,
-    RepoDeletionImpact, Repository, ReviewPolicy, Settings, SourceKind, StatsAggregate, Task,
-    TaskColumn, TaskStatus, Turn,
+    AnswerKind, AutomationRule, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite,
+    InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingQuestion, Question,
+    QuestionOption, QuestionStatus, RepoDeletionImpact, Repository, ReviewPolicy, Settings,
+    SourceKind, StatsAggregate, Task, TaskColumn, TaskStatus, Turn,
 };
+use crate::automation::{RuleAction, RuleGroup, Trigger};
 
 // --- Settings ----------------------------------------------------------------
 
@@ -705,6 +706,115 @@ pub async fn delete_jira_board(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
         .execute(pool)
         .await?;
     Ok(())
+}
+
+// --- Automation rules --------------------------------------------------------
+
+/// Every rule, in evaluation order (first match wins).
+pub async fn list_automation_rules(pool: &PgPool) -> sqlx::Result<Vec<AutomationRule>> {
+    sqlx::query_as::<_, AutomationRule>(
+        "SELECT * FROM automation_rules ORDER BY position, created_at",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// The enabled rules only, in evaluation order. Used by the event handlers.
+pub async fn list_enabled_automation_rules(pool: &PgPool) -> sqlx::Result<Vec<AutomationRule>> {
+    sqlx::query_as::<_, AutomationRule>(
+        "SELECT * FROM automation_rules WHERE enabled = TRUE ORDER BY position, created_at",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// The bottom rank, so a newly created rule sorts after the others.
+pub async fn max_automation_rule_position(pool: &PgPool) -> sqlx::Result<Option<f64>> {
+    sqlx::query_scalar::<_, Option<f64>>("SELECT MAX(position) FROM automation_rules")
+        .fetch_one(pool)
+        .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create_automation_rule(
+    pool: &PgPool,
+    name: &str,
+    enabled: bool,
+    source_kind: &str,
+    triggers: &[Trigger],
+    criteria: &RuleGroup,
+    action: &RuleAction,
+    position: f64,
+) -> sqlx::Result<AutomationRule> {
+    sqlx::query_as::<_, AutomationRule>(
+        "INSERT INTO automation_rules \
+         (name, enabled, source_kind, triggers, criteria, action, position) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *",
+    )
+    .bind(name)
+    .bind(enabled)
+    .bind(source_kind)
+    .bind(Json(triggers))
+    .bind(Json(criteria))
+    .bind(Json(action))
+    .bind(position)
+    .fetch_one(pool)
+    .await
+}
+
+/// Updates a rule's editable fields, preserving its rank. `None` if it's gone.
+#[allow(clippy::too_many_arguments)]
+pub async fn update_automation_rule(
+    pool: &PgPool,
+    id: Uuid,
+    name: &str,
+    enabled: bool,
+    source_kind: &str,
+    triggers: &[Trigger],
+    criteria: &RuleGroup,
+    action: &RuleAction,
+) -> sqlx::Result<Option<AutomationRule>> {
+    sqlx::query_as::<_, AutomationRule>(
+        "UPDATE automation_rules SET \
+         name = $2, enabled = $3, source_kind = $4, triggers = $5, criteria = $6, \
+         action = $7, updated_at = now() \
+         WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(name)
+    .bind(enabled)
+    .bind(source_kind)
+    .bind(Json(triggers))
+    .bind(Json(criteria))
+    .bind(Json(action))
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn delete_automation_rule(pool: &PgPool, id: Uuid) -> sqlx::Result<bool> {
+    let result = sqlx::query("DELETE FROM automation_rules WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Looks up a tracked task by its source identity (the way sync dedupes it).
+pub async fn find_issue_task(
+    pool: &PgPool,
+    source_kind: SourceKind,
+    repo_id: Option<Uuid>,
+    external_id: &str,
+) -> sqlx::Result<Option<Task>> {
+    sqlx::query_as::<_, Task>(
+        "SELECT * FROM tasks \
+         WHERE source_kind = $1 AND repo_id IS NOT DISTINCT FROM $2 AND external_id = $3",
+    )
+    .bind(source_kind)
+    .bind(repo_id)
+    .bind(external_id)
+    .fetch_optional(pool)
+    .await
 }
 
 /// Records the source ticket's state on a task (e.g. "open"/"closed" after a

--- a/api/src/http/automation.rs
+++ b/api/src/http/automation.rs
@@ -1,0 +1,98 @@
+//! Automation rules CRUD. The rule's triggers, condition group, and action are
+//! validated against the typed `automation` structs as they deserialize, so a
+//! malformed rule is rejected at the boundary.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::ApiResult;
+use crate::automation::{RuleAction, RuleGroup, Trigger};
+use crate::db::models::AutomationRule;
+use crate::db::queries;
+use crate::state::AppState;
+
+/// `GET /api/v1/automation/rules` - every rule, in evaluation order.
+pub async fn list(State(state): State<AppState>) -> ApiResult<Json<Vec<AutomationRule>>> {
+    Ok(Json(queries::list_automation_rules(&state.db).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RuleRequest {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_source")]
+    pub source_kind: String,
+    #[serde(default)]
+    pub triggers: Vec<Trigger>,
+    pub criteria: RuleGroup,
+    pub action: RuleAction,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_source() -> String {
+    "github".to_string()
+}
+
+/// `POST /api/v1/automation/rules` - create a rule, appended after the others.
+pub async fn create(
+    State(state): State<AppState>,
+    Json(body): Json<RuleRequest>,
+) -> ApiResult<Json<AutomationRule>> {
+    let position = queries::max_automation_rule_position(&state.db)
+        .await?
+        .unwrap_or(0.0)
+        + 1.0;
+    let rule = queries::create_automation_rule(
+        &state.db,
+        &body.name,
+        body.enabled,
+        &body.source_kind,
+        &body.triggers,
+        &body.criteria,
+        &body.action,
+        position,
+    )
+    .await?;
+    Ok(Json(rule))
+}
+
+/// `PUT /api/v1/automation/rules/:id` - replace a rule's editable fields.
+pub async fn update(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<RuleRequest>,
+) -> ApiResult<Response> {
+    let updated = queries::update_automation_rule(
+        &state.db,
+        id,
+        &body.name,
+        body.enabled,
+        &body.source_kind,
+        &body.triggers,
+        &body.criteria,
+        &body.action,
+    )
+    .await?;
+    match updated {
+        Some(rule) => Ok(Json(rule).into_response()),
+        None => Ok(StatusCode::NOT_FOUND.into_response()),
+    }
+}
+
+/// `DELETE /api/v1/automation/rules/:id`
+pub async fn delete(State(state): State<AppState>, Path(id): Path<Uuid>) -> ApiResult<Response> {
+    if queries::delete_automation_rule(&state.db, id).await? {
+        Ok(StatusCode::NO_CONTENT.into_response())
+    } else {
+        Ok(StatusCode::NOT_FOUND.into_response())
+    }
+}

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -4,6 +4,7 @@
 //! turns an `eyre` error into a 500 with a JSON body, so the happy path stays
 //! free of error plumbing.
 
+mod automation;
 mod board;
 mod data;
 mod jira;
@@ -109,6 +110,14 @@ pub fn router(state: AppState) -> Router {
         .route("/workspace/restart", post(workspace::restart))
         .route("/workspace/recreate", post(workspace::recreate))
         .route("/workspace/provision", post(workspace::provision))
+        .route(
+            "/automation/rules",
+            get(automation::list).post(automation::create),
+        )
+        .route(
+            "/automation/rules/:id",
+            axum::routing::put(automation::update).delete(automation::delete),
+        )
         .route("/export", get(data::export))
         .route("/import", post(data::import))
         .with_state(state);

--- a/api/src/http/webhooks.rs
+++ b/api/src/http/webhooks.rs
@@ -19,6 +19,7 @@ use axum::response::{IntoResponse, Response};
 use eyre::Result;
 use serde::Deserialize;
 
+use crate::automation;
 use crate::db::models::SourceKind;
 use crate::db::queries;
 use crate::state::AppState;
@@ -51,22 +52,36 @@ pub async fn github(
         return Ok((StatusCode::UNAUTHORIZED, "invalid signature").into_response());
     }
 
-    match header_str(&headers, "x-github-event").unwrap_or_default() {
-        // GitHub's first delivery after configuring the hook; acknowledge it.
-        "ping" => return Ok((StatusCode::OK, "pong").into_response()),
-        // We only act on issue lifecycle events; ignore comments, pushes, etc.
-        "issues" => {}
-        _ => return Ok(StatusCode::OK.into_response()),
-    }
+    let changed =
+        match header_str(&headers, "x-github-event").unwrap_or_default() {
+            // GitHub's first delivery after configuring the hook; acknowledge it.
+            "ping" => return Ok((StatusCode::OK, "pong").into_response()),
+            "issues" => {
+                let event: GithubIssueEvent = match serde_json::from_slice(&body) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        return Ok((StatusCode::BAD_REQUEST, format!("bad payload: {error}"))
+                            .into_response())
+                    }
+                };
+                apply_github_event(&state, event).await?
+            }
+            // Comments can fire `comment` automation rules (e.g. a trigger phrase).
+            "issue_comment" => {
+                let event: GithubCommentEvent = match serde_json::from_slice(&body) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        return Ok((StatusCode::BAD_REQUEST, format!("bad payload: {error}"))
+                            .into_response())
+                    }
+                };
+                apply_github_comment_event(&state, event).await?
+            }
+            // Any other event type (pushes, etc.) is ignored.
+            _ => return Ok(StatusCode::OK.into_response()),
+        };
 
-    let event: GithubIssueEvent = match serde_json::from_slice(&body) {
-        Ok(event) => event,
-        Err(error) => {
-            return Ok((StatusCode::BAD_REQUEST, format!("bad payload: {error}")).into_response())
-        }
-    };
-
-    if apply_github_event(&state, event).await? {
+    if changed {
         state.notify_board();
     }
     Ok(StatusCode::OK.into_response())
@@ -107,34 +122,87 @@ async fn apply_github_event(state: &AppState, event: GithubIssueEvent) -> Result
                 .any(|wanted| wanted.eq_ignore_ascii_case(&label.name))
         });
 
+    let open_issue = event.issue.to_open_issue();
+    let labels = event.issue.label_names();
+    let mut changed = false;
+
     if event.issue.state == "open" && matches_labels {
-        let issue = git::OpenIssue {
-            number: event.issue.number,
-            title: event.issue.title,
-            body: event.issue.body.unwrap_or_default(),
-            url: event.issue.html_url,
-            author_login: event.issue.user.login,
-            author_avatar_url: event.issue.user.avatar_url,
-        };
         // upsert_github_issue also reflects a reopen (closed -> open) by returning
         // the card to Available.
-        orchestrator::upsert_github_issue(state, repo.id, &issue, "open").await?;
-        Ok(true)
+        orchestrator::upsert_github_issue(state, repo.id, &open_issue, "open").await?;
+        changed = true;
     } else if event.issue.state == "closed" {
         // Closed outside Seraphim: move the tracked card to Done.
-        Ok(orchestrator::reflect_closed_github_issue(state, repo.id, &external_id).await?)
+        changed |= orchestrator::reflect_closed_github_issue(state, repo.id, &external_id).await?;
     } else {
         // Open but filtered out by the repo's labels: keep the cached state
         // current without moving a card we may not even track.
-        Ok(queries::refresh_issue_external_state(
+        changed |= queries::refresh_issue_external_state(
             &state.db,
             SourceKind::Github,
             Some(repo.id),
             &external_id,
             &event.issue.state,
         )
-        .await?)
+        .await?;
     }
+
+    // Automation: a create/update rule may pull this open issue into To Do (even
+    // past the repo's label filter, since a matching rule ensures it is tracked).
+    if event.issue.state == "open" {
+        let trigger = if event.action == "opened" {
+            automation::Trigger::Created
+        } else {
+            automation::Trigger::Updated
+        };
+        if orchestrator::run_github_automation(
+            state,
+            &repo,
+            &open_issue,
+            &labels,
+            "open",
+            trigger,
+            "",
+            "",
+        )
+        .await?
+        {
+            changed = true;
+        }
+    }
+
+    Ok(changed)
+}
+
+/// `issue_comment` events: a comment posted on an issue, which can fire `comment`
+/// automation rules (e.g. a trigger phrase). Returns whether the board changed.
+async fn apply_github_comment_event(state: &AppState, event: GithubCommentEvent) -> Result<bool> {
+    // Only newly-posted comments fire rules; edits/deletes don't re-trigger.
+    if event.action != "created" || event.issue.state != "open" {
+        return Ok(false);
+    }
+    let Some(repo) =
+        queries::get_repository_by_full_name(&state.db, &event.repository.full_name).await?
+    else {
+        return Ok(false);
+    };
+    if !repo.enabled {
+        return Ok(false);
+    }
+
+    let open_issue = event.issue.to_open_issue();
+    let labels = event.issue.label_names();
+    orchestrator::run_github_automation(
+        state,
+        &repo,
+        &open_issue,
+        &labels,
+        "open",
+        automation::Trigger::Comment,
+        event.comment.body.as_deref().unwrap_or(""),
+        &event.comment.user.login,
+    )
+    .await
 }
 
 #[derive(Debug, Deserialize)]
@@ -158,6 +226,23 @@ struct GithubIssue {
     labels: Vec<GithubLabel>,
 }
 
+impl GithubIssue {
+    fn to_open_issue(&self) -> git::OpenIssue {
+        git::OpenIssue {
+            number: self.number,
+            title: self.title.clone(),
+            body: self.body.clone().unwrap_or_default(),
+            url: self.html_url.clone(),
+            author_login: self.user.login.clone(),
+            author_avatar_url: self.user.avatar_url.clone(),
+        }
+    }
+
+    fn label_names(&self) -> Vec<String> {
+        self.labels.iter().map(|label| label.name.clone()).collect()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct GithubUser {
     login: String,
@@ -167,6 +252,21 @@ struct GithubUser {
 #[derive(Debug, Deserialize)]
 struct GithubLabel {
     name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubCommentEvent {
+    action: String,
+    issue: GithubIssue,
+    comment: GithubComment,
+    repository: GithubRepo,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubComment {
+    #[serde(default)]
+    body: Option<String>,
+    user: GithubUser,
 }
 
 #[derive(Debug, Deserialize)]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,6 +4,7 @@
 //! the background loops (issue sync, the autonomous agent, and auto-merge review)
 //! and serves the REST + SSE surface the kanban UI talks to.
 
+mod automation;
 mod claude;
 mod config;
 mod db;

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -26,8 +26,11 @@ use futures::StreamExt;
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
+use crate::automation::{self, QueuePosition, RuleAction, RuleContext};
 use crate::claude::{run_turn, AgentEventKind, TurnArgs};
-use crate::db::models::{Repository, ReviewPolicy, SourceKind, Task, TaskColumn, TaskStatus};
+use crate::db::models::{
+    AutomationRule, Repository, ReviewPolicy, SourceKind, Task, TaskColumn, TaskStatus,
+};
 use crate::db::queries;
 use crate::git;
 use crate::secrets::Scrubber;
@@ -218,6 +221,97 @@ async fn top_of_column_position(state: &AppState, column: TaskColumn) -> Result<
         .await?
         .unwrap_or(0.0)
         - 1.0)
+}
+
+/// The position that places a card at the bottom of `column` (just below the
+/// current lowest).
+async fn bottom_of_column_position(state: &AppState, column: TaskColumn) -> Result<f64> {
+    Ok(queries::max_position_in_column(&state.db, column)
+        .await?
+        .unwrap_or(0.0)
+        + 1.0)
+}
+
+// --- Automation rules --------------------------------------------------------
+
+/// The short source name a rule's `source_kind` is matched against.
+fn source_name(source: SourceKind) -> &'static str {
+    match source {
+        SourceKind::Github => "github",
+        SourceKind::Jira => "jira",
+        SourceKind::Internal => "internal",
+    }
+}
+
+/// The action of the first enabled rule (in order) whose source, trigger, and
+/// conditions all match the event, or `None` if nothing matches.
+fn first_matching_action(
+    rules: &[AutomationRule],
+    source: SourceKind,
+    ctx: &RuleContext,
+) -> Option<QueuePosition> {
+    let name = source_name(source);
+    rules
+        .iter()
+        .filter(|rule| rule.source_kind == "any" || rule.source_kind == name)
+        .filter(|rule| rule.triggers.0.contains(&ctx.trigger))
+        .find(|rule| rule.criteria.0.matches(ctx))
+        .map(|rule| match &rule.action.0 {
+            RuleAction::MoveToTodo { position } => *position,
+        })
+}
+
+/// Evaluates the automation rules for a GitHub issue event. If a rule matches,
+/// the issue is ensured-tracked and moved to To Do (top or bottom of the queue),
+/// even if the repo's label filter would otherwise exclude it. Returns whether
+/// the board changed. Only meaningful for open issues.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_github_automation(
+    state: &AppState,
+    repo: &Repository,
+    issue: &git::OpenIssue,
+    labels: &[String],
+    issue_state: &str,
+    trigger: automation::Trigger,
+    comment: &str,
+    comment_author: &str,
+) -> Result<bool> {
+    let rules = queries::list_enabled_automation_rules(&state.db).await?;
+    if rules.is_empty() {
+        return Ok(false);
+    }
+
+    let ctx = RuleContext {
+        trigger,
+        repo: &repo.full_name,
+        author: &issue.author_login,
+        labels,
+        title: &issue.title,
+        body: &issue.body,
+        state: issue_state,
+        comment,
+        comment_author,
+    };
+    let Some(position) = first_matching_action(&rules, SourceKind::Github, &ctx) else {
+        return Ok(false);
+    };
+
+    // A rule matched: ensure the issue is tracked, then move its card to To Do.
+    upsert_github_issue(state, repo.id, issue, "open").await?;
+    let external_id = issue.number.to_string();
+    let Some(task) =
+        queries::find_issue_task(&state.db, SourceKind::Github, Some(repo.id), &external_id)
+            .await?
+    else {
+        return Ok(false);
+    };
+    let target = match position {
+        QueuePosition::Top => top_of_column_position(state, TaskColumn::Todo).await?,
+        QueuePosition::Bottom => bottom_of_column_position(state, TaskColumn::Todo).await?,
+    };
+    queries::move_task(&state.db, task.id, TaskColumn::Todo, target).await?;
+    info!(task_id = %task.id, ?position, "automation matched: moved issue to To Do");
+    Ok(true)
 }
 
 /// Upserts a GitHub issue as a task: a brand-new one lands at the top of

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,8 @@ import ky from 'ky'
 
 import type {
   AnswerKind,
+  AutomationRule,
+  AutomationTrigger,
   AvailabilityWindow,
   BoardResponse,
   ConfigBundle,
@@ -21,6 +23,9 @@ import type {
   RepoDeletionImpact,
   Repository,
   ReviewPolicy,
+  RuleAction,
+  RuleGroup,
+  RuleSource,
   Settings,
   Stats,
   Task,
@@ -287,6 +292,33 @@ export function recreateWorkspace() {
 
 export function provisionWorkspace() {
   return apiClient.post('workspace/provision').json()
+}
+
+// --- Automation rules --------------------------------------------------------
+
+export type RuleRequest = {
+  name: string
+  enabled: boolean
+  source_kind: RuleSource
+  triggers: AutomationTrigger[]
+  criteria: RuleGroup
+  action: RuleAction
+}
+
+export function listAutomationRules() {
+  return apiClient.get('automation/rules').json<AutomationRule[]>()
+}
+
+export function createAutomationRule(body: RuleRequest) {
+  return apiClient.post('automation/rules', { json: body }).json<AutomationRule>()
+}
+
+export function updateAutomationRule(id: string, body: RuleRequest) {
+  return apiClient.put(`automation/rules/${id}`, { json: body }).json<AutomationRule>()
+}
+
+export function deleteAutomationRule(id: string) {
+  return apiClient.delete(`automation/rules/${id}`)
 }
 
 // --- Config export / import --------------------------------------------------

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -298,6 +298,41 @@ export type PendingQuestion = {
   created_at: string
 }
 
+// --- Automation rules --------------------------------------------------------
+
+export type AutomationTrigger = 'created' | 'updated' | 'comment'
+export type RuleCombinator = 'and' | 'or'
+export type RuleField =
+  | 'labels'
+  | 'author'
+  | 'repo'
+  | 'title'
+  | 'body'
+  | 'comment'
+  | 'comment_author'
+  | 'state'
+export type RuleOperator = 'exactly' | 'contains' | 'has_one_of' | 'is_empty' | 'is_not_empty'
+export type QueuePosition = 'top' | 'bottom'
+// A rule's source: a real source kind or 'any' to match all.
+export type RuleSource = 'github' | 'jira' | 'internal' | 'any'
+
+export type RuleCondition = { field: RuleField; operator: RuleOperator; values: string[] }
+export type RuleGroup = { combinator: RuleCombinator; conditions: RuleCondition[] }
+export type RuleAction = { type: 'move_to_todo'; position: QueuePosition }
+
+export type AutomationRule = {
+  id: string
+  name: string
+  enabled: boolean
+  source_kind: RuleSource
+  triggers: AutomationTrigger[]
+  criteria: RuleGroup
+  action: RuleAction
+  position: number
+  created_at: string
+  updated_at: string
+}
+
 export type BoardResponse = {
   tasks: Task[]
   settings: Settings

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
   const links = [
     { href: '/', label: 'Board' },
     { href: '/watch', label: 'Watch' },
+    { href: '/automation', label: 'Automation' },
     { href: '/repos', label: 'Repositories' },
     { href: '/settings', label: 'Settings' }
   ]

--- a/frontend/src/routes/automation/+page.svelte
+++ b/frontend/src/routes/automation/+page.svelte
@@ -1,0 +1,350 @@
+<script lang="ts">
+  // The Automation page: create rulesets that react to issue events (created /
+  // updated / commented) and act on a match (today: move the card to To Do).
+  // Each rule is an inline, always-open editor; saving creates or updates it.
+  import type {
+    AutomationRule,
+    AutomationTrigger,
+    QueuePosition,
+    RuleCombinator,
+    RuleCondition,
+    RuleField,
+    RuleOperator,
+    RuleSource
+  } from '$lib/types'
+  import type { RuleRequest } from '$lib/api'
+
+  import { onMount } from 'svelte'
+  import { Plus, Trash2, Zap } from '@lucide/svelte'
+
+  import {
+    createAutomationRule,
+    deleteAutomationRule,
+    listAutomationRules,
+    updateAutomationRule
+  } from '$lib/api'
+  import * as Card from '$lib/components/ui/card'
+  import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Switch } from '$lib/components/ui/switch'
+  import { Label } from '$lib/components/ui/label'
+
+  // A condition while editing: values are kept as free text and parsed on save.
+  type ConditionDraft = { field: RuleField; operator: RuleOperator; valuesText: string }
+  type RuleDraft = {
+    id?: string
+    name: string
+    enabled: boolean
+    source_kind: RuleSource
+    triggers: AutomationTrigger[]
+    combinator: RuleCombinator
+    conditions: ConditionDraft[]
+    actionPosition: QueuePosition
+    saving: boolean
+    savedAt: string | null
+    error: string | null
+  }
+
+  let rules = $state<RuleDraft[]>([])
+  let loading = $state(true)
+
+  const FIELDS: { value: RuleField; label: string; placeholder: string; list: boolean }[] = [
+    { value: 'labels', label: 'Labels', placeholder: 'automation, bug', list: true },
+    { value: 'author', label: 'Author', placeholder: 'navarrotech', list: false },
+    { value: 'repo', label: 'Repository', placeholder: 'owner/repo', list: false },
+    { value: 'title', label: 'Title', placeholder: 'crash, regression', list: false },
+    { value: 'body', label: 'Body', placeholder: 'urgent', list: false },
+    { value: 'comment', label: 'Comment', placeholder: 'Jarvis, can you take this on?', list: false },
+    { value: 'comment_author', label: 'Comment author', placeholder: 'navarrotech', list: false },
+    { value: 'state', label: 'State', placeholder: 'open', list: false }
+  ]
+  const OPERATORS: { value: RuleOperator; label: string; needsValues: boolean }[] = [
+    { value: 'has_one_of', label: 'has one of', needsValues: true },
+    { value: 'exactly', label: 'is exactly', needsValues: true },
+    { value: 'contains', label: 'contains', needsValues: true },
+    { value: 'is_empty', label: 'is empty', needsValues: false },
+    { value: 'is_not_empty', label: 'is not empty', needsValues: false }
+  ]
+  const TRIGGERS: { value: AutomationTrigger; label: string }[] = [
+    { value: 'created', label: 'Created' },
+    { value: 'updated', label: 'Updated' },
+    { value: 'comment', label: 'Comment' }
+  ]
+  const SOURCES: { value: RuleSource; label: string }[] = [
+    { value: 'github', label: 'GitHub' },
+    { value: 'jira', label: 'Jira' },
+    { value: 'any', label: 'Any source' }
+  ]
+
+  const SELECT_CLASS =
+    'h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground focus:border-primary focus:outline-none'
+
+  function operatorNeedsValues(operator: RuleOperator): boolean {
+    return OPERATORS.find((entry) => entry.value === operator)?.needsValues ?? true
+  }
+  function fieldMeta(field: RuleField) {
+    return FIELDS.find((entry) => entry.value === field) ?? FIELDS[0]
+  }
+
+  function toDraft(rule: AutomationRule): RuleDraft {
+    return {
+      id: rule.id,
+      name: rule.name,
+      enabled: rule.enabled,
+      source_kind: rule.source_kind,
+      triggers: [...rule.triggers],
+      combinator: rule.criteria.combinator,
+      conditions: rule.criteria.conditions.map((condition) => ({
+        field: condition.field,
+        operator: condition.operator,
+        valuesText: condition.values.join(', ')
+      })),
+      actionPosition: rule.action.position,
+      saving: false,
+      savedAt: null,
+      error: null
+    }
+  }
+
+  function blankDraft(): RuleDraft {
+    return {
+      name: '',
+      enabled: true,
+      source_kind: 'github',
+      triggers: ['created'],
+      combinator: 'and',
+      conditions: [{ field: 'labels', operator: 'has_one_of', valuesText: '' }],
+      actionPosition: 'top',
+      saving: false,
+      savedAt: null,
+      error: null
+    }
+  }
+
+  function toRequest(draft: RuleDraft): RuleRequest {
+    const conditions: RuleCondition[] = draft.conditions.map((condition) => ({
+      field: condition.field,
+      operator: condition.operator,
+      values: operatorNeedsValues(condition.operator)
+        ? condition.valuesText
+            .split(',')
+            .map((value) => value.trim())
+            .filter((value) => value.length > 0)
+        : []
+    }))
+    return {
+      name: draft.name.trim() || 'Untitled rule',
+      enabled: draft.enabled,
+      source_kind: draft.source_kind,
+      triggers: draft.triggers,
+      criteria: { combinator: draft.combinator, conditions },
+      action: { type: 'move_to_todo', position: draft.actionPosition }
+    }
+  }
+
+  async function load() {
+    loading = true
+    try {
+      const fetched = await listAutomationRules()
+      rules = fetched.map(toDraft)
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(load)
+
+  function addRule() {
+    rules = [...rules, blankDraft()]
+  }
+
+  function addCondition(draft: RuleDraft) {
+    draft.conditions = [...draft.conditions, { field: 'labels', operator: 'has_one_of', valuesText: '' }]
+  }
+  function removeCondition(draft: RuleDraft, index: number) {
+    draft.conditions = draft.conditions.filter((_, i) => i !== index)
+  }
+  function toggleTrigger(draft: RuleDraft, trigger: AutomationTrigger) {
+    draft.triggers = draft.triggers.includes(trigger)
+      ? draft.triggers.filter((value) => value !== trigger)
+      : [...draft.triggers, trigger]
+  }
+
+  async function save(draft: RuleDraft) {
+    draft.saving = true
+    draft.error = null
+    try {
+      const body = toRequest(draft)
+      const saved = draft.id
+        ? await updateAutomationRule(draft.id, body)
+        : await createAutomationRule(body)
+      draft.id = saved.id
+      draft.savedAt = new Date().toLocaleTimeString()
+    } catch (error) {
+      console.error('failed to save rule', error)
+      draft.error = 'Failed to save. Check the rule and try again.'
+    } finally {
+      draft.saving = false
+    }
+  }
+
+  async function remove(draft: RuleDraft) {
+    if (draft.id) {
+      try {
+        await deleteAutomationRule(draft.id)
+      } catch (error) {
+        console.error('failed to delete rule', error)
+        return
+      }
+    }
+    rules = rules.filter((entry) => entry !== draft)
+  }
+</script>
+
+<div class="mx-auto max-w-4xl space-y-6 p-6">
+  <header class="flex items-start justify-between gap-4">
+    <div>
+      <h1 class="flex items-center gap-2 text-2xl font-bold tracking-tight">
+        <Zap class="size-6 text-primary" /> Automation
+      </h1>
+      <p class="mt-1 max-w-2xl text-sm text-muted-foreground">
+        Rules react to issue events from the realtime webhooks. When an issue is created, updated, or
+        commented on and a rule's conditions match, its action runs, for example moving the card to
+        the top of To Do. Try: <em>labels has one of "automation, bug" AND author is exactly
+        navarrotech</em>, or a comment that contains "Jarvis, can you take this on?".
+      </p>
+    </div>
+    <Button onclick={addRule}><Plus class="size-4" /> New rule</Button>
+  </header>
+
+  {#if loading}
+    <p class="text-muted-foreground">Loading…</p>
+  {:else if rules.length === 0}
+    <Card.Root>
+      <Card.Content class="py-10 text-center text-muted-foreground">
+        No rules yet. Click <span class="font-medium text-foreground">New rule</span> to create one.
+      </Card.Content>
+    </Card.Root>
+  {/if}
+
+  {#each rules as draft (draft)}
+    <Card.Root class={draft.enabled ? '' : 'opacity-70'}>
+      <Card.Content class="space-y-5 pt-6">
+        <!-- Name + enabled + source -->
+        <div class="flex flex-wrap items-center gap-3">
+          <Switch bind:checked={draft.enabled} aria-label="Enabled" />
+          <Input class="max-w-xs flex-1" placeholder="Rule name" bind:value={draft.name} />
+          <select class={SELECT_CLASS} bind:value={draft.source_kind} aria-label="Source">
+            {#each SOURCES as source}
+              <option value={source.value}>{source.label}</option>
+            {/each}
+          </select>
+          <button
+            type="button"
+            onclick={() => remove(draft)}
+            title="Delete rule"
+            aria-label="Delete rule"
+            class="ml-auto rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+          >
+            <Trash2 class="size-4" />
+          </button>
+        </div>
+
+        <!-- Triggers -->
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">On</span>
+          {#each TRIGGERS as trigger}
+            <button
+              type="button"
+              onclick={() => toggleTrigger(draft, trigger.value)}
+              aria-pressed={draft.triggers.includes(trigger.value)}
+              class="rounded-full border px-3 py-1 text-xs font-medium transition-colors {draft.triggers.includes(
+                trigger.value
+              )
+                ? 'border-primary bg-primary/15 text-primary'
+                : 'border-border text-muted-foreground hover:bg-secondary'}"
+            >
+              {trigger.label}
+            </button>
+          {/each}
+        </div>
+
+        <!-- Conditions -->
+        <div class="space-y-2 rounded-lg border border-border p-3">
+          <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Match
+            <select class={SELECT_CLASS} bind:value={draft.combinator} aria-label="Combinator">
+              <option value="and">all (AND)</option>
+              <option value="or">any (OR)</option>
+            </select>
+            of:
+          </div>
+
+          {#each draft.conditions as condition, index (index)}
+            {@const meta = fieldMeta(condition.field)}
+            <div class="flex flex-wrap items-center gap-2">
+              <select class={SELECT_CLASS} bind:value={condition.field} aria-label="Field">
+                {#each FIELDS as field}
+                  <option value={field.value}>{field.label}</option>
+                {/each}
+              </select>
+              <select class={SELECT_CLASS} bind:value={condition.operator} aria-label="Operator">
+                {#each OPERATORS as operator}
+                  <option value={operator.value}>{operator.label}</option>
+                {/each}
+              </select>
+              {#if operatorNeedsValues(condition.operator)}
+                <Input
+                  class="min-w-0 flex-1"
+                  placeholder={meta.list ? `${meta.placeholder} (comma-separated)` : meta.placeholder}
+                  bind:value={condition.valuesText}
+                />
+              {:else}
+                <span class="flex-1 text-sm text-muted-foreground">(no value needed)</span>
+              {/if}
+              <button
+                type="button"
+                onclick={() => removeCondition(draft, index)}
+                title="Remove condition"
+                aria-label="Remove condition"
+                class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+              >
+                <Trash2 class="size-4" />
+              </button>
+            </div>
+          {/each}
+
+          <Button variant="outline" size="sm" onclick={() => addCondition(draft)}>
+            <Plus class="size-4" /> Add condition
+          </Button>
+        </div>
+
+        <!-- Action -->
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Then</span>
+          <span class="text-sm">move the card to</span>
+          <select class={SELECT_CLASS} bind:value={draft.actionPosition} aria-label="Queue position">
+            <option value="top">the top</option>
+            <option value="bottom">the bottom</option>
+          </select>
+          <span class="text-sm">of To Do.</span>
+        </div>
+
+        <!-- Save -->
+        <div class="flex items-center gap-3 border-t border-border pt-4">
+          <Button onclick={() => save(draft)} disabled={draft.saving}>
+            {draft.saving ? 'Saving…' : draft.id ? 'Save' : 'Create rule'}
+          </Button>
+          {#if draft.error}
+            <span class="text-sm text-destructive">{draft.error}</span>
+          {:else if draft.savedAt}
+            <span class="text-sm text-muted-foreground">Saved at {draft.savedAt}</span>
+          {/if}
+          {#if !draft.triggers.length}
+            <span class="text-sm text-warning">Pick at least one trigger.</span>
+          {/if}
+        </div>
+      </Card.Content>
+    </Card.Root>
+  {/each}
+</div>


### PR DESCRIPTION
Closes #71.

## What
A dedicated **Automation** page (new navbar link) where you build rulesets that watch issue events and act when they match, e.g. the issue's example:

> ON create/update ISSUE, IF labels HAS ONE OF "automation" OR "bug" AND author IS EXACTLY navarrotech, THEN MOVE ITEM TO TODO ON top of the queue.

and the comment flow:

> when a comment contains the phrase "Jarvis, can you take this on?", move it to the bottom of the stack.

## The engine (`api/src/automation/`, pure + unit-tested)
- **Triggers:** `created` / `updated` / `comment`.
- **Condition group:** AND / OR of `{ field, operator, values }`.
- **Fields:** labels, author, repo, title, body, comment, comment author, state.
- **Operators:** is exactly, contains, has one of, is empty, is not empty (case-insensitive; list-aware for labels).
- **Action:** move the card to the **top** or **bottom** of To Do.
- **Multiple rules**, evaluated in order; the first match wins. **Source-agnostic** (a rule can target `github`, `jira`, or `any`).

The rule shape and the matcher are I/O-free and unit-tested (the issue's exact example, the comment phrase, AND/OR, every operator, JSON round-trip).

## Wiring (GitHub, webhook-driven)
Rules fire on the realtime webhook events, which is exactly the "ON create/update/comment" semantics and avoids the poll sync re-firing every cycle:
- The existing `issues` webhook fires `created` (opened) and `updated` (edited/labeled/...) rules.
- A new **`issue_comment`** webhook handler fires `comment` rules.
- When a rule matches, the issue is **ensured-tracked** (created if the repo's label filter would otherwise exclude it) and its card is **moved to To Do** at the chosen end. If nothing matches, there are **no side effects** (and zero overhead when no rules exist).

## Plumbing
- `automation_rules` table (migration `0027`): triggers / criteria / action stored as JSON, validated against the typed structs on read & write.
- CRUD endpoints (`/automation/rules`) + queries, `api.ts` client + types, the Automation page (an inline rule builder), and the navbar link.

## Scope / decisions
- **GitHub-first.** The engine is source-agnostic so Jira drops into the same `run_*_automation` path later; since Jira tickets aren't auto-worked yet (and their label/comment model differs), only GitHub events are wired now. Rules can still be authored for `any`/`jira` (they just won't fire until Jira events call the engine).
- **Webhook-driven.** Automation requires the GitHub webhook (already a feature). The poll sync deliberately does not fire rules (it would re-fire on every pass).

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings from the new code) / `test` (64 passed, incl. 6 new engine tests). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass. The end-to-end webhook -> move needs a live GitHub webhook to observe (no CI harness for that here); the matcher, CRUD, and UI build green.