### PR TITLE
Dead-agent management: heart attacks and the defibrillator (#89)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,12 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and
   surfaced as toasts + native notifications + a sidebar.
+- **`heart_attacks`** — recorded "heart attacks" (turns that died mid-flight),
+  written by the defibrillator loop (see above), never by a request. Each holds a
+  task snapshot, the status at death, the diagnostic `detail` (error logs kept for
+  later patching), what the defibrillator did (`recovery`), and `acknowledged`.
+  The board reads the unacknowledged ones into its payload and shows a dismissible
+  red banner; `POST /heart-attacks/:id/ack` clears one.
 - **`automation_rules`** — user-defined rules (Automation page). When a GitHub
   webhook delivers an issue `created`/`updated`/`comment` event, each enabled
   rule whose source + trigger match is checked against the event; if its
@@ -175,7 +181,7 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 - **Auth:** `CLAUDE_CODE_OAUTH_TOKEN` (subscription) for Claude; mounted host
   `~/.ssh` for `git@` clones; `GH_TOKEN` for HTTPS + octocrab.
 
-### The three orchestrator loops (`api/src/orchestrator/mod.rs`)
+### The orchestrator loops (`api/src/orchestrator/mod.rs`)
 1. **sync** — polls every repo with `sync_issues` for open issues and upserts
    them into the **top** of **Available** (never clobbers human-set
    column/position). Tasks are unique per `(repo_id, source_kind, external_id)`.
@@ -212,6 +218,23 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    bounded by `MAX_CI_FIX_ATTEMPTS` (3) before parking it `ci_blocked` for a
    human. A failed merge (e.g. base conflict) also parks it `ci_blocked` rather
    than retrying forever.
+4. **defibrillator** (dead-agent management) — recovers turns that die mid-flight,
+   which we call a **"heart attack"**: the agent hangs with no output, its stream
+   breaks, or the turn aborts internally, leaving the card stranded `in_progress`
+   and the `claude -p` child possibly leaked. Detection is layered: an **in-turn
+   heartbeat** in `stream_turn` (each wait for the next event is bounded by
+   `HEARTBEAT_TIMEOUT`, 20 min; a longer silence ends the turn as a heart attack),
+   the `agent_loop` catching a turn that aborted with an error, and a background
+   **watchdog** (`defibrillator_loop`) that reaps any task left `working` with no
+   activity past `WATCHDOG_TIMEOUT` (25 min, strictly above the heartbeat so it
+   never races a live turn). All three funnel into `defibrillate`, which kills the
+   orphaned process (`kill_agent_process`), records a `heart_attacks` incident with
+   the diagnostic detail, and revives the task — requeue to **To Do** if it had no
+   PR, else back to **In Review** — bounded by `MAX_DEFIBRILLATIONS` (3) before it
+   leaves the task failed for a human. Each incident alerts the operator: a
+   persistent, dismissible red banner on the board (carrying the error logs) plus a
+   toast and native notification. The revive-vs-give-up choice is the pure,
+   unit-tested `decide_recovery`.
 
 ## Ports & URLs
 

--- a/api/migrations/0028_heart_attacks.sql
+++ b/api/migrations/0028_heart_attacks.sql
@@ -1,0 +1,34 @@
+-- Dead-agent management ("heart attacks").
+--
+-- A turn can die mid-flight: the Claude process hangs with no output, its stream
+-- breaks, or the turn aborts on an internal error. When that happens the card is
+-- left stranded in In Progress and the underlying `claude -p` child can leak and
+-- spin orphaned. We call that a "heart attack"; the recovery (kill the orphan,
+-- revive the task, alert the operator) is the "defibrillator".
+--
+-- Each heart attack is recorded here so the operator is alerted in the UI and the
+-- diagnostic detail survives for later patching, even after the task itself is
+-- requeued, completed, or deleted.
+CREATE TABLE heart_attacks (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- The task that died. Nullable so the incident outlives the task being deleted.
+    task_id         UUID REFERENCES tasks(id) ON DELETE SET NULL,
+    -- Snapshot of the task title, so the alert is readable even if the task is gone.
+    task_title      TEXT NOT NULL,
+    -- The task's operational status at the moment it died (e.g. 'working').
+    status_label    TEXT NOT NULL DEFAULT '',
+    -- The diagnosis / error logs: what we knew about why the agent died, kept so
+    -- the operator can patch the underlying cause later.
+    detail          TEXT NOT NULL,
+    -- What the defibrillator did about it (revived, or left for a human).
+    recovery        TEXT NOT NULL DEFAULT '',
+    -- Cleared by the operator once they have seen it; the board banner shows the
+    -- unacknowledged ones.
+    acknowledged    BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    acknowledged_at TIMESTAMPTZ
+);
+
+-- The board reads the unacknowledged incidents on every load; index that path.
+CREATE INDEX heart_attacks_unacked_idx ON heart_attacks (created_at DESC)
+    WHERE acknowledged = FALSE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -441,6 +441,29 @@ pub struct EnvSuggestion {
     pub acknowledged_at: Option<DateTime<Utc>>,
 }
 
+/// A recorded "heart attack": a turn that died mid-flight (the agent hung with no
+/// output, its stream broke, or the turn aborted internally). The defibrillator
+/// records one so the operator is alerted and the diagnostic detail survives for
+/// later patching, even after the task is requeued, finished, or deleted.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct HeartAttack {
+    pub id: Uuid,
+    /// The task that died; `None` once that task has been deleted.
+    pub task_id: Option<Uuid>,
+    /// The task's title at the time, so the alert reads even if the task is gone.
+    pub task_title: String,
+    /// The task's operational status when it died (e.g. `working`).
+    pub status_label: String,
+    /// The diagnosis / error logs: why we think the agent died.
+    pub detail: String,
+    /// What the defibrillator did about it (revived, or left for a human).
+    pub recovery: String,
+    /// Cleared once the operator has seen it; the board banner shows the rest.
+    pub acknowledged: bool,
+    pub created_at: DateTime<Utc>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+}
+
 /// One environment suggestion as posted by the agent's `seraphim-suggest`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct EnvSuggestionWrite {

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -13,9 +13,9 @@ use uuid::Uuid;
 
 use super::models::{
     AnswerKind, AutomationRule, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite,
-    InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingQuestion, Question,
-    QuestionOption, QuestionStatus, RepoDeletionImpact, Repository, ReviewPolicy, Settings,
-    SourceKind, StatsAggregate, Task, TaskColumn, TaskStatus, Turn,
+    HeartAttack, InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingQuestion,
+    Question, QuestionOption, QuestionStatus, RepoDeletionImpact, Repository, ReviewPolicy,
+    Settings, SourceKind, StatsAggregate, Task, TaskColumn, TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -1587,6 +1587,79 @@ pub async fn unacknowledged_suggestion_counts(pool: &PgPool) -> sqlx::Result<Vec
          WHERE acknowledged = FALSE GROUP BY task_id",
     )
     .fetch_all(pool)
+    .await
+}
+
+// --- Heart attacks (dead-agent management) -----------------------------------
+
+/// Records a heart attack: a turn that died mid-flight. The detail is the
+/// diagnosis kept for later patching; `recovery` is what the defibrillator did.
+pub async fn create_heart_attack(
+    pool: &PgPool,
+    task_id: Option<Uuid>,
+    task_title: &str,
+    status_label: &str,
+    detail: &str,
+    recovery: &str,
+) -> sqlx::Result<HeartAttack> {
+    sqlx::query_as::<_, HeartAttack>(
+        "INSERT INTO heart_attacks (task_id, task_title, status_label, detail, recovery) \
+         VALUES ($1, $2, $3, $4, $5) RETURNING *",
+    )
+    .bind(task_id)
+    .bind(task_title)
+    .bind(status_label)
+    .bind(detail)
+    .bind(recovery)
+    .fetch_one(pool)
+    .await
+}
+
+/// The unacknowledged heart attacks, newest first, for the board's alert banner.
+/// Bounded so a storm of incidents can't bloat the board payload.
+pub async fn list_unacknowledged_heart_attacks(pool: &PgPool) -> sqlx::Result<Vec<HeartAttack>> {
+    sqlx::query_as::<_, HeartAttack>(
+        "SELECT * FROM heart_attacks WHERE acknowledged = FALSE \
+         ORDER BY created_at DESC LIMIT 20",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Clears a heart attack once the operator has seen it.
+pub async fn acknowledge_heart_attack(pool: &PgPool, id: Uuid) -> sqlx::Result<HeartAttack> {
+    sqlx::query_as::<_, HeartAttack>(
+        "UPDATE heart_attacks SET acknowledged = TRUE, acknowledged_at = now() \
+         WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+}
+
+/// How many heart attacks a task has suffered. Bounds how many times the
+/// defibrillator revives the same task before leaving it for a human.
+pub async fn count_heart_attacks_for_task(pool: &PgPool, task_id: Uuid) -> sqlx::Result<i64> {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM heart_attacks WHERE task_id = $1")
+        .bind(task_id)
+        .fetch_one(pool)
+        .await
+}
+
+/// The task that has been mid-turn (`working`) with no activity for at least
+/// `stale_secs`, if any. The defibrillator watchdog uses this to catch a turn
+/// that hung or stranded the card without the in-turn heartbeat noticing. Picks
+/// the most stale first.
+pub async fn find_stranded_task(pool: &PgPool, stale_secs: i64) -> sqlx::Result<Option<Task>> {
+    sqlx::query_as::<_, Task>(
+        "SELECT * FROM tasks \
+         WHERE board_column = 'in_progress' AND status = 'working' \
+         AND last_activity_at IS NOT NULL \
+         AND last_activity_at < now() - ($1 * interval '1 second') \
+         ORDER BY last_activity_at ASC LIMIT 1",
+    )
+    .bind(stale_secs)
+    .fetch_optional(pool)
     .await
 }
 

--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use tracing::warn;
 
 use super::ApiResult;
-use crate::db::models::{Settings, SourceKind, Task, TaskColumn};
+use crate::db::models::{HeartAttack, Settings, SourceKind, Task, TaskColumn};
 use crate::db::queries;
 use crate::state::AppState;
 
@@ -21,10 +21,13 @@ pub struct BoardResponse {
     /// Unacknowledged setup-suggestion counts, keyed by task id, so a card can
     /// shout when the agent left recommendations. Tasks with none are omitted.
     pub suggestion_counts: HashMap<Uuid, i64>,
+    /// Unacknowledged heart attacks (turns that died), newest first, so the board
+    /// can alert the operator with the diagnostic detail until they clear them.
+    pub heart_attacks: Vec<HeartAttack>,
 }
 
-/// `GET /api/v1/board` - every card, the org/pause settings, and per-card
-/// counts of open environment suggestions.
+/// `GET /api/v1/board` - every card, the org/pause settings, per-card counts of
+/// open environment suggestions, and any unacknowledged heart attacks.
 pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardResponse>> {
     let tasks = queries::list_tasks(&state.db).await?;
     let mut settings = queries::get_settings(&state.db).await?;
@@ -34,10 +37,12 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
         .await?
         .into_iter()
         .collect();
+    let heart_attacks = queries::list_unacknowledged_heart_attacks(&state.db).await?;
     Ok(Json(BoardResponse {
         tasks,
         settings,
         suggestion_counts,
+        heart_attacks,
     }))
 }
 

--- a/api/src/http/heart_attacks.rs
+++ b/api/src/http/heart_attacks.rs
@@ -1,0 +1,26 @@
+//! Heart attacks (dead-agent management): the operator clearing the alerts the
+//! defibrillator raised.
+//!
+//! The incidents themselves are created by the orchestrator's defibrillator, not
+//! by any request, and are delivered to the board via the board payload. The only
+//! endpoint here is the operator acknowledging one once they have read its logs.
+
+use axum::extract::{Path, State};
+use axum::Json;
+use uuid::Uuid;
+
+use super::ApiResult;
+use crate::db::models::HeartAttack;
+use crate::db::queries;
+use crate::state::AppState;
+
+/// `POST /api/v1/heart-attacks/:id/ack` - the operator dismisses an incident once
+/// they have seen it, clearing it from the board banner.
+pub async fn acknowledge(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<HeartAttack>> {
+    let incident = queries::acknowledge_heart_attack(&state.db, id).await?;
+    state.notify_board();
+    Ok(Json(incident))
+}

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -7,6 +7,7 @@
 mod automation;
 mod board;
 mod data;
+mod heart_attacks;
 mod jira;
 mod notepad;
 mod questions;
@@ -83,6 +84,7 @@ pub fn router(state: AppState) -> Router {
         .route("/questions/pending", get(questions::pending))
         .route("/questions/:id/answer", post(questions::answer))
         .route("/notifications/stream", get(sse::notification_stream))
+        .route("/heart-attacks/:id/ack", post(heart_attacks::acknowledge))
         .route("/repos", get(repos::list).post(repos::upsert))
         .route(
             "/repos/:id",

--- a/api/src/http/sse.rs
+++ b/api/src/http/sse.rs
@@ -27,7 +27,11 @@ pub async fn board_stream(
                 Ok(ServerEvent::Usage { .. }) => {
                     yield Ok(Event::default().event("usage").data("{}"));
                 }
-                Ok(ServerEvent::Task { .. } | ServerEvent::Notification { .. }) => {}
+                Ok(
+                    ServerEvent::Task { .. }
+                    | ServerEvent::Notification { .. }
+                    | ServerEvent::HeartAttack { .. },
+                ) => {}
                 // A lagged consumer just resyncs; a closed channel ends the stream.
                 Err(RecvError::Lagged(_)) => continue,
                 Err(RecvError::Closed) => break,
@@ -56,6 +60,15 @@ pub async fn notification_stream(
                     });
                     let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
                     yield Ok(Event::default().event("notification").data(data));
+                }
+                Ok(ServerEvent::HeartAttack { task_id, task_title, summary }) => {
+                    let payload = serde_json::json!({
+                        "task_id": task_id,
+                        "task_title": task_title,
+                        "summary": summary,
+                    });
+                    let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+                    yield Ok(Event::default().event("heart_attack").data(data));
                 }
                 Ok(ServerEvent::Board) => {
                     yield Ok(Event::default().event("refresh").data("{}"));

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use eyre::{eyre, Result};
 use futures::StreamExt;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 use tracing::{error, info, warn};
 
 use crate::automation::{self, QueuePosition, RuleAction, RuleContext};
@@ -74,6 +74,30 @@ const RATE_LIMIT_RETRY_MAX: u32 = 5;
 /// the UI.
 const LIVE_USAGE_TICK: Duration = Duration::from_millis(350);
 
+/// How long a turn may go without emitting a single event before it is presumed
+/// dead (a "heart attack"). A healthy turn streams partial-message usage events
+/// continuously while generating and a tool event around each call, so the only
+/// legitimate silence is one long-running tool (a build or test). This is set
+/// well above the longest realistic silent step so a slow build is never mistaken
+/// for a hang, while still bounding how long a genuinely dead turn wastes the
+/// single-threaded agent before the defibrillator steps in.
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+
+/// How often the defibrillator watchdog scans for a stranded turn.
+const DEFIB_POLL: Duration = Duration::from_secs(60);
+
+/// How long a task may sit `working` with no activity before the watchdog treats
+/// it as stranded. Strictly greater than [`HEARTBEAT_TIMEOUT`] so a live turn
+/// always self-terminates through the in-turn heartbeat first; only a turn the
+/// in-turn path could not catch (an aborted loop, a wedged non-stream await) is
+/// ever reaped here, so the watchdog never races a healthy turn.
+const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(25 * 60);
+
+/// How many heart attacks one task may suffer before the defibrillator stops
+/// reviving it and leaves it for a human. Bounds a task that dies every run from
+/// looping forever.
+const MAX_DEFIBRILLATIONS: i64 = 3;
+
 /// What kind of work a pulled card needs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WorkMode {
@@ -93,6 +117,7 @@ pub fn spawn(state: AppState) {
     tokio::spawn(provision_on_startup(state.clone()));
     tokio::spawn(sync_loop(state.clone()));
     tokio::spawn(review_loop(state.clone()));
+    tokio::spawn(defibrillator_loop(state.clone()));
     tokio::spawn(agent_loop(state));
 }
 
@@ -483,8 +508,18 @@ async fn agent_loop(state: AppState) {
     loop {
         match next_actionable_task(&state).await {
             Ok(Some((task, mode))) => {
+                // Keep a snapshot: if the turn aborts (a `?` propagated, leaving
+                // the card stranded and possibly an orphaned process), the
+                // defibrillator needs the task to record and recover it.
+                let snapshot = task.clone();
                 if let Err(error) = work_task(&state, task, mode).await {
-                    error!(error = %error, "task run failed");
+                    error!(error = %error, task_id = %snapshot.id, "task run aborted; defibrillating");
+                    let detail = format!("The turn aborted with an error: {error}");
+                    if let Err(defib_error) =
+                        defibrillate(&state, &snapshot, "working", &detail).await
+                    {
+                        error!(error = %defib_error, task_id = %snapshot.id, "defibrillator failed after a turn abort");
+                    }
                 }
                 // Immediately look for the next card; only sleep when idle.
             }
@@ -626,6 +661,16 @@ async fn work_fresh(state: &AppState, task: Task, resume: bool) -> Result<()> {
         info!(task_id = %task.id, "hard reset during turn; leaving the task to the reset");
         return Ok(());
     }
+    // The turn died (hung or its stream broke), not merely reported a problem:
+    // hand it to the defibrillator (kill the orphan, revive, alert) rather than a
+    // plain failure.
+    if outcome.heart_attack {
+        let detail = outcome
+            .error
+            .as_deref()
+            .unwrap_or("the agent stopped responding");
+        return defibrillate(state, &task, "working", detail).await;
+    }
     // Surface a turn failure (e.g. "Not logged in") on the task itself, instead
     // of letting it fall through to the generic "no pull request" message.
     if let Some(message) = outcome.error {
@@ -746,6 +791,15 @@ async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> 
         info!(task_id = %task.id, "hard reset during turn; leaving the task to the reset");
         return Ok(());
     }
+    // A turn that died mid-fix goes to the defibrillator: it already has a PR, so
+    // recovery returns it to review rather than re-queuing it as fresh work.
+    if outcome.heart_attack {
+        let detail = outcome
+            .error
+            .as_deref()
+            .unwrap_or("the agent stopped responding");
+        return defibrillate(state, &task, "working", detail).await;
+    }
     if let Some(message) = outcome.error {
         return fail(state, &task, &message).await;
     }
@@ -803,6 +857,10 @@ struct TurnOutcome {
     session_id: Option<String>,
     /// A failure message to surface on the task, if the turn errored.
     error: Option<String>,
+    /// Whether the turn *died* rather than merely reporting a problem: it hung with
+    /// no output past the heartbeat, or its stream broke. These are routed to the
+    /// defibrillator (kill the orphan, revive, alert) instead of a plain failure.
+    heart_attack: bool,
     /// The hard-reset epoch captured when the turn started, so the caller can tell
     /// whether a reset interrupted it.
     epoch: u64,
@@ -932,20 +990,8 @@ async fn stream_turn(
 
     // Clear any claude process leaked by a previously aborted turn. The agent is
     // single-threaded, so none should legitimately be running; a leftover would
-    // otherwise contend on the same shared session. The `[c]` keeps pkill from
-    // matching its own command line. Best-effort.
-    let _ = state
-        .workspace
-        .exec_capture(
-            "/workspace",
-            vec![
-                "bash".to_string(),
-                "-lc".to_string(),
-                "pkill -9 -f '[c]laude -p' || true".to_string(),
-            ],
-            vec![],
-        )
-        .await;
+    // otherwise contend on the same shared session. Best-effort.
+    kill_agent_process(state).await;
 
     let mut stream = Box::pin(run_turn(state.workspace.docker(), args));
     // seq 0 is the prompt event recorded above; the stream's events follow.
@@ -957,6 +1003,9 @@ async fn stream_turn(
     // persisted on the turn so the stats endpoints can aggregate it.
     let mut token_usage: Option<serde_json::Value> = None;
     let mut error_message: Option<String> = None;
+    // Set when the turn *died* (hung past the heartbeat, or its stream broke), as
+    // opposed to the agent merely reporting a problem; routes to the defibrillator.
+    let mut heart_attack = false;
     // The reset time of the last usage pause we applied this turn, so repeated
     // rate-limit notices don't re-write the same value.
     let mut usage_pause_reset: Option<i64> = None;
@@ -972,12 +1021,34 @@ async fn stream_turn(
     // A stale overlay from a prior turn would otherwise show until the first tick.
     state.set_live_usage(None);
 
-    while let Some(item) = stream.next().await {
+    loop {
+        // Bound each wait for the next event by the heartbeat: a turn that goes
+        // silent past it is presumed dead (a heart attack), not merely slow.
+        let item = match timeout(HEARTBEAT_TIMEOUT, stream.next()).await {
+            Ok(Some(item)) => item,
+            // The stream ended: the claude process exited. Normal completion.
+            Ok(None) => break,
+            Err(_elapsed) => {
+                let minutes = HEARTBEAT_TIMEOUT.as_secs() / 60;
+                warn!(task_id = %task.id, minutes, "agent heartbeat timed out; presumed hung");
+                error_message = Some(format!(
+                    "No output from the agent for {minutes} minutes; presumed hung."
+                ));
+                heart_attack = true;
+                // Stop the stalled process now so it can't keep spinning orphaned
+                // and so the dropped stream's exec is reaped promptly.
+                kill_agent_process(state).await;
+                break;
+            }
+        };
         let event = match item {
             Ok(event) => event,
             Err(error) => {
+                // A broken stream means the docker exec/process died under us: a
+                // heart attack, not an agent-reported failure.
                 warn!(error = %error, "claude stream error");
                 error_message = Some(format!("Claude stream error: {error}"));
+                heart_attack = true;
                 break;
             }
         };
@@ -1111,6 +1182,7 @@ async fn stream_turn(
     Ok(TurnOutcome {
         session_id,
         error: error_message,
+        heart_attack,
         epoch: reset_epoch,
     })
 }
@@ -1295,6 +1367,161 @@ async fn block(state: &AppState, task: &Task, message: &str) -> Result<()> {
     Ok(())
 }
 
+// --- Dead-agent management (heart attacks / the defibrillator) ----------------
+
+/// Kills any `claude -p` process left running in the workspace. The agent is
+/// single-threaded, so on a healthy machine none should be running between turns;
+/// a leftover is an orphan from an aborted turn that would otherwise keep spinning
+/// (and contend on the shared session). The `[c]` keeps pkill from matching its
+/// own command line. Best-effort: a cleanup failure must never abort the caller.
+async fn kill_agent_process(state: &AppState) {
+    let _ = state
+        .workspace
+        .exec_capture(
+            "/workspace",
+            vec![
+                "bash".to_string(),
+                "-lc".to_string(),
+                "pkill -9 -f '[c]laude -p' || true".to_string(),
+            ],
+            vec![],
+        )
+        .await;
+}
+
+/// What the defibrillator should do with a task it just revived from a heart
+/// attack. A pure decision so the gating is unit-testable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Recovery {
+    /// Send a fresh task back to To Do to be reworked from a clean branch.
+    Requeue,
+    /// Return a task that already has a PR to In Review, where the review loop
+    /// re-evaluates it (and its own CI-fix budget bounds further attempts).
+    ReturnToReview,
+    /// Stop reviving and leave it failed for a human: it has died too many times.
+    GiveUp,
+}
+
+/// Decides how to recover a task given how many heart attacks it has now suffered
+/// (this one included) and whether it already has a pull request. A task that
+/// keeps dying is left for a human once it hits [`MAX_DEFIBRILLATIONS`].
+fn decide_recovery(incident_count: i64, has_pr: bool) -> Recovery {
+    if incident_count >= MAX_DEFIBRILLATIONS {
+        Recovery::GiveUp
+    } else if has_pr {
+        Recovery::ReturnToReview
+    } else {
+        Recovery::Requeue
+    }
+}
+
+/// The defibrillator: handles a task whose turn died (a heart attack). It stops
+/// the orphaned process, records the incident with its diagnostic detail so the
+/// operator can patch the cause later, revives the task (or leaves it for a human
+/// once it has died too often), and raises a UI alert.
+///
+/// `detail` is the diagnosis (why we think it died). `status_label` is the task's
+/// operational status at death, captured for the incident record.
+async fn defibrillate(
+    state: &AppState,
+    task: &Task,
+    status_label: &str,
+    detail: &str,
+) -> Result<()> {
+    warn!(task_id = %task.id, detail, "heart attack: defibrillating");
+
+    // Shock first: make sure no orphaned claude process keeps spinning.
+    kill_agent_process(state).await;
+
+    // Decide recovery from how many times this task has now died.
+    let incident_count = queries::count_heart_attacks_for_task(&state.db, task.id).await? + 1;
+    let recovery = decide_recovery(incident_count, task.pr_url.is_some());
+    let recovery_note = match recovery {
+        Recovery::Requeue => "Revived: requeued to To Do for a clean re-run.",
+        Recovery::ReturnToReview => "Revived: returned the pull request to review.",
+        Recovery::GiveUp => "Left for a human: too many heart attacks on this task.",
+    };
+
+    // Record the incident before acting, so the alert and its logs survive even if
+    // the recovery move below fails. A blank title is unhelpful in the banner.
+    let title = if task.title.trim().is_empty() {
+        "(untitled task)"
+    } else {
+        task.title.trim()
+    };
+    let detail: String = detail.trim().chars().take(2000).collect();
+    queries::create_heart_attack(
+        &state.db,
+        Some(task.id),
+        title,
+        status_label,
+        &detail,
+        recovery_note,
+    )
+    .await?;
+
+    // Carry out the recovery.
+    match recovery {
+        Recovery::Requeue => {
+            let position = top_of_column_position(state, TaskColumn::Todo).await?;
+            queries::move_task(&state.db, task.id, TaskColumn::Todo, position).await?;
+        }
+        Recovery::ReturnToReview => {
+            queries::move_task(&state.db, task.id, TaskColumn::InReview, task.position).await?;
+            queries::set_task_status(&state.db, task.id, TaskStatus::AwaitingReview).await?;
+        }
+        Recovery::GiveUp => {
+            let note = format!("{detail} ({recovery_note})");
+            let trimmed: String = note.trim().chars().take(800).collect();
+            queries::set_task_error(&state.db, task.id, &trimmed).await?;
+            queries::move_task(&state.db, task.id, TaskColumn::InReview, task.position).await?;
+        }
+    }
+
+    state.notify_board();
+    state.notify_heart_attack(
+        Some(task.id),
+        title.to_string(),
+        format!("Agent heart attack. {recovery_note}"),
+    );
+    Ok(())
+}
+
+/// The defibrillator watchdog: a backstop for a turn that died without the
+/// in-turn heartbeat catching it (an aborted agent loop, a wedged non-stream
+/// await). It runs independently of the single-threaded agent loop, so it can act
+/// even while that loop is blocked.
+///
+/// It only reaps a task left `working` with no activity for longer than
+/// [`WATCHDOG_TIMEOUT`], which is strictly greater than [`HEARTBEAT_TIMEOUT`]; a
+/// healthy turn keeps its activity fresh on every event and self-terminates
+/// through the in-turn heartbeat well before this fires, so it never races a live
+/// turn.
+async fn defibrillator_loop(state: AppState) {
+    loop {
+        sleep(DEFIB_POLL).await;
+        let stale_secs = i64::try_from(WATCHDOG_TIMEOUT.as_secs()).unwrap_or(i64::MAX);
+        match queries::find_stranded_task(&state.db, stale_secs).await {
+            Ok(Some(task)) => {
+                // Invalidate the wedged turn so that, if it ever unblocks, its
+                // post-turn handling abandons rather than clobbering the recovery
+                // (the same guard a hard reset relies on).
+                state.bump_reset_epoch();
+                let detail = format!(
+                    "The turn was stuck working with no activity for over {} minutes and did \
+                     not recover on its own.",
+                    WATCHDOG_TIMEOUT.as_secs() / 60,
+                );
+                if let Err(error) = defibrillate(&state, &task, "working", &detail).await {
+                    error!(error = %error, task_id = %task.id, "defibrillator failed to recover a stranded task");
+                }
+            }
+            Ok(None) => {}
+            Err(error) => warn!(error = %error, "defibrillator watchdog query failed"),
+        }
+    }
+}
+
 /// Detects the open PR for `branch`, retrying to absorb GitHub's indexing lag.
 ///
 /// A freshly created PR can take a few seconds to surface in the head-filtered
@@ -1390,6 +1617,25 @@ mod tests {
     fn slugify_is_branch_safe() {
         assert_eq!(slugify("Fix the Login Bug!"), "fix-the-login-bug");
         assert_eq!(slugify("   spaces   "), "spaces");
+    }
+
+    #[test]
+    fn defibrillator_revives_then_gives_up() {
+        // A fresh task (no PR) is requeued; one with a PR returns to review.
+        assert_eq!(decide_recovery(1, false), Recovery::Requeue);
+        assert_eq!(decide_recovery(1, true), Recovery::ReturnToReview);
+        assert_eq!(decide_recovery(2, false), Recovery::Requeue);
+        // Once it has died too many times, stop reviving and leave it for a human,
+        // regardless of whether it has a PR.
+        assert_eq!(
+            decide_recovery(MAX_DEFIBRILLATIONS, false),
+            Recovery::GiveUp
+        );
+        assert_eq!(decide_recovery(MAX_DEFIBRILLATIONS, true), Recovery::GiveUp);
+        assert_eq!(
+            decide_recovery(MAX_DEFIBRILLATIONS + 1, false),
+            Recovery::GiveUp
+        );
     }
 
     #[test]

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -36,6 +36,14 @@ pub enum ServerEvent {
         task_title: String,
         prompt: String,
     },
+    /// A turn died mid-flight (a "heart attack") and the defibrillator handled it;
+    /// drives an alert toast and native notification so the operator notices.
+    HeartAttack {
+        task_id: Option<Uuid>,
+        task_title: String,
+        /// A one-line summary of what happened and what the defibrillator did.
+        summary: String,
+    },
     /// A throttled tick that the in-progress turn's token usage advanced, so the
     /// stats gauges refetch and the counter ticks live mid-turn. Carries no
     /// numbers; the live values live on [`AppState::live_usage`] and are read by
@@ -232,6 +240,16 @@ impl AppState {
             task_id,
             task_title,
             prompt,
+        });
+    }
+
+    /// Announces a heart attack so the UI alerts the operator immediately, in
+    /// addition to the persistent board banner driven by [`Self::notify_board`].
+    pub fn notify_heart_attack(&self, task_id: Option<Uuid>, task_title: String, summary: String) {
+        let _ = self.events.send(ServerEvent::HeartAttack {
+            task_id,
+            task_title,
+            summary,
         });
     }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   ConfigBundle,
   EnvSuggestion,
   EnvVar,
+  HeartAttack,
   IssueComment,
   IssueDetail,
   IssueThread,
@@ -125,6 +126,13 @@ export function createIssueFromSuggestion(suggestionId: string, target: CreateIs
   return apiClient
     .post(`suggestions/${suggestionId}/create`, { json: { target } })
     .json<{ suggestion: EnvSuggestion; url: string | null }>()
+}
+
+// --- Heart attacks (dead-agent management) -----------------------------------
+
+// Clears a heart attack from the board banner once the operator has read it.
+export function acknowledgeHeartAttack(id: string) {
+  return apiClient.post(`heart-attacks/${id}/ack`).json<HeartAttack>()
 }
 
 // --- Questions ---------------------------------------------------------------

--- a/frontend/src/lib/components/Notifications.svelte
+++ b/frontend/src/lib/components/Notifications.svelte
@@ -21,9 +21,12 @@
 
   type Toast = {
     id: number
-    taskId: string
+    // The task to open when clicked; null for a heart attack whose task is gone.
+    taskId: string | null
     taskTitle: string
     prompt: string
+    // 'question' is the agent asking for input; 'heart_attack' is a dead turn.
+    kind: 'question' | 'heart_attack'
   }
 
   function loadIds(key: string): Set<string> {
@@ -112,9 +115,14 @@
     }
   }
 
-  function pushToast(taskId: string, taskTitle: string, prompt: string) {
+  function pushToast(
+    taskId: string | null,
+    taskTitle: string,
+    prompt: string,
+    kind: Toast['kind'] = 'question'
+  ) {
     const id = nextToastId++
-    toasts = [...toasts, { id, taskId, taskTitle, prompt }]
+    toasts = [...toasts, { id, taskId, taskTitle, prompt, kind }]
     setTimeout(() => dismissToast(id), TOAST_TIMEOUT_MS)
   }
 
@@ -122,10 +130,13 @@
     toasts = toasts.filter((toast) => toast.id !== id)
   }
 
-  function goToTask(taskId: string) {
+  function goToTask(taskId: string | null) {
     open = false
     toasts = []
-    goto(`/task/${taskId}`)
+    // A heart attack whose task was deleted has nowhere to navigate.
+    if (taskId) {
+      goto(`/task/${taskId}`)
+    }
   }
 
   function openTask(question: PendingQuestion) {
@@ -140,6 +151,19 @@
     refresh()
   }
 
+  // A turn died (a "heart attack"); the defibrillator already handled recovery.
+  // Surface it immediately as an alert toast and native notification; the board's
+  // own banner persists the detail until the operator clears it.
+  function handleHeartAttack(event: MessageEvent) {
+    const data = JSON.parse(event.data) as {
+      task_id: string | null
+      task_title: string
+      summary: string
+    }
+    pushToast(data.task_id, data.task_title, data.summary, 'heart_attack')
+    notifyNatively(`Agent heart attack: ${data.task_title}`, data.summary)
+  }
+
   onMount(() => {
     refresh()
     // Prompt for native desktop notifications on first load, as the issue asks.
@@ -152,6 +176,7 @@
     // question answered elsewhere) refreshes the pending list.
     eventSource = new EventSource('/api/v1/notifications/stream')
     eventSource.addEventListener('notification', handleNotification)
+    eventSource.addEventListener('heart_attack', handleHeartAttack)
     eventSource.addEventListener('refresh', () => refresh())
   })
 
@@ -243,16 +268,25 @@
 <div class="pointer-events-none fixed bottom-5 right-5 z-50 flex max-w-sm flex-col gap-2">
   {#each toasts as toast (toast.id)}
     <div
-      class="pointer-events-auto flex items-start overflow-hidden rounded-lg border border-warning/50 bg-card shadow-2xl"
+      class="pointer-events-auto flex items-start overflow-hidden rounded-lg border bg-card shadow-2xl {toast.kind ===
+      'heart_attack'
+        ? 'border-destructive/60'
+        : 'border-warning/50'}"
     >
       <button
         type="button"
         class="flex flex-1 flex-col gap-0.5 px-4 py-3 text-left"
         onclick={() => goToTask(toast.taskId)}
       >
-        <span class="text-[10px] font-bold uppercase tracking-wide text-warning"
-          >Seraphim needs your input</span
-        >
+        {#if toast.kind === 'heart_attack'}
+          <span class="text-[10px] font-bold uppercase tracking-wide text-destructive"
+            >Agent heart attack</span
+          >
+        {:else}
+          <span class="text-[10px] font-bold uppercase tracking-wide text-warning"
+            >Seraphim needs your input</span
+          >
+        {/if}
         <span class="text-xs text-muted-foreground">{toast.taskTitle}</span>
         <span class="text-sm">{toast.prompt}</span>
       </button>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -335,11 +335,29 @@ export type AutomationRule = {
   updated_at: string
 }
 
+// A recorded "heart attack": a turn that died mid-flight. The defibrillator
+// records one so the operator is alerted with the diagnostic logs.
+export type HeartAttack = {
+  id: string
+  task_id: string | null
+  task_title: string
+  status_label: string
+  // The diagnosis / error logs, kept so the cause can be patched later.
+  detail: string
+  // What the defibrillator did about it (revived, or left for a human).
+  recovery: string
+  acknowledged: boolean
+  created_at: string
+  acknowledged_at: string | null
+}
+
 export type BoardResponse = {
   tasks: Task[]
   settings: Settings
   // Unacknowledged suggestion counts keyed by task id (tasks with none omitted).
   suggestion_counts: Record<string, number>
+  // Unacknowledged heart attacks (dead turns), newest first, for the alert banner.
+  heart_attacks: HeartAttack[]
 }
 
 export type TaskDetail = {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import type { DndEvent } from 'svelte-dnd-action'
-  import type { Settings, Task, TaskColumn } from '$lib/types'
+  import type { HeartAttack, Settings, Task, TaskColumn } from '$lib/types'
 
   import { onMount, onDestroy } from 'svelte'
   import { dndzone } from 'svelte-dnd-action'
-  import { NotebookPen, RefreshCw, Pause, Play, Eye, EyeOff } from '@lucide/svelte'
+  import { HeartPulse, NotebookPen, RefreshCw, Pause, Play, Eye, EyeOff, X } from '@lucide/svelte'
   import { PaneGroup } from 'paneforge'
 
   import { COLUMNS } from '$lib/types'
   import {
+    acknowledgeHeartAttack,
     getBoard,
     getNotepad,
     listRepos,
@@ -32,6 +33,9 @@
 
   let settings = $state<Settings | null>(null)
   let suggestionCounts = $state<Record<string, number>>({})
+  // Unacknowledged heart attacks (dead turns) the defibrillator recorded; shown
+  // as a dismissible alert banner so the operator notices and can read the logs.
+  let heartAttacks = $state<HeartAttack[]>([])
   // One array per lane; svelte-dnd-action mutates these during a drag.
   let columns = $state<Record<TaskColumn, Task[]>>({
     available: [],
@@ -131,6 +135,7 @@
     const [board, repos] = await Promise.all([getBoard(), listRepos()])
     settings = board.settings
     suggestionCounts = board.suggestion_counts
+    heartAttacks = board.heart_attacks
     repoNames = Object.fromEntries(repos.map((repo) => [repo.id, repo.full_name]))
     const grouped: Record<TaskColumn, Task[]> = {
       available: [],
@@ -150,6 +155,17 @@
       grouped[key] = sortTasks(grouped[key], sortState[key])
     }
     columns = grouped
+  }
+
+  // Clears a heart-attack alert once the operator has read it. Optimistic: drop
+  // it locally first so the banner feels instant, then persist.
+  async function dismissHeartAttack(id: string) {
+    heartAttacks = heartAttacks.filter((incident) => incident.id !== id)
+    try {
+      await acknowledgeHeartAttack(id)
+    } catch (error) {
+      console.debug('failed to acknowledge heart attack', error)
+    }
   }
 
   function handleConsider(column: TaskColumn, event: CustomEvent<DndEvent<Task>>) {
@@ -262,6 +278,41 @@
   `lg`-only; on narrow screens the lanes stack and the page scrolls normally.
 -->
 <div class="flex flex-col lg:h-full lg:min-h-0">
+  {#each heartAttacks as incident (incident.id)}
+    <!-- A turn died and the defibrillator handled it. Keep the diagnostic detail
+         visible (monospaced) so the operator can patch the underlying cause, with
+         a dismiss once they have read it. -->
+    <Alert.Root variant="destructive" class="mx-6 mt-4 flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <Alert.Title class="flex items-center gap-1.5">
+          <HeartPulse class="size-4 flex-none" />
+          Agent heart attack: "{incident.task_title}"
+        </Alert.Title>
+        <Alert.Description class="break-words">
+          <span class="font-mono text-xs break-words">{incident.detail}</span>
+          {#if incident.recovery}
+            <span class="mt-1 block text-xs opacity-80">{incident.recovery}</span>
+          {/if}
+          {#if incident.task_id}
+            <a href={`/task/${incident.task_id}`} class="mt-1 inline-block text-xs underline">
+              Open the task to see the full activity log
+            </a>
+          {/if}
+        </Alert.Description>
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        class="flex-none"
+        title="Dismiss"
+        aria-label="Dismiss heart attack"
+        onclick={() => dismissHeartAttack(incident.id)}
+      >
+        <X class="size-4" />
+      </Button>
+    </Alert.Root>
+  {/each}
+
   {#if settings?.config_repo_error}
     <Alert.Root variant="destructive" class="mx-6 mt-4 flex items-center justify-between gap-4">
       <div>


### PR DESCRIPTION
Closes #89.

## Problem

A turn sometimes dies mid-flight: the agent hangs with no output, its Claude stream breaks, or the turn aborts on an internal error (the issue's example was a NUL-byte DB write). Today that strands the card in **In Progress**, can leave the `claude -p` child spinning orphaned, and freezes the UI on the last message with nothing recovering it.

Per the issue, this names the condition a **"heart attack"**, the recovery a **"defibrillator"**, and alerts the operator in the UI with the error logs so the underlying cause can be patched later.

## Detection (layered, tuned to avoid false positives on slow builds)

- **In-turn heartbeat** (`stream_turn`): each wait for the next event is bounded by `HEARTBEAT_TIMEOUT` (20 min). A healthy turn streams partial-message usage events continuously, so the only legitimate silence is one long tool call; a longer silence ends the turn as a heart attack and kills the stalled process.
- **`agent_loop`** now catches a turn that aborted with an error (a `?` propagating) instead of only logging it, so a stranded card is recovered rather than left stuck (the exact bug from the issue).
- **Watchdog** (`defibrillator_loop`): a background loop that reaps any task left `working` with no activity past `WATCHDOG_TIMEOUT` (25 min). It is strictly above the heartbeat, so a live turn always self-terminates first and the watchdog never races it.

## Recovery (the defibrillator)

All three paths funnel into `defibrillate`, which:
- kills the orphaned `claude -p` child (`kill_agent_process`) — fixes the process leak;
- records the incident in a new `heart_attacks` table with the diagnostic detail, kept for later patching;
- revives the task: requeue to **To Do** if it had no PR, else return to **In Review**, bounded by `MAX_DEFIBRILLATIONS` (3) before leaving it failed for a human.

The revive-vs-give-up choice is the pure, unit-tested `decide_recovery`.

## Operator alert

- A persistent, dismissible **red banner** on the board carries the error logs and links to the task's full activity log; `POST /heart-attacks/:id/ack` clears it.
- A **toast and native notification** fire immediately via the notifications SSE stream.

## Safety / scope

- The single-threaded model and the reset-epoch guard are preserved; the watchdog bumps the epoch so a wedged turn that later unblocks abandons its post-handling rather than clobbering the recovery.
- A heart attack is a new turn outcome distinct from a plain failure; existing `fail`/`block` paths and all other outcomes are unchanged.

## Validation

- `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (no new warnings), `test` (65 passing, including the new `decide_recovery` test); frontend `yarn check` and `yarn build` green.

## Note

`HEARTBEAT_TIMEOUT`/`WATCHDOG_TIMEOUT` are constants. If an operator runs unusually long silent build steps, they could be promoted to settings later; left as documented constants here to keep the change focused.