### PR TITLE
Fix live-stats context % overflow and usage-limit gauge (closes #154)

### DIFF
--- a/api/src/http/stats.rs
+++ b/api/src/http/stats.rs
@@ -3,10 +3,11 @@
 //!
 //! Several pieces lean on what we actually capture: cost and per-turn token usage
 //! (which also drive cost) come from each turn's terminal `result` event, time is
-//! summed turn elapsed time, the context gauge measures the latest turn's tokens
-//! against the model's window, and the usage gauge reads the latest rate-limit
-//! notice's global utilization. These are session/global totals; Seraphim runs
-//! one shared Claude session, so they are not split per task or per source.
+//! summed turn elapsed time, the context gauge measures the latest turn's largest
+//! single-request prompt against the model's window, and the usage gauge reads the
+//! latest rate-limit notice's utilization when present, otherwise its categorical
+//! status. These are session/global totals; Seraphim runs one shared Claude
+//! session, so they are not split per task or per source.
 
 use axum::extract::{Path, State};
 use axum::Json;
@@ -42,6 +43,9 @@ pub struct StatsResponse {
     pub usage_utilization: Option<f64>,
     /// When the usage window resets (unix seconds), if known.
     pub usage_resets_at: Option<i64>,
+    /// The rate-limit status (e.g. "allowed") when the stream reports no numeric
+    /// utilization, so the UI can show a status instead of a misleading 0%.
+    pub usage_status: Option<String>,
     pub turns: i64,
 }
 
@@ -55,16 +59,37 @@ fn context_window(model: &str) -> i64 {
     }
 }
 
-/// The context size a turn's `usage` block implies: the input it sent, cached or
-/// not, which is the conversation currently in the window.
-fn context_tokens(usage: &Value) -> i64 {
+/// The prompt size of a single API request: its fresh input plus cached tokens.
+fn request_total(usage: &Value) -> i64 {
     let field = |key: &str| usage.get(key).and_then(Value::as_i64).unwrap_or(0);
     field("input_tokens") + field("cache_creation_input_tokens") + field("cache_read_input_tokens")
 }
 
-/// Pulls `(utilization 0-100, resetsAt)` from a rate-limit event payload. The
-/// utilization may arrive as a fraction (0-1) or a percentage (0-100).
-fn rate_limit_fields(payload: &Value) -> (Option<f64>, Option<i64>) {
+/// The context-window occupancy a turn's `usage` block implies: a single API
+/// request's prompt size (input + cache), not the whole turn's total.
+///
+/// A turn is one `claude -p` run that makes many internal API requests; the
+/// top-level `usage` sums them, and `cache_read_input_tokens` re-counts the
+/// cached context on every request, so the total runs to many times the window.
+/// The real occupancy is one request's prompt, so take the largest per-request
+/// total from the `iterations` breakdown, falling back to the top-level totals
+/// only for a single-request turn that carries no `iterations`.
+fn context_tokens(usage: &Value) -> i64 {
+    usage
+        .get("iterations")
+        .and_then(Value::as_array)
+        .and_then(|requests| requests.iter().map(request_total).max())
+        .filter(|&largest| largest > 0)
+        .unwrap_or_else(|| request_total(usage))
+}
+
+/// Pulls `(utilization 0-100, resetsAt, status)` from a rate-limit event payload.
+///
+/// The headless `claude -p` stream reports a categorical `status` and a reset
+/// time but usually no numeric `utilization`, so the percentage is often `None`
+/// and the UI falls back to the status. When utilization is present it may arrive
+/// as a fraction (0-1) or a percentage (0-100).
+fn rate_limit_fields(payload: &Value) -> (Option<f64>, Option<i64>, Option<String>) {
     let info = payload.get("rate_limit_info").unwrap_or(payload);
     let utilization = info
         .get("utilization")
@@ -74,7 +99,11 @@ fn rate_limit_fields(payload: &Value) -> (Option<f64>, Option<i64>) {
             percent.clamp(0.0, 100.0)
         });
     let resets_at = info.get("resetsAt").and_then(Value::as_i64);
-    (utilization, resets_at)
+    let status = info
+        .get("status")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    (utilization, resets_at, status)
 }
 
 fn build_response(
@@ -86,7 +115,8 @@ fn build_response(
     live_usage: Option<LiveUsage>,
 ) -> StatsResponse {
     let input_total = agg.input_tokens + agg.cache_creation_tokens + agg.cache_read_tokens;
-    let (usage_utilization, usage_resets_at) = rate_limit.map_or((None, None), rate_limit_fields);
+    let (usage_utilization, usage_resets_at, usage_status) =
+        rate_limit.map_or((None, None, None), rate_limit_fields);
 
     // Overlay the in-progress turn's live usage (if any) on top of the persisted,
     // completed-turn totals so the counter ticks mid-turn. Only output is added to
@@ -110,6 +140,7 @@ fn build_response(
         context_window: context_window(&settings.claude_model),
         usage_utilization,
         usage_resets_at,
+        usage_status,
         turns: agg.turns,
     }
 }

--- a/frontend/src/lib/components/Stats.svelte
+++ b/frontend/src/lib/components/Stats.svelte
@@ -60,9 +60,14 @@
   })
 
   const contextPct = $derived(
-    stats && stats.context_window > 0 ? (stats.context_tokens / stats.context_window) * 100 : 0
+    stats && stats.context_window > 0
+      ? Math.min(100, Math.max(0, (stats.context_tokens / stats.context_window) * 100))
+      : 0
   )
   const usagePct = $derived(stats?.usage_utilization ?? 0)
+  // When the headless stream reports no numeric utilization, fall back to its
+  // categorical status (e.g. "allowed") rather than a misleading 0%.
+  const usageStatusLabel = $derived(stats?.usage_status?.replace(/_/g, ' ') ?? 'Unknown')
 
   // SVG donut geometry (radius 42 in a 0..100 viewBox).
   const RADIUS = 42
@@ -152,12 +157,27 @@
     <div
       class="flex flex-wrap items-center justify-around gap-x-8 gap-y-4 border-t border-border px-4 py-4"
     >
-      {@render gauge(
-        usagePct,
-        'Usage limit',
-        usageColor(usagePct),
-        `Subscription usage limit: ${pctLabel(usagePct)} used${resetsLabel(stats.usage_resets_at)}. This is the whole subscription (all terminals), not just Seraphim.`
-      )}
+      {#if stats.usage_utilization != null}
+        {@render gauge(
+          usagePct,
+          'Usage limit',
+          usageColor(usagePct),
+          `Subscription usage limit: ${pctLabel(usagePct)} used${resetsLabel(stats.usage_resets_at)}. This is the whole subscription (all terminals), not just Seraphim.`
+        )}
+      {:else}
+        <!-- The headless agent stream reports a status, not a percentage. -->
+        <div
+          class="flex flex-col items-center gap-1.5"
+          title={`Subscription rate-limit status from the agent stream${resetsLabel(stats.usage_resets_at)}. The headless stream reports a status, not a percentage.`}
+        >
+          <div class="flex size-20 items-center justify-center rounded-full border-[9px] border-border">
+            <span class="px-1 text-center text-xs font-semibold capitalize leading-tight">
+              {usageStatusLabel}
+            </span>
+          </div>
+          <span class="text-xs text-muted-foreground">Usage limit</span>
+        </div>
+      {/if}
 
       {@render gauge(
         contextPct,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -238,6 +238,8 @@ export type Stats = {
   // Subscription usage-limit utilization (0-100), or null when unknown.
   usage_utilization: number | null
   usage_resets_at: number | null
+  // Rate-limit status (e.g. "allowed") shown when the stream reports no number.
+  usage_status: string | null
   turns: number
 }
 


### PR DESCRIPTION
## What

Fixes the two wrong numbers in the live agent statistics (#74): a context gauge that overflowed to **999.7%** globally / **248.3%** on a 3-minute task, and a usage-limit gauge stuck at **0.0%**.

## Context % overflow

`context_tokens()` summed the turn's `result` usage (`input + cache_creation + cache_read`). But a Seraphim turn is one `claude -p` run that makes many internal API requests, and the result usage is the **sum across all of them** - `cache_read_input_tokens` re-counts the cached context on every request, so the total reached millions (2.48M on the reported task). The real occupancy is a single request's prompt size, and the result's `iterations[]` breakdown carries it (~505K ≈ 50% on that task). `context_tokens()` now takes the max per-request total from `iterations`, falling back to the top-level totals only for a single-request turn, and the frontend gauge is clamped to [0, 100]%.

## Usage-limit 0%

The headless `claude -p` `rate_limit_event` payload has no `utilization` field - only `status: "allowed"`, `rateLimitType`, and reset times. `rate_limit_fields()` read a `utilization` that never exists, so the gauge always showed 0.0%. The numeric percentage in the interactive CLI comes from telemetry that is not in the `-p` stream. The API now also returns `usage_status`, and the frontend shows the status + reset countdown instead of a fake percentage when no number is available. The orchestrator's auto-pause already keys off `status` (`orchestrator/usage.rs`), so it is unaffected.

Backend `cargo +1.88 fmt`/`clippy`/`test` (58 tests) and frontend `yarn check`/`build` pass.

Closes #154
