### PR TITLE
Add an in-app self-update (#67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,17 @@ TS_HOSTNAME=seraphim
 # socket. The in-container path is the same on Linux and Docker Desktop/Windows.
 DOCKER_SOCKET=/var/run/docker.sock
 
+# --- Self-update --------------------------------------------------------------
+# The in-app "Update" button (Settings -> Updates) launches a short-lived updater
+# container that bind-mounts this HOST path to the cloned repo and runs
+# `git pull` + `docker compose up -d --build`. scripts/start.sh fills this in
+# automatically (the repo root), so you only need to set it when starting the
+# stack some other way, or when the auto-detected path isn't Docker-mountable.
+#   Linux:    /home/youruser/Seraphim
+#   Windows:  C:/Users/youruser/Seraphim
+# Leave blank to disable the in-app update (the version check still works).
+HOST_REPO_DIR=
+
 # --- Org profile bootstrap ----------------------------------------------------
 # Seeds the initial environment profile on first run (editable later in the UI).
 # Examples: JalapenoLabs, MooreslabAI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,17 @@ built on demand from the DB token, and the agent's `claude`/`git` execs get the
 tokens injected as env at call time. Migrations are embedded at compile time
 (`sqlx::migrate!`) and run on API boot.
 
+**Self-update** (Settings -> Updates, `src/update/`): the running image is stamped
+with `GIT_SHA`/`GIT_BRANCH` (compose build args set by `scripts/start.sh` from
+host git, baked in `api/Dockerfile`). The hourly check compares that to the
+branch's latest commit via the GitHub API. The "Update" button refuses while a
+turn is in progress, pauses the agent, then launches a detached `docker:cli`
+**updater container** (via the Docker socket) that bind-mounts the host repo
+(`HOST_REPO_DIR`) + socket + `SSH_HOME` and runs `git pull` + `docker compose up
+-d --build`; being outside the compose project, it survives the API being rebuilt.
+The UI then polls `/version` and reloads when the commit changes. `HOST_REPO_DIR`
+is the only new required env for the in-app update (the check works without it).
+
 ## Local dev / checks (must pass before committing)
 
 ```bash

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,5 +28,14 @@ RUN apt-get update \
 
 COPY --from=builder /app/target/release/seraphim-api /usr/local/bin/seraphim-api
 
+# Stamp the commit/branch this image was built from (passed by scripts/start.sh
+# and the self-updater) so the running API knows its version for the update check
+# and the "reload when done" signal. Placed after the binary copy so a new stamp
+# never busts the build cache.
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+ENV GIT_SHA=$GIT_SHA \
+    GIT_BRANCH=$GIT_BRANCH
+
 EXPOSE 27182
 CMD ["seraphim-api"]

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -19,6 +19,31 @@ pub struct Config {
     /// recommendations. Defaults to the compose service address (`api:27182`),
     /// reachable on the shared Docker network.
     pub internal_api_url: String,
+    /// Self-update settings: where the running build came from and how to rebuild.
+    pub update: UpdateConfig,
+}
+
+/// What the self-update needs: the commit/branch the running image was built from
+/// (baked at build time) and the host paths the updater container bind-mounts to
+/// `git pull` + `docker compose up -d --build`.
+#[derive(Debug, Clone)]
+pub struct UpdateConfig {
+    /// The commit the running image was built from (`unknown` if not stamped).
+    pub git_sha: String,
+    /// The branch the running image was built from (`unknown` if not stamped).
+    pub git_branch: String,
+    /// `owner/repo` on GitHub to check for newer commits.
+    pub repo: String,
+    /// Absolute HOST path to the checked-out repo, bind-mounted into the updater
+    /// so it can `git pull` + rebuild. Empty disables the actual update (the
+    /// version check still works).
+    pub host_repo_dir: String,
+    /// HOST path to `~/.ssh`, mounted read-only so the updater's `git pull` can use
+    /// SSH credentials (mirrors the workspace). Empty skips the mount.
+    pub ssh_home: String,
+    /// HOST path to the Docker socket, mounted into the updater so it can drive
+    /// the daemon (`docker compose`).
+    pub docker_socket: String,
 }
 
 impl Config {
@@ -34,6 +59,16 @@ impl Config {
                 .unwrap_or_else(|_| "seraphim-workspace".to_string()),
             internal_api_url: env::var("INTERNAL_API_URL")
                 .unwrap_or_else(|_| "http://api:27182".to_string()),
+            update: UpdateConfig {
+                git_sha: env::var("GIT_SHA").unwrap_or_else(|_| "unknown".to_string()),
+                git_branch: env::var("GIT_BRANCH").unwrap_or_else(|_| "unknown".to_string()),
+                repo: env::var("SERAPHIM_REPO")
+                    .unwrap_or_else(|_| "JalapenoLabs/Seraphim".to_string()),
+                host_repo_dir: env::var("HOST_REPO_DIR").unwrap_or_default(),
+                ssh_home: env::var("SSH_HOME").unwrap_or_default(),
+                docker_socket: env::var("DOCKER_SOCKET")
+                    .unwrap_or_else(|_| "/var/run/docker.sock".to_string()),
+            },
         })
     }
 }

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -540,6 +540,16 @@ pub async fn list_tasks(pool: &PgPool) -> sqlx::Result<Vec<Task>> {
         .await
 }
 
+/// Whether the agent is mid-turn (a card sits in the In Progress lane). Used to
+/// block a self-update while work is actively running.
+pub async fn any_task_in_progress(pool: &PgPool) -> sqlx::Result<bool> {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM tasks WHERE board_column = 'in_progress')",
+    )
+    .fetch_one(pool)
+    .await
+}
+
 pub async fn get_task(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Task>> {
     sqlx::query_as::<_, Task>("SELECT * FROM tasks WHERE id = $1")
         .bind(id)

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -15,6 +15,7 @@ mod sse;
 mod stats;
 mod suggestions;
 mod tasks;
+mod update;
 mod webhooks;
 mod workspace;
 
@@ -110,6 +111,10 @@ pub fn router(state: AppState) -> Router {
         .route("/workspace/recreate", post(workspace::recreate))
         .route("/workspace/provision", post(workspace::provision))
         .route("/agent/reset", post(workspace::reset))
+        .route("/version", get(update::version))
+        .route("/update/status", get(update::status))
+        .route("/update/check", post(update::check))
+        .route("/update", post(update::run))
         .route("/export", get(data::export))
         .route("/import", post(data::import))
         .with_state(state);

--- a/api/src/http/update.rs
+++ b/api/src/http/update.rs
@@ -1,0 +1,89 @@
+//! Self-update endpoints: report the running version, check for a newer one, and
+//! trigger the rebuild. The actual work happens in [`crate::update`].
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use serde_json::json;
+
+use super::ApiResult;
+use crate::db::queries;
+use crate::state::{AppState, UpdateStatus};
+use crate::update;
+
+#[derive(Serialize)]
+pub struct VersionResponse {
+    sha: String,
+    branch: String,
+}
+
+/// `GET /api/v1/version` - the commit/branch the running build came from. The UI
+/// polls this after triggering an update and reloads once the SHA changes.
+pub async fn version(State(state): State<AppState>) -> Json<VersionResponse> {
+    Json(VersionResponse {
+        sha: state.update.git_sha.clone(),
+        branch: state.update.git_branch.clone(),
+    })
+}
+
+#[derive(Serialize)]
+pub struct UpdateStatusResponse {
+    #[serde(flatten)]
+    status: UpdateStatus,
+    /// Whether the agent is paused (a prerequisite for updating).
+    agent_paused: bool,
+    /// Whether a turn is actively running (the Update button is disabled then).
+    agent_working: bool,
+}
+
+async fn status_response(state: &AppState) -> ApiResult<UpdateStatusResponse> {
+    let settings = queries::get_settings(&state.db).await?;
+    let working = queries::any_task_in_progress(&state.db).await?;
+    Ok(UpdateStatusResponse {
+        status: state.update_status(),
+        agent_paused: settings.agent_paused,
+        agent_working: working,
+    })
+}
+
+/// `GET /api/v1/update/status` - the cached check result + live agent state.
+pub async fn status(State(state): State<AppState>) -> ApiResult<Json<UpdateStatusResponse>> {
+    Ok(Json(status_response(&state).await?))
+}
+
+/// `POST /api/v1/update/check` - re-check for updates right now.
+pub async fn check(State(state): State<AppState>) -> ApiResult<Json<UpdateStatusResponse>> {
+    update::check(&state).await?;
+    Ok(Json(status_response(&state).await?))
+}
+
+/// `POST /api/v1/update` - pull the latest source and rebuild the stack. Refuses
+/// while the agent is mid-turn; pauses the agent before the rebuild begins.
+pub async fn run(State(state): State<AppState>) -> ApiResult<Response> {
+    if queries::any_task_in_progress(&state.db).await? {
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "The agent is working. Wait for it to finish (or pause it) before updating."
+            })),
+        )
+            .into_response());
+    }
+    if state.update.host_repo_dir.trim().is_empty() {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Self-update isn't configured: set HOST_REPO_DIR in .env." })),
+        )
+            .into_response());
+    }
+
+    // The agent must be paused before the rebuild begins (so nothing new starts
+    // while the stack is coming down and back up).
+    queries::set_paused(&state.db, true).await?;
+    state.notify_board();
+
+    update::trigger(&state).await?;
+    Ok((StatusCode::ACCEPTED, Json(json!({ "status": "updating" }))).into_response())
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -14,6 +14,7 @@ mod jira;
 mod orchestrator;
 mod secrets;
 mod state;
+mod update;
 
 use eyre::{Context, Result};
 use mimalloc::MiMalloc;
@@ -48,8 +49,14 @@ async fn main() -> Result<()> {
         settings.workspace_image_tag.clone(),
     )?;
 
-    let state = AppState::new(db, workspace, config.internal_api_url.clone());
+    let state = AppState::new(
+        db,
+        workspace,
+        config.internal_api_url.clone(),
+        config.update.clone(),
+    );
     orchestrator::spawn(state.clone());
+    update::spawn_check_loop(state.clone());
 
     let listener = tokio::net::TcpListener::bind(&config.api_bind)
         .await

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -81,11 +81,48 @@ pub struct AppState {
     /// post-turn handling (session persist, task move) if it changed, so a reset
     /// that lands mid-turn is never undone by the turn it interrupted.
     reset_epoch: Arc<AtomicU64>,
+    /// Static self-update config (the build's commit/branch + host paths).
+    pub update: crate::config::UpdateConfig,
+    /// The cached result of the last self-update check, refreshed hourly.
+    update_status: Arc<RwLock<UpdateStatus>>,
+}
+
+/// The cached result of the last self-update check, plus whether an update is
+/// running. Refreshed hourly in the background and on demand from the UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateStatus {
+    /// The commit the running build is on (`unknown` if not stamped at build).
+    pub current_sha: String,
+    pub current_branch: String,
+    /// The latest commit on the branch upstream, when the last check succeeded.
+    pub latest_sha: Option<String>,
+    pub update_available: bool,
+    /// Whether self-update is wired up (a host repo dir is set) so it can run.
+    pub configured: bool,
+    /// True from the moment an update is triggered until this process is replaced.
+    pub updating: bool,
+    pub checked_at: Option<DateTime<Utc>>,
+    pub error: Option<String>,
 }
 
 impl AppState {
-    pub fn new(db: PgPool, workspace: Workspace, internal_api_url: String) -> Self {
+    pub fn new(
+        db: PgPool,
+        workspace: Workspace,
+        internal_api_url: String,
+        update: crate::config::UpdateConfig,
+    ) -> Self {
         let (events, _receiver) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        let update_status = UpdateStatus {
+            current_sha: update.git_sha.clone(),
+            current_branch: update.git_branch.clone(),
+            latest_sha: None,
+            update_available: false,
+            configured: !update.host_repo_dir.trim().is_empty(),
+            updating: false,
+            checked_at: None,
+            error: None,
+        };
         Self {
             db,
             workspace,
@@ -94,7 +131,25 @@ impl AppState {
             cooldown_until: Arc::new(RwLock::new(None)),
             live_usage: Arc::new(RwLock::new(None)),
             reset_epoch: Arc::new(AtomicU64::new(0)),
+            update,
+            update_status: Arc::new(RwLock::new(update_status)),
         }
+    }
+
+    /// The cached self-update status.
+    pub fn update_status(&self) -> UpdateStatus {
+        self.update_status
+            .read()
+            .expect("update status lock poisoned")
+            .clone()
+    }
+
+    /// Replaces the cached self-update status.
+    pub fn set_update_status(&self, status: UpdateStatus) {
+        *self
+            .update_status
+            .write()
+            .expect("update status lock poisoned") = status;
     }
 
     /// The current hard-reset generation. A turn captures this at its start and

--- a/api/src/update/mod.rs
+++ b/api/src/update/mod.rs
@@ -1,0 +1,190 @@
+//! Self-update: check whether a newer commit is on the deployed branch, and,
+//! when asked, rebuild the stack from the latest source.
+//!
+//! The API container can drive the host Docker daemon (via the mounted socket)
+//! but has no git or repo source of its own, so the actual update runs in a
+//! short-lived **updater container**: it bind-mounts the host repo, runs
+//! `git pull` (honoring the checked-out branch), then `docker compose up -d
+//! --build`. Because that container is started directly (not part of the compose
+//! project), it survives the API container being rebuilt out from under it.
+//!
+//! The version check is lighter: it asks GitHub for the branch's latest commit
+//! and compares it to the commit baked into the running image (`GIT_SHA`).
+
+use std::time::Duration;
+
+use eyre::{eyre, Context, Result};
+use futures::StreamExt;
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use crate::state::{AppState, UpdateStatus};
+
+/// How often the background check refreshes the cached status.
+const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// The image the updater container runs from: the Docker CLI (Alpine), to which
+/// we add git + the compose plugin at start. It drives the host daemon to rebuild.
+const UPDATER_IMAGE_REPO: &str = "docker";
+const UPDATER_IMAGE_TAG: &str = "cli";
+
+/// Spawns the background loop that re-checks for updates every hour (and once at
+/// boot), keeping [`AppState`]'s cached status fresh whenever the UI opens.
+pub fn spawn_check_loop(state: AppState) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(error) = check(&state).await {
+                warn!(error = %error, "scheduled update check failed");
+            }
+            tokio::time::sleep(CHECK_INTERVAL).await;
+        }
+    });
+}
+
+/// Checks GitHub for a newer commit on the deployed branch and refreshes the
+/// cached status. Returns the new status. Never errors the caller for a transient
+/// GitHub hiccup; that is recorded on the status instead.
+pub async fn check(state: &AppState) -> Result<UpdateStatus> {
+    let cfg = &state.update;
+    let mut status = state.update_status();
+    status.current_sha.clone_from(&cfg.git_sha);
+    status.current_branch.clone_from(&cfg.git_branch);
+    status.configured = !cfg.host_repo_dir.trim().is_empty();
+    status.checked_at = Some(chrono::Utc::now());
+    status.error = None;
+    status.update_available = false;
+    status.latest_sha = None;
+
+    if cfg.git_sha.is_empty() || cfg.git_sha == "unknown" {
+        status.error = Some(
+            "This build isn't version-stamped, so updates can't be detected. \
+             Deploy with scripts/start.sh so the commit is baked in."
+                .to_string(),
+        );
+        state.set_update_status(status.clone());
+        return Ok(status);
+    }
+
+    let Some((owner, repo)) = cfg.repo.split_once('/') else {
+        status.error = Some(format!("update repo '{}' is not owner/repo", cfg.repo));
+        state.set_update_status(status.clone());
+        return Ok(status);
+    };
+    let branch = match cfg.git_branch.as_str() {
+        "" | "unknown" => "main",
+        branch => branch,
+    };
+
+    match latest_commit_sha(state, owner, repo, branch).await {
+        Ok(latest) => {
+            status.update_available = !latest.eq_ignore_ascii_case(&cfg.git_sha);
+            status.latest_sha = Some(latest);
+        }
+        Err(error) => status.error = Some(format!("update check failed: {error}")),
+    }
+    state.set_update_status(status.clone());
+    Ok(status)
+}
+
+/// The latest commit SHA on `branch` of `owner/repo`, via the stored GitHub token.
+async fn latest_commit_sha(
+    state: &AppState,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+) -> Result<String> {
+    #[derive(Deserialize)]
+    struct CommitRef {
+        sha: String,
+    }
+    let octo = state.github().await?;
+    let commit: CommitRef = octo
+        .get(
+            format!("/repos/{owner}/{repo}/commits/{branch}"),
+            None::<&()>,
+        )
+        .await
+        .wrap_err("failed to read the branch's latest commit")?;
+    Ok(commit.sha)
+}
+
+/// Launches the detached updater container that pulls the latest source and
+/// rebuilds the stack. The caller has already confirmed the agent is paused and
+/// idle. Marks the cached status as `updating` so the UI reflects it until the
+/// new build replaces this process.
+pub async fn trigger(state: &AppState) -> Result<()> {
+    let cfg = &state.update;
+    if cfg.host_repo_dir.trim().is_empty() {
+        return Err(eyre!(
+            "HOST_REPO_DIR is not set, so the API can't reach the repo to rebuild it. \
+             Set it in .env (the host path to the cloned repo) and restart."
+        ));
+    }
+
+    let docker = state.workspace.docker();
+    pull_image(docker).await?;
+
+    // git+ssh are required; the compose plugin is usually already in docker:cli,
+    // so its install is best-effort. Then pull (honoring the branch) and rebuild.
+    let script = "set -e\n\
+        apk add --no-cache git openssh-client >/dev/null 2>&1\n\
+        apk add --no-cache docker-cli-compose >/dev/null 2>&1 || true\n\
+        git config --global --add safe.directory /repo\n\
+        export GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'\n\
+        cd /repo\n\
+        git pull --ff-only\n\
+        export GIT_SHA=\"$(git rev-parse HEAD)\"\n\
+        export GIT_BRANCH=\"$(git rev-parse --abbrev-ref HEAD)\"\n\
+        docker compose up -d --build\n"
+        .to_string();
+
+    let mut binds = vec![
+        format!("{}:/repo", cfg.host_repo_dir),
+        format!("{}:/var/run/docker.sock", cfg.docker_socket),
+    ];
+    if !cfg.ssh_home.trim().is_empty() {
+        binds.push(format!("{}:/root/.ssh:ro", cfg.ssh_home));
+    }
+
+    let config: bollard::container::Config<String> = bollard::container::Config {
+        image: Some(format!("{UPDATER_IMAGE_REPO}:{UPDATER_IMAGE_TAG}")),
+        cmd: Some(vec!["sh".to_string(), "-c".to_string(), script]),
+        host_config: Some(bollard::models::HostConfig {
+            binds: Some(binds),
+            // The updater removes itself once the rebuild finishes.
+            auto_remove: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let created = docker
+        .create_container::<String, String>(None, config)
+        .await
+        .wrap_err("failed to create the updater container")?;
+    docker
+        .start_container::<String>(&created.id, None)
+        .await
+        .wrap_err("failed to start the updater container")?;
+
+    let mut status = state.update_status();
+    status.updating = true;
+    state.set_update_status(status);
+    info!(container = %created.id, "self-update launched (git pull + compose rebuild)");
+    Ok(())
+}
+
+/// Pulls the updater image so `create_container` finds it. Pulling an
+/// already-present image just refreshes it.
+async fn pull_image(docker: &bollard::Docker) -> Result<()> {
+    let options = bollard::image::CreateImageOptions {
+        from_image: UPDATER_IMAGE_REPO,
+        tag: UPDATER_IMAGE_TAG,
+        ..Default::default()
+    };
+    let mut stream = docker.create_image(Some(options), None, None);
+    while let Some(item) = stream.next().await {
+        item.wrap_err("failed to pull the updater image")?;
+    }
+    Ok(())
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
     container_name: seraphim-api
     build:
       context: ./api
+      args:
+        # The commit/branch this image is built from, stamped in so the running
+        # API can detect updates and signal when a rebuild has landed. Set by
+        # scripts/start.sh (and the self-updater) from host git.
+        GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_BRANCH: ${GIT_BRANCH:-unknown}
     restart: unless-stopped
     environment:
       DATABASE_URL: ${DATABASE_URL}
@@ -42,6 +48,13 @@ services:
       # Name of the workspace container the API drives via `docker exec`.
       WORKSPACE_CONTAINER: seraphim-workspace
       RUST_LOG: info,seraphim_api=debug
+      # Self-update: the API launches an updater container that bind-mounts these
+      # HOST paths to git pull + `docker compose up -d --build`. HOST_REPO_DIR is
+      # the host path to this checked-out repo (scripts/start.sh sets it to the
+      # repo root; override in .env if needed, e.g. on Windows).
+      HOST_REPO_DIR: ${HOST_REPO_DIR:-}
+      SSH_HOME: ${SSH_HOME}
+      DOCKER_SOCKET: ${DOCKER_SOCKET}
     ports:
       - "${API_PORT}:27182"
     volumes:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -293,6 +293,40 @@ export function resetAgent(purgeMemories: boolean) {
   return apiClient.post('agent/reset', { json: { purge_memories: purgeMemories } }).json()
 }
 
+// --- Self-update -------------------------------------------------------------
+
+export type UpdateStatus = {
+  current_sha: string
+  current_branch: string
+  latest_sha: string | null
+  update_available: boolean
+  // Whether the in-app update is wired up (HOST_REPO_DIR set).
+  configured: boolean
+  updating: boolean
+  checked_at: string | null
+  error: string | null
+  agent_paused: boolean
+  agent_working: boolean
+}
+
+export function getUpdateStatus() {
+  return apiClient.get('update/status').json<UpdateStatus>()
+}
+
+export function checkForUpdate() {
+  return apiClient.post('update/check').json<UpdateStatus>()
+}
+
+export function runUpdate() {
+  return apiClient.post('update').json<{ status: string }>()
+}
+
+export type VersionInfo = { sha: string; branch: string }
+
+export function getVersion() {
+  return apiClient.get('version').json<VersionInfo>()
+}
+
 // --- Config export / import --------------------------------------------------
 
 export function exportConfig() {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -10,7 +10,7 @@
     Settings,
     TaskColumn
   } from '$lib/types'
-  import type { EnvVarWrite } from '$lib/api'
+  import type { EnvVarWrite, UpdateStatus } from '$lib/api'
 
   import { onMount } from 'svelte'
 
@@ -18,10 +18,13 @@
   import { WEEKDAYS, minutesToTime, timeToMinutes } from '$lib/schedule'
   import { usFederalHolidays } from '$lib/holidays'
   import {
+    checkForUpdate,
     deleteJiraBoard,
     discoverJiraBoards,
     exportConfig,
     getSettings,
+    getUpdateStatus,
+    getVersion,
     importConfig,
     listEnvVars,
     listJiraBoards,
@@ -30,6 +33,7 @@
     resetAgent,
     resetStats,
     restartWorkspace,
+    runUpdate,
     setEnvVars,
     setTokens,
     testJira,
@@ -62,6 +66,7 @@
     { id: 'statistics', label: 'Statistics' },
     { id: 'env', label: 'Environment variables' },
     { id: 'workspace', label: 'Workspace' },
+    { id: 'updates', label: 'Updates' },
     { id: 'backup', label: 'Backup & restore' }
   ] as const
 
@@ -549,7 +554,74 @@
     input.value = ''
   }
 
-  onMount(load)
+  // --- Self-update -----------------------------------------------------------
+  let updateStatus = $state<UpdateStatus | null>(null)
+  let checkingUpdate = $state(false)
+  let updateMessage = $state<string | null>(null)
+  // True from clicking Update until the new build is up and we reload.
+  let updateRunning = $state(false)
+
+  async function loadUpdateStatus() {
+    try {
+      updateStatus = await getUpdateStatus()
+    } catch (error) {
+      console.debug('failed to load update status', error)
+    }
+  }
+
+  async function runCheck() {
+    checkingUpdate = true
+    updateMessage = null
+    try {
+      updateStatus = await checkForUpdate()
+    } catch {
+      updateMessage = 'Update check failed.'
+    } finally {
+      checkingUpdate = false
+    }
+  }
+
+  async function doUpdate() {
+    if (!updateStatus) {
+      return
+    }
+    updateRunning = true
+    updateMessage = 'Pausing the agent and rebuilding… this can take a few minutes.'
+    let startingSha: string
+    try {
+      startingSha = (await getVersion()).sha
+      await runUpdate()
+    } catch {
+      updateMessage = 'Failed to start the update. Is the agent idle and HOST_REPO_DIR set?'
+      updateRunning = false
+      return
+    }
+    // The rebuild replaces the API; poll /version (tolerating downtime) until the
+    // commit changes, then reload onto the new build.
+    const deadline = Date.now() + 12 * 60 * 1000
+    const poll = setInterval(async () => {
+      if (Date.now() > deadline) {
+        clearInterval(poll)
+        updateMessage = 'Update is taking a while. Refresh the page once it finishes.'
+        updateRunning = false
+        return
+      }
+      try {
+        const { sha } = await getVersion()
+        if (sha && sha !== startingSha) {
+          clearInterval(poll)
+          window.location.reload()
+        }
+      } catch {
+        // API is down mid-rebuild; keep polling until it returns on the new build.
+      }
+    }, 4000)
+  }
+
+  onMount(() => {
+    load()
+    loadUpdateStatus()
+  })
 </script>
 
 <div class="mx-auto flex max-w-5xl gap-6 px-6 py-6">
@@ -1353,6 +1425,88 @@
             </AlertDialog.Footer>
           </AlertDialog.Content>
         </AlertDialog.Root>
+      </Card.Content>
+    </Card.Root>
+    {/if}
+
+    {#if active === 'updates'}
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>Updates</Card.Title>
+        <Card.Description>
+          Pull the latest from GitHub (the branch this was deployed from) and rebuild the stack.
+          Checked automatically every hour. The agent is paused before an update begins, and the
+          page reloads once the new build is live.
+        </Card.Description>
+      </Card.Header>
+      <Card.Content class="space-y-4">
+        {#if updateStatus}
+          <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-sm">
+            <span class="text-muted-foreground">
+              Running:
+              <code class="rounded bg-secondary px-1 py-0.5">{updateStatus.current_branch}</code>
+              @
+              <code class="rounded bg-secondary px-1 py-0.5">
+                {updateStatus.current_sha === 'unknown'
+                  ? 'unknown'
+                  : updateStatus.current_sha.slice(0, 7)}
+              </code>
+            </span>
+            {#if updateStatus.checked_at}
+              <span class="text-muted-foreground">
+                Last checked {new Date(updateStatus.checked_at).toLocaleString()}
+              </span>
+            {/if}
+          </div>
+
+          {#if updateStatus.update_available}
+            <div
+              class="flex flex-wrap items-center gap-3 rounded-lg border border-primary/40 bg-primary/10 px-4 py-3"
+            >
+              <span class="text-sm font-medium text-primary">An update is available.</span>
+              {#if updateStatus.latest_sha}
+                <code class="rounded bg-secondary px-1 py-0.5 text-xs">
+                  {updateStatus.latest_sha.slice(0, 7)}
+                </code>
+              {/if}
+              <Button
+                onclick={doUpdate}
+                disabled={updateRunning ||
+                  updateStatus.updating ||
+                  updateStatus.agent_working ||
+                  !updateStatus.configured}
+              >
+                {updateRunning || updateStatus.updating ? 'Updating…' : 'Update'}
+              </Button>
+            </div>
+          {:else if !updateStatus.error}
+            <p class="text-sm text-success">You're on the latest version.</p>
+          {/if}
+
+          {#if updateStatus.agent_working}
+            <p class="text-sm text-warning">
+              The agent is working. Wait until it's idle (or pause it) to update.
+            </p>
+          {/if}
+          {#if !updateStatus.configured}
+            <p class="text-sm text-muted-foreground">
+              In-app updates aren't configured: set
+              <code class="rounded bg-secondary px-1 py-0.5">HOST_REPO_DIR</code> in
+              <code class="rounded bg-secondary px-1 py-0.5">.env</code> (the host path to this repo)
+              and restart. The version check still works without it.
+            </p>
+          {/if}
+          {#if updateStatus.error}
+            <p class="text-sm text-muted-foreground">{updateStatus.error}</p>
+          {/if}
+        {/if}
+
+        <div class="flex items-center gap-3">
+          <Button variant="outline" onclick={runCheck} disabled={checkingUpdate || updateRunning}>
+            {checkingUpdate ? 'Checking…' : 'Check for updates'}
+          </Button>
+          {#if updateMessage}<span class="text-sm text-muted-foreground">{updateMessage}</span>{/if}
+        </div>
       </Card.Content>
     </Card.Root>
     {/if}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,5 +12,13 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
+# Stamp the running build with the host's commit/branch (for the in-app update
+# check) and tell the API where the repo lives on the host (so its self-updater
+# can git pull + rebuild). HOST_REPO_DIR can be overridden in .env (e.g. on
+# Windows, set it to a Docker-friendly path).
+export GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+export GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+export HOST_REPO_DIR="${HOST_REPO_DIR:-$(pwd)}"
+
 docker compose up -d --build
 docker compose ps


### PR DESCRIPTION
Closes #67.

> I'd previously paused this issue with two architecture questions. The task was re-dispatched without answering them (and with a new requirement: pause the agent first), so I proceeded with the recommended approach the issue pre-endorsed ("Fine to leverage docker in docker in the API") and documented the deployment requirements here.

## UX (Settings -> Updates)
- Auto-checks for updates **every hour** (and on boot), so "update available" shows whenever you open the page.
- **Check for updates** button for an on-demand check.
- When newer: an **"update available"** banner and a primary **Update** button.
- Clicking Update shows a loading state; the page **reloads automatically once the new build is live**.

## How it works
**Version stamp.** The API image is built with `GIT_SHA` / `GIT_BRANCH` (compose build args set by `scripts/start.sh` from host git, baked in `api/Dockerfile` after the binary copy so they don't bust the build cache). The running API therefore knows its own commit.

**Check** (`src/update/`, hourly background loop + `POST /update/check`). Compares the stamped commit to the deployed branch's latest commit via the **GitHub API** (the stored token), cached on `AppState` and exposed at `GET /update/status`. No container needed to check.

**Update** (`POST /update`). The API container can drive the host Docker daemon but has no git/repo of its own, so the actual update runs in a **detached `docker:cli` updater container** launched via the socket: it bind-mounts the host repo (`HOST_REPO_DIR`) + the Docker socket + `SSH_HOME`, then runs `git pull --ff-only` (honoring the checked-out branch) and `docker compose up -d --build`. Because that container isn't part of the compose project, it **survives the API container being rebuilt out from under it**. The new image re-stamps the new `GIT_SHA`, so the UI's `/version` poll sees the commit change and reloads.

**Agent safety** (per the issue comment "must be paused before it begins / disabled while running"): `POST /update` returns **409 while a turn is in progress**, and **pauses the agent** before launching the rebuild. The UI disables Update while the agent is working.

## Deployment / config
- One new env: **`HOST_REPO_DIR`** = host path to the cloned repo (so the updater can bind-mount it). `scripts/start.sh` sets it automatically to the repo root; overridable in `.env` (documented, incl. a Windows example). Left blank, the in-app **update** is disabled but the **check** still works.
- Reuses existing `SSH_HOME` (git auth) and `DOCKER_SOCKET`. Cross-platform via Docker Desktop on Win11 and the Docker socket on Linux.

## Scope / caveats
- The version **check** uses GitHub (works for the JalapenoLabs/Seraphim repo via the stored token; `SERAPHIM_REPO` overrides the owner/repo).
- This is inherently deployment-specific and can't be exercised in CI (no real host/Docker-in-Docker): the Rust logic, endpoints, and UI build green and are reasoned through; the live `git pull` + rebuild needs a real deployment to observe.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (58 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass.