### PR TITLE
One-click create issue from an environment recommendation (#141)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,10 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 - **`environment_suggestions`** — setup recommendations the agent makes after a
   task (`title`, `detail`, `acknowledged`). Posted by the agent's
   `seraphim-suggest` helper; shown loudly on the board and as checkboxes on the
-  task until the user acknowledges them.
+  task until the user acknowledges them. A split "Create issue" button
+  (`POST /suggestions/:id/create` with `target` internal/github/jira) turns one
+  into a tracked issue (internal task, a GitHub issue in the task's repo via
+  octocrab, or a Jira ticket) and marks the recommendation done.
 - **`questions`** — decisions the agent escalated to the user, stored on the task
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1541,6 +1541,14 @@ pub async fn create_suggestion(
     .await
 }
 
+/// One suggestion by id (to act on it, e.g. create an issue from it).
+pub async fn get_suggestion(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<EnvSuggestion>> {
+    sqlx::query_as::<_, EnvSuggestion>("SELECT * FROM environment_suggestions WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+}
+
 /// Every suggestion on a task, oldest first, for the task detail view.
 pub async fn list_suggestions_for_task(
     pool: &PgPool,

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -515,6 +515,30 @@ pub async fn set_issue_state(
 }
 
 /// Posts a comment to an issue and returns the created comment.
+/// A freshly opened GitHub issue, enough to link to it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreatedIssue {
+    pub html_url: String,
+}
+
+/// Opens a new issue on `owner/repo` and returns its number + URL.
+pub async fn create_issue(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    title: &str,
+    body: &str,
+) -> Result<CreatedIssue> {
+    let issue: CreatedIssue = octo
+        .post(
+            format!("/repos/{owner}/{repo}/issues"),
+            Some(&json!({ "title": title, "body": body })),
+        )
+        .await
+        .wrap_err("failed to create GitHub issue")?;
+    Ok(issue)
+}
+
 pub async fn add_issue_comment(
     octo: &Octocrab,
     owner: &str,

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -78,6 +78,7 @@ pub fn router(state: AppState) -> Router {
         .route("/stats/reset", post(stats::reset))
         .route("/agent/suggestions", post(suggestions::create))
         .route("/suggestions/:id/ack", post(suggestions::acknowledge))
+        .route("/suggestions/:id/create", post(suggestions::create_issue))
         .route("/agent/questions", post(questions::ask))
         .route("/questions/pending", get(questions::pending))
         .route("/questions/:id/answer", post(questions::answer))

--- a/api/src/http/suggestions.rs
+++ b/api/src/http/suggestions.rs
@@ -3,19 +3,21 @@
 //!
 //! The agent's `seraphim-suggest` helper posts recommendations
 //! (`POST /agent/suggestions`); the task view checks them off
-//! (`POST /suggestions/:id/ack`). They are listed as part of the task detail.
+//! (`POST /suggestions/:id/ack`) or turns one into a tracked issue
+//! (`POST /suggestions/:id/create`). They are listed as part of the task detail.
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
 use super::ApiResult;
-use crate::db::models::EnvSuggestionWrite;
+use crate::db::models::{EnvSuggestion, EnvSuggestionWrite, Task, TaskColumn};
 use crate::db::queries;
+use crate::git;
 use crate::state::AppState;
 
 /// The most suggestions a single post may record, to bound a runaway agent.
@@ -76,4 +78,147 @@ pub async fn acknowledge(
     let suggestion = queries::set_suggestion_acknowledged(&state.db, id, body.acknowledged).await?;
     state.notify_board();
     Ok(Json(suggestion))
+}
+
+/// Where a one-click "create issue from this recommendation" lands.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CreateTarget {
+    /// A Seraphim-only internal ticket.
+    Internal,
+    /// A new GitHub issue in the originating task's repo.
+    Github,
+    /// A new Jira ticket.
+    Jira,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateFromSuggestionRequest {
+    pub target: CreateTarget,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateFromSuggestionResponse {
+    /// The recommendation, now marked done.
+    pub suggestion: EnvSuggestion,
+    /// A link to the created issue, when the target has one.
+    pub url: Option<String>,
+}
+
+/// `POST /api/v1/suggestions/:id/create` - turn a recommendation into a tracked
+/// issue (internal / GitHub / Jira), then mark the recommendation done.
+pub async fn create_issue(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<CreateFromSuggestionRequest>,
+) -> ApiResult<Response> {
+    let Some(suggestion) = queries::get_suggestion(&state.db, id).await? else {
+        return Ok((
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "suggestion not found" })),
+        )
+            .into_response());
+    };
+    let task = queries::get_task(&state.db, suggestion.task_id).await?;
+    let title = suggestion.title.clone();
+    let detail = suggestion.detail.clone();
+
+    let url = match body.target {
+        CreateTarget::Internal => {
+            // Land it at the bottom of Available, like the manual "create issue".
+            let position = queries::max_position_in_column(&state.db, TaskColumn::Available)
+                .await?
+                .unwrap_or(0.0)
+                + 1.0;
+            queries::create_internal_task(&state.db, &title, &detail, "open", position).await?;
+            None
+        }
+        CreateTarget::Github => {
+            match create_github_issue(&state, task.as_ref(), &title, &detail).await {
+                Ok(url) => Some(url),
+                Err(message) => return Ok(bad_request(&message)),
+            }
+        }
+        CreateTarget::Jira => match create_jira_issue(&state, task.as_ref(), &title, &detail).await
+        {
+            Ok(url) => Some(url),
+            Err(message) => return Ok(bad_request(&message)),
+        },
+    };
+
+    // The recommendation has been actioned, so check it off.
+    let suggestion = queries::set_suggestion_acknowledged(&state.db, id, true).await?;
+    state.notify_board();
+    Ok(Json(CreateFromSuggestionResponse { suggestion, url }).into_response())
+}
+
+fn bad_request(message: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))).into_response()
+}
+
+/// Creates the GitHub issue in the originating task's repo, returning its URL or a
+/// user-facing reason it can't be created.
+async fn create_github_issue(
+    state: &AppState,
+    task: Option<&Task>,
+    title: &str,
+    body: &str,
+) -> Result<String, String> {
+    let Some(repo_id) = task.and_then(|task| task.repo_id) else {
+        return Err("This task has no linked repository to open a GitHub issue in.".to_string());
+    };
+    let repo = queries::get_repository(&state.db, repo_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "The linked repository no longer exists.".to_string())?;
+    let Some((owner, name)) = repo.full_name.split_once('/') else {
+        return Err(format!(
+            "Repository '{}' is not owner/repo.",
+            repo.full_name
+        ));
+    };
+    let github = state.github().await.map_err(|error| error.to_string())?;
+    let issue = git::create_issue(&github, owner, name, title, body)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(issue.html_url)
+}
+
+/// Creates a Jira ticket (in the task's board project, else the first followed
+/// board's project), returning its URL or a user-facing reason it can't be.
+async fn create_jira_issue(
+    state: &AppState,
+    task: Option<&Task>,
+    title: &str,
+    body: &str,
+) -> Result<String, String> {
+    let Some(jira) = state.jira().await.map_err(|error| error.to_string())? else {
+        return Err("Jira isn't configured. Connect it in Settings first.".to_string());
+    };
+
+    // Prefer the project of the task's own Jira board; otherwise the first board.
+    let mut project_key = None;
+    if let Some(board_id) = task.and_then(|task| task.jira_board_id) {
+        project_key = queries::get_jira_board(&state.db, board_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .map(|board| board.project_key);
+    }
+    if project_key.is_none() {
+        project_key = queries::list_jira_boards(&state.db)
+            .await
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .next()
+            .map(|board| board.project_key);
+    }
+    let Some(project_key) = project_key.filter(|key| !key.trim().is_empty()) else {
+        return Err("No Jira project to create in. Follow a board in Settings first.".to_string());
+    };
+
+    let issue = jira
+        .create_issue(&project_key, title, body)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(issue.url)
 }

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -323,6 +323,67 @@ impl JiraClient {
         }
         Ok(true)
     }
+
+    /// Creates a `Task`-type issue in `project_key` and returns its key + URL.
+    /// Cloud (REST v3) takes the description as Atlassian Document Format; Server
+    /// (v2) takes plain text, so the description is encoded per deployment.
+    pub async fn create_issue(
+        &self,
+        project_key: &str,
+        summary: &str,
+        description: &str,
+    ) -> Result<CreatedJiraIssue> {
+        #[derive(Deserialize)]
+        struct Created {
+            key: String,
+        }
+
+        let url = format!("{}{}/issue", self.config.base_url, self.config.api_base());
+
+        let mut fields = serde_json::json!({
+            "project": { "key": project_key },
+            "summary": summary,
+            "issuetype": { "name": "Task" },
+        });
+        if !description.trim().is_empty() {
+            fields["description"] = match self.config.deployment {
+                JiraDeployment::Cloud => serde_json::json!({
+                    "type": "doc",
+                    "version": 1,
+                    "content": [{
+                        "type": "paragraph",
+                        "content": [{ "type": "text", "text": description }],
+                    }],
+                }),
+                JiraDeployment::Server => serde_json::json!(description),
+            };
+        }
+
+        let response = self
+            .http
+            .post(&url)
+            .header("Authorization", self.config.auth_header())
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({ "fields": fields }))
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(eyre!("Jira issue creation failed ({status}): {body}"));
+        }
+
+        let created: Created = response.json().await?;
+        Ok(CreatedJiraIssue {
+            url: format!("{}/browse/{}", self.config.base_url, created.key),
+        })
+    }
+}
+
+/// A freshly created Jira ticket.
+#[derive(Debug, Clone)]
+pub struct CreatedJiraIssue {
+    pub url: String,
 }
 
 /// Flattens a Jira description into plain text. Server (v2) returns a string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -116,6 +116,17 @@ export function acknowledgeSuggestion(suggestionId: string, acknowledged: boolea
     .json<EnvSuggestion>()
 }
 
+// Where a one-click "create issue from this recommendation" lands.
+export type CreateIssueTarget = 'internal' | 'github' | 'jira'
+
+// Turns a recommendation into a tracked issue (Seraphim / GitHub / Jira) and
+// marks it done. Returns the updated suggestion and a link when there is one.
+export function createIssueFromSuggestion(suggestionId: string, target: CreateIssueTarget) {
+  return apiClient
+    .post(`suggestions/${suggestionId}/create`, { json: { target } })
+    .json<{ suggestion: EnvSuggestion; url: string | null }>()
+}
+
 // --- Questions ---------------------------------------------------------------
 
 type PendingQuestionsResponse = {

--- a/frontend/src/lib/components/SuggestionCreateButton.svelte
+++ b/frontend/src/lib/components/SuggestionCreateButton.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  // A split button for turning an environment recommendation into a tracked
+  // issue: a default action (matching where the ticket originally came from) and
+  // a smushed-on dropdown arrow to pick a different target. While creating, the
+  // whole control shows a loading state; on success the recommendation is marked
+  // done by the server and the parent is told.
+  import type { EnvSuggestion, SourceKind } from '$lib/types'
+  import type { CreateIssueTarget } from '$lib/api'
+
+  import { ChevronDown, LoaderCircle } from '@lucide/svelte'
+  import { toast } from 'svelte-sonner'
+
+  import { createIssueFromSuggestion } from '$lib/api'
+
+  let {
+    suggestion,
+    source,
+    repoLinked = false,
+    oncreated
+  }: {
+    suggestion: EnvSuggestion
+    // Where the ticket was originally created from; the default action mirrors it.
+    source: SourceKind
+    // Whether the task has a linked repo (a GitHub issue needs one).
+    repoLinked?: boolean
+    oncreated: (updated: EnvSuggestion) => void
+  } = $props()
+
+  const LABELS: Record<CreateIssueTarget, string> = {
+    internal: 'Seraphim',
+    github: 'GitHub',
+    jira: 'Jira'
+  }
+  // Dropdown order, as listed in the issue.
+  const OPTIONS: CreateIssueTarget[] = ['internal', 'jira', 'github']
+
+  // The originating source maps 1:1 onto a target; internal sources default to a
+  // Seraphim issue.
+  const defaultTarget = $derived<CreateIssueTarget>(
+    source === 'github' ? 'github' : source === 'jira' ? 'jira' : 'internal'
+  )
+
+  let open = $state(false)
+  let loading = $state(false)
+  let wrapper = $state<HTMLDivElement>()
+
+  function enabled(target: CreateIssueTarget): boolean {
+    // A GitHub issue needs a repo to open it in.
+    return target !== 'github' || repoLinked
+  }
+
+  async function extractError(error: unknown): Promise<string> {
+    if (error && typeof error === 'object' && 'response' in error) {
+      try {
+        const body = await (error as { response: Response }).response.json()
+        if (body?.error) return String(body.error)
+      } catch {
+        // fall through to the generic message
+      }
+    }
+    return 'Failed to create the issue.'
+  }
+
+  async function run(target: CreateIssueTarget) {
+    if (loading || !enabled(target)) return
+    open = false
+    loading = true
+    try {
+      const { suggestion: updated, url } = await createIssueFromSuggestion(suggestion.id, target)
+      toast.success(`Created ${LABELS[target]} issue`, {
+        description: url ? 'Click to open it on the source.' : undefined,
+        action: url
+          ? { label: 'Open', onClick: () => window.open(url, '_blank', 'noopener') }
+          : undefined
+      })
+      oncreated(updated)
+    } catch (error) {
+      toast.error(await extractError(error))
+    } finally {
+      loading = false
+    }
+  }
+
+  function onWindowPointerDown(event: MouseEvent) {
+    if (open && wrapper && !wrapper.contains(event.target as Node)) open = false
+  }
+  function onWindowKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') open = false
+  }
+</script>
+
+<svelte:window onpointerdown={onWindowPointerDown} onkeydown={onWindowKeydown} />
+
+<div bind:this={wrapper} class="relative flex flex-none">
+  <!-- Default action: create in the originating source. -->
+  <button
+    type="button"
+    onclick={() => run(defaultTarget)}
+    disabled={loading}
+    class="inline-flex items-center gap-1.5 rounded-l-md border border-primary bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+  >
+    {#if loading}
+      <LoaderCircle class="size-3.5 animate-spin" />
+    {/if}
+    Create {LABELS[defaultTarget]} Issue
+  </button>
+  <!-- Smushed-on dropdown toggle (shares a border, only the right edge rounds). -->
+  <button
+    type="button"
+    onclick={() => (open = !open)}
+    disabled={loading}
+    aria-haspopup="menu"
+    aria-expanded={open}
+    aria-label="Choose where to create the issue"
+    class="-ml-px inline-flex items-center rounded-r-md border border-primary bg-primary px-1 py-1 text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+  >
+    <ChevronDown class="size-3.5" />
+  </button>
+
+  {#if open}
+    <div
+      role="menu"
+      class="absolute right-0 top-full z-50 mt-1 min-w-[12rem] overflow-hidden rounded-md border border-border bg-card py-1 text-xs shadow-lg"
+    >
+      {#each OPTIONS as target (target)}
+        <button
+          type="button"
+          role="menuitem"
+          onclick={() => run(target)}
+          disabled={!enabled(target)}
+          title={enabled(target) ? '' : 'This task has no linked repository.'}
+          class="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <span>Create {LABELS[target]} issue</span>
+          {#if target === defaultTarget}
+            <span class="text-[10px] uppercase tracking-wide text-muted-foreground">default</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -24,6 +24,7 @@
   import * as Resizable from '$lib/components/ui/resizable'
   import { buttonVariants } from '$lib/components/ui/button'
   import IssueView from '$lib/components/IssueView.svelte'
+  import SuggestionCreateButton from '$lib/components/SuggestionCreateButton.svelte'
   import Stats from '$lib/components/Stats.svelte'
   import Markdown from '$lib/components/Markdown.svelte'
   import JsonHighlight from '$lib/components/JsonHighlight.svelte'
@@ -60,6 +61,15 @@
     } catch (error) {
       console.debug('failed to update suggestion, reverting', error)
       suggestion.acknowledged = !next
+    }
+  }
+
+  // After a recommendation is turned into an issue, the server marks it done;
+  // reflect that so it checks off and the create button drops away.
+  function onSuggestionCreated(updated: EnvSuggestion) {
+    const index = suggestions.findIndex((entry) => entry.id === updated.id)
+    if (index !== -1) {
+      suggestions[index] = updated
     }
   }
 
@@ -426,8 +436,8 @@
         </p>
         <ul class="mt-2 divide-y divide-border">
           {#each suggestions as suggestion (suggestion.id)}
-            <li>
-              <label class="flex cursor-pointer items-start gap-2 py-2">
+            <li class="flex items-start justify-between gap-3 py-2">
+              <label class="flex min-w-0 flex-1 cursor-pointer items-start gap-2">
                 <input
                   type="checkbox"
                   checked={suggestion.acknowledged}
@@ -449,6 +459,14 @@
                   {/if}
                 </span>
               </label>
+              {#if !suggestion.acknowledged && task}
+                <SuggestionCreateButton
+                  {suggestion}
+                  source={task.source_kind}
+                  repoLinked={!!task.repo_id}
+                  oncreated={onSuggestionCreated}
+                />
+              {/if}
             </li>
           {/each}
         </ul>


### PR DESCRIPTION
Closes #141.

## What
Each unacknowledged environment recommendation in the task view gets a **split button** on the right that turns it into a tracked issue.

```
[ Create GitHub Issue ][▾]
```

- **Default action** mirrors where the ticket originally came from: a GitHub task reads **"Create GitHub Issue"**, a Jira task **"Create Jira Issue"**, an internal task **"Create Seraphim Issue"**.
- The two halves are smushed together (shared border, only the outer edges round) but have **separate logic**: the left half runs the default action, the right arrow toggles a dropdown.
- The **dropdown** lists all three, per the issue: *Create Seraphim issue*, *Create Jira issue*, *Create GitHub issue*. The GitHub option is disabled when the task has no linked repo.
- **Behavior:** clicking shows the button **loading** and closes the dropdown; on success the server **marks the recommendation done** (it checks off and the button drops away), with a toast that links to the created issue.

## How
- **Backend:** `POST /api/v1/suggestions/:id/create` with `{ target: internal | github | jira }`:
  - `internal` → a Seraphim internal task (bottom of Available).
  - `github` → a real GitHub issue in the originating task's repo, via new `git::create_issue` (octocrab).
  - `jira` → a Jira "Task" via new `JiraClient::create_issue`, in the task's own board project (or the first followed board's project as a fallback); the description is sent as ADF on Cloud (v3) and plain text on Server (v2).
  - Then the recommendation is acknowledged. Missing context (a task with no repo, or Jira not configured) returns a clear `400` that the UI surfaces as a toast.
- **Frontend:** a self-contained `SuggestionCreateButton.svelte` (split button + dropdown + loading/toast), wired into the task page's recommendations list using the task's `source_kind` for the default and `repo_id` to gate the GitHub option.

## Notes
- A created GitHub/Jira issue lands on the board through the existing realtime webhook / poll sync (like any other issue); the internal one appears immediately.
- Jira create uses issue type "Task" (the common default) and surfaces any Jira API error verbatim, since the right issue type/project can vary per instance.

## Verification
`cargo +1.88 fmt` / `clippy --all-targets --all-features` (no new warnings) / `test` (64 passed). Frontend `yarn check` (0 errors/warnings) and `yarn build` pass. The live GitHub/Jira issue creation needs real credentials to observe end to end (no CI harness for that here); the wiring, error paths, and UI build green.