### PR TITLE
Add a Tailscale management UI (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,12 @@ scripts/    start.sh stop.sh restart.sh
 - `src/db/` — `models.rs` (enums + `FromRow` structs), `queries.rs` (runtime sqlx), `mod.rs` (pool + migrate). Migrations in `api/migrations/`.
 - `src/claude/` — `events.rs` (stream-json parser, unit-tested), `exec.rs` (the `docker exec` turn runner).
 - `src/docker/` — `Workspace`: exec, restart, recreate (bollard).
+- `src/tailscale/` — `Tailscale`: manages the `seraphim-tailscale` sidecar via the
+  host Docker socket (exec `tailscale status/up/down/login` as root, container
+  restart). Powers the Settings → Tailscale panel (`http/tailscale.rs`,
+  `/api/v1/tailscale/{status,up,down,reauth,restart}`): the tailnet URL, hosting
+  status, connect/disconnect, and a login URL when the node needs auth. Status
+  JSON parsing is pure + unit-tested. Container name from `TAILSCALE_CONTAINER`.
 - `src/sources/` — `Source` enum (GitHub; Jira is a future variant), `github.rs`, `types.rs`.
 - `src/git/` — PR detection, CI-green check, squash-merge (octocrab).
 - `src/orchestrator/` — `mod.rs` (the loops), `provision.rs` (workspace provisioning), `prompt.rs`.

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub claude_model: String,
     pub org_name: String,
     pub workspace_container: String,
+    /// Name of the Tailscale sidecar container the API manages via Docker.
+    pub tailscale_container: String,
     /// URL the workspace container uses to reach this API, so the agent's
     /// `seraphim-ask` and `seraphim-suggest` helpers can post questions and
     /// recommendations. Defaults to the compose service address (`api:27182`),
@@ -57,6 +59,8 @@ impl Config {
             org_name: env::var("ORG_NAME").unwrap_or_else(|_| "Seraphim".to_string()),
             workspace_container: env::var("WORKSPACE_CONTAINER")
                 .unwrap_or_else(|_| "seraphim-workspace".to_string()),
+            tailscale_container: env::var("TAILSCALE_CONTAINER")
+                .unwrap_or_else(|_| "seraphim-tailscale".to_string()),
             internal_api_url: env::var("INTERNAL_API_URL")
                 .unwrap_or_else(|_| "http://api:27182".to_string()),
             update: UpdateConfig {

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -16,6 +16,7 @@ mod settings;
 mod sse;
 mod stats;
 mod suggestions;
+mod tailscale;
 mod tasks;
 mod update;
 mod webhooks;
@@ -124,6 +125,11 @@ pub fn router(state: AppState) -> Router {
         .route("/workspace/recreate", post(workspace::recreate))
         .route("/workspace/provision", post(workspace::provision))
         .route("/agent/reset", post(workspace::reset))
+        .route("/tailscale/status", get(tailscale::status))
+        .route("/tailscale/up", post(tailscale::up))
+        .route("/tailscale/down", post(tailscale::down))
+        .route("/tailscale/reauth", post(tailscale::reauth))
+        .route("/tailscale/restart", post(tailscale::restart))
         .route(
             "/automation/rules",
             get(automation::list).post(automation::create),

--- a/api/src/http/tailscale.rs
+++ b/api/src/http/tailscale.rs
@@ -1,0 +1,120 @@
+//! Tailscale sidecar management endpoints (issue #52): read the node status and
+//! run the handful of management actions surfaced in the Settings UI.
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use super::ApiResult;
+use crate::state::AppState;
+use crate::tailscale::TailscaleStatus;
+
+/// A management action's result plus the refreshed node status, so the UI updates
+/// in one round-trip and can show what happened.
+#[derive(Debug, Serialize)]
+pub struct TailscaleActionResponse {
+    /// Whether the underlying command succeeded.
+    pub ok: bool,
+    /// A short human-readable result (the command's own output when it has any).
+    pub message: String,
+    /// The node status after the action.
+    pub status: TailscaleStatus,
+}
+
+/// `GET /api/v1/tailscale/status` - the node's current state for the UI panel.
+pub async fn status(State(state): State<AppState>) -> ApiResult<Json<TailscaleStatus>> {
+    Ok(Json(state.tailscale.status().await?))
+}
+
+/// `POST /api/v1/tailscale/up` - connect the node to the tailnet.
+pub async fn up(State(state): State<AppState>) -> ApiResult<Json<TailscaleActionResponse>> {
+    info!("tailscale up requested");
+    let (ok, message) = match state.tailscale.up().await {
+        Ok(output) => (
+            output.succeeded(),
+            action_message(&output.output, "Connecting to the tailnet."),
+        ),
+        Err(error) => (false, error.to_string()),
+    };
+    Ok(Json(action_response(&state, ok, message).await))
+}
+
+/// `POST /api/v1/tailscale/down` - disconnect the node from the tailnet.
+pub async fn down(State(state): State<AppState>) -> ApiResult<Json<TailscaleActionResponse>> {
+    info!("tailscale down requested");
+    let (ok, message) = match state.tailscale.down().await {
+        Ok(output) => (
+            output.succeeded(),
+            action_message(&output.output, "Disconnecting from the tailnet."),
+        ),
+        Err(error) => (false, error.to_string()),
+    };
+    Ok(Json(action_response(&state, ok, message).await))
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ReauthRequest {
+    /// Force a fresh login even if the node is already authenticated (this is how
+    /// the operator gets a new login URL). Off by default.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// `POST /api/v1/tailscale/reauth` - start an interactive login and surface the
+/// URL the operator must visit to authenticate the node.
+pub async fn reauth(
+    State(state): State<AppState>,
+    Json(body): Json<ReauthRequest>,
+) -> ApiResult<Json<TailscaleActionResponse>> {
+    info!(force = body.force, "tailscale reauth requested");
+    let (ok, message, login_url) = match state.tailscale.reauth(body.force).await {
+        Ok(Some(url)) => (
+            true,
+            "Open the login URL to authenticate this node.".to_string(),
+            Some(url),
+        ),
+        Ok(None) => (
+            true,
+            "Re-authentication started; refresh for the login URL.".to_string(),
+            None,
+        ),
+        Err(error) => (false, error.to_string(), None),
+    };
+    let mut response = action_response(&state, ok, message).await;
+    // Prefer the URL the daemon reports in status; otherwise the one login printed.
+    if response.status.auth_url.is_none() {
+        response.status.auth_url = login_url;
+    }
+    Ok(Json(response))
+}
+
+/// `POST /api/v1/tailscale/restart` - restart the Tailscale container in place.
+pub async fn restart(State(state): State<AppState>) -> ApiResult<Json<TailscaleActionResponse>> {
+    info!("tailscale restart requested");
+    let (ok, message) = match state.tailscale.restart().await {
+        Ok(()) => (true, "Restarting the Tailscale container.".to_string()),
+        Err(error) => (false, error.to_string()),
+    };
+    Ok(Json(action_response(&state, ok, message).await))
+}
+
+/// Re-reads the node status (best-effort) and packages it with the action result.
+async fn action_response(state: &AppState, ok: bool, message: String) -> TailscaleActionResponse {
+    let status = state.tailscale.status().await.unwrap_or_default();
+    TailscaleActionResponse {
+        ok,
+        message,
+        status,
+    }
+}
+
+/// The command's own output, trimmed, or a friendly fallback when it printed none.
+fn action_message(output: &str, fallback: &str) -> String {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -15,6 +15,7 @@ mod jira;
 mod orchestrator;
 mod secrets;
 mod state;
+mod tailscale;
 mod update;
 
 use eyre::{Context, Result};
@@ -49,10 +50,12 @@ async fn main() -> Result<()> {
         config.workspace_container.clone(),
         settings.workspace_image_tag.clone(),
     )?;
+    let tailscale = tailscale::Tailscale::connect(config.tailscale_container.clone())?;
 
     let state = AppState::new(
         db,
         workspace,
+        tailscale,
         config.internal_api_url.clone(),
         config.update.clone(),
     );

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -75,6 +75,8 @@ pub struct LiveUsage {
 pub struct AppState {
     pub db: PgPool,
     pub workspace: Workspace,
+    /// Handle to the Tailscale sidecar container, for the management UI.
+    pub tailscale: crate::tailscale::Tailscale,
     pub events: broadcast::Sender<ServerEvent>,
     /// URL the workspace uses to reach this API (for the agent's helpers).
     pub internal_api_url: String,
@@ -119,6 +121,7 @@ impl AppState {
     pub fn new(
         db: PgPool,
         workspace: Workspace,
+        tailscale: crate::tailscale::Tailscale,
         internal_api_url: String,
         update: crate::config::UpdateConfig,
     ) -> Self {
@@ -136,6 +139,7 @@ impl AppState {
         Self {
             db,
             workspace,
+            tailscale,
             events,
             internal_api_url,
             cooldown_until: Arc::new(RwLock::new(None)),

--- a/api/src/tailscale/mod.rs
+++ b/api/src/tailscale/mod.rs
@@ -1,0 +1,401 @@
+//! Management of the Tailscale sidecar container (issue #52).
+//!
+//! Tailscale runs as its own container (`seraphim-tailscale`) that exposes the UI
+//! over the tailnet with `tailscale serve`. The API already drives other
+//! containers through the host Docker socket; this module reaches into the
+//! Tailscale container the same way to read its status (the serve URL, online
+//! state, the login URL when auth is needed) and to run the handful of management
+//! commands the operator wants from the UI: connect, disconnect, re-authenticate,
+//! and restart.
+//!
+//! Everything is best-effort and tolerant: the Tailscale CLI's JSON shape is read
+//! leniently (unknown fields ignored, missing fields defaulted), and commands are
+//! bounded by a timeout so a request never hangs on a node that is waiting for
+//! interactive login.
+
+use std::time::Duration;
+
+use bollard::container::LogOutput;
+use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::Docker;
+use eyre::{Context, Result};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::time::{timeout, timeout_at, Instant};
+
+use crate::docker::ExecOutput;
+
+/// Upper bound on a single Tailscale command. Generous, but it keeps a request
+/// from hanging forever if the daemon stalls.
+const EXEC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long we wait for `tailscale login` to print its URL before returning. The
+/// command keeps running in the container afterward, so the pending login (and
+/// its URL) stay valid for the operator to finish in the browser.
+const REAUTH_WAIT: Duration = Duration::from_secs(8);
+
+/// Handle to the Tailscale sidecar container on the host Docker daemon.
+#[derive(Debug, Clone)]
+pub struct Tailscale {
+    docker: Docker,
+    container: String,
+}
+
+/// The Tailscale node's state as the UI sees it.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "a flat status DTO of independent node-state flags for the UI"
+)]
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TailscaleStatus {
+    /// Whether the sidecar container itself is running. When false, the rest is
+    /// empty and the management actions are unavailable.
+    pub container_running: bool,
+    /// The daemon's backend state, e.g. `Running`, `Stopped`, `NeedsLogin`.
+    pub backend_state: String,
+    /// True when the node is connected to the tailnet (`backend_state == Running`).
+    pub connected: bool,
+    /// Whether this node currently shows as online in the tailnet.
+    pub online: bool,
+    /// True when the node needs the operator to authenticate it.
+    pub needs_login: bool,
+    /// The node's short hostname on the tailnet.
+    pub hostname: String,
+    /// The node's `MagicDNS` name (trailing dot stripped), e.g. `seraphim.tailnet.ts.net`.
+    pub dns_name: String,
+    /// The HTTPS URL the UI is reachable at over the tailnet, when known.
+    pub url: Option<String>,
+    /// The tailnet's name (e.g. the owning account), when known.
+    pub tailnet: String,
+    /// The node's tailnet IPs.
+    pub tailscale_ips: Vec<String>,
+    /// A pending interactive-login URL the operator should visit, when one exists.
+    pub auth_url: Option<String>,
+    /// Whether `tailscale serve` is actively proxying (the UI is being hosted).
+    pub serve_active: bool,
+}
+
+impl Tailscale {
+    /// Connects to the local Docker daemon (the mounted host socket).
+    pub fn connect(container: impl Into<String>) -> Result<Self> {
+        let docker = Docker::connect_with_local_defaults()
+            .wrap_err("failed to connect to the Docker daemon")?;
+        Ok(Self {
+            docker,
+            container: container.into(),
+        })
+    }
+
+    /// Whether the Tailscale container is currently running.
+    async fn is_running(&self) -> bool {
+        match self.docker.inspect_container(&self.container, None).await {
+            Ok(info) => info.state.and_then(|state| state.running).unwrap_or(false),
+            Err(_) => false,
+        }
+    }
+
+    /// Runs `tailscale <args>` in the container (as root, which the CLI needs to
+    /// reach the local daemon socket), capturing combined stdout/stderr + the exit
+    /// code. Bounded by [`EXEC_TIMEOUT`].
+    async fn run(&self, args: &[&str]) -> Result<ExecOutput> {
+        let mut cmd = vec!["tailscale".to_string()];
+        cmd.extend(args.iter().map(|arg| (*arg).to_string()));
+
+        let exec = self
+            .docker
+            .create_exec(
+                &self.container,
+                CreateExecOptions {
+                    cmd: Some(cmd),
+                    user: Some("root".to_string()),
+                    attach_stdout: Some(true),
+                    attach_stderr: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .wrap_err("failed to create tailscale exec")?;
+
+        let output = timeout(EXEC_TIMEOUT, self.drain(&exec.id))
+            .await
+            .wrap_err("the tailscale command timed out")??;
+        let inspect = self.docker.inspect_exec(&exec.id).await?;
+        Ok(ExecOutput {
+            exit_code: inspect.exit_code.unwrap_or(-1),
+            output,
+        })
+    }
+
+    /// Reads an exec's combined output to completion.
+    async fn drain(&self, exec_id: &str) -> Result<String> {
+        let mut collected = String::new();
+        if let StartExecResults::Attached { mut output, .. } =
+            self.docker.start_exec(exec_id, None).await?
+        {
+            while let Some(chunk) = output.next().await {
+                match chunk? {
+                    LogOutput::StdOut { message }
+                    | LogOutput::StdErr { message }
+                    | LogOutput::Console { message } => {
+                        collected.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    LogOutput::StdIn { .. } => {}
+                }
+            }
+        }
+        Ok(collected)
+    }
+
+    /// The full node status, including the serve URL and any pending login URL.
+    pub async fn status(&self) -> Result<TailscaleStatus> {
+        if !self.is_running().await {
+            return Ok(TailscaleStatus::default());
+        }
+        let status = self.run(&["status", "--json"]).await?;
+        // Serve status is a nice-to-have; never let it fail the whole status read.
+        let serve_active = match self.run(&["serve", "status", "--json"]).await {
+            Ok(serve) => serve_is_active(&serve.output),
+            Err(_) => false,
+        };
+        Ok(parse_status(&status.output, true, serve_active))
+    }
+
+    /// Connects the node to the tailnet (`tailscale up`). After a prior `down`, this
+    /// reconnects with the node's existing preferences (it does not reset them).
+    pub async fn up(&self) -> Result<ExecOutput> {
+        self.run(&["up"]).await
+    }
+
+    /// Disconnects the node from the tailnet (`tailscale down`). The container keeps
+    /// running, so the node can be brought back up without a restart.
+    pub async fn down(&self) -> Result<ExecOutput> {
+        self.run(&["down"]).await
+    }
+
+    /// Starts an interactive login and returns the URL the operator must visit.
+    ///
+    /// `tailscale login` blocks until the user finishes authenticating, so we only
+    /// wait long enough to capture the printed URL ([`REAUTH_WAIT`]) and then leave
+    /// it running: the daemon keeps the pending login (and its URL) alive until the
+    /// browser visit completes. `force` re-authenticates even an already-logged-in
+    /// node, which is how the operator gets a fresh login link.
+    pub async fn reauth(&self, force: bool) -> Result<Option<String>> {
+        let mut cmd = vec!["tailscale".to_string(), "login".to_string()];
+        if force {
+            cmd.push("--force-reauth".to_string());
+        }
+        let exec = self
+            .docker
+            .create_exec(
+                &self.container,
+                CreateExecOptions {
+                    cmd: Some(cmd),
+                    user: Some("root".to_string()),
+                    attach_stdout: Some(true),
+                    attach_stderr: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .wrap_err("failed to start tailscale login")?;
+
+        let mut collected = String::new();
+        if let StartExecResults::Attached { mut output, .. } =
+            self.docker.start_exec(&exec.id, None).await?
+        {
+            let deadline = Instant::now() + REAUTH_WAIT;
+            // Read until the login URL appears, the command exits, or our wait is up
+            // (whichever comes first); login keeps running in the container after.
+            while let Ok(Some(chunk)) = timeout_at(deadline, output.next()).await {
+                match chunk {
+                    Ok(
+                        LogOutput::StdOut { message }
+                        | LogOutput::StdErr { message }
+                        | LogOutput::Console { message },
+                    ) => collected.push_str(&String::from_utf8_lossy(&message)),
+                    Ok(LogOutput::StdIn { .. }) => {}
+                    Err(_) => break,
+                }
+                if extract_login_url(&collected).is_some() {
+                    break;
+                }
+            }
+        }
+        Ok(extract_login_url(&collected))
+    }
+
+    /// Restarts the Tailscale container in place (re-runs its entrypoint, which
+    /// re-applies the serve config and any auth key). Volumes are preserved.
+    pub async fn restart(&self) -> Result<()> {
+        self.docker
+            .restart_container(&self.container, None)
+            .await
+            .wrap_err("failed to restart the tailscale container")
+    }
+}
+
+/// `tailscale status --json`, read leniently into just the fields the UI needs.
+#[derive(Debug, Default, Deserialize)]
+struct RawStatus {
+    #[serde(rename = "BackendState")]
+    backend_state: Option<String>,
+    #[serde(rename = "AuthURL")]
+    auth_url: Option<String>,
+    #[serde(rename = "TailscaleIPs")]
+    tailscale_ips: Option<Vec<String>>,
+    #[serde(rename = "Self")]
+    self_node: Option<RawNode>,
+    #[serde(rename = "CurrentTailnet")]
+    tailnet: Option<RawTailnet>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawNode {
+    #[serde(rename = "DNSName")]
+    dns_name: Option<String>,
+    #[serde(rename = "HostName")]
+    host_name: Option<String>,
+    #[serde(rename = "Online")]
+    online: Option<bool>,
+    #[serde(rename = "TailscaleIPs")]
+    tailscale_ips: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawTailnet {
+    #[serde(rename = "Name")]
+    name: Option<String>,
+}
+
+/// Maps `tailscale status --json` plus the externally-determined container/serve
+/// state into the UI status. Pure, so it is unit-tested against real CLI output.
+fn parse_status(json: &str, container_running: bool, serve_active: bool) -> TailscaleStatus {
+    let raw: RawStatus = serde_json::from_str(json).unwrap_or_default();
+    let backend_state = raw.backend_state.unwrap_or_default();
+    let node = raw.self_node.unwrap_or_default();
+
+    let dns_name = node
+        .dns_name
+        .unwrap_or_default()
+        .trim_end_matches('.')
+        .to_string();
+    let url = (!dns_name.is_empty()).then(|| format!("https://{dns_name}"));
+
+    TailscaleStatus {
+        container_running,
+        connected: backend_state == "Running",
+        needs_login: matches!(backend_state.as_str(), "NeedsLogin" | "NoState"),
+        online: node.online.unwrap_or(false),
+        hostname: node.host_name.unwrap_or_default(),
+        dns_name,
+        url,
+        tailnet: raw
+            .tailnet
+            .and_then(|tailnet| tailnet.name)
+            .unwrap_or_default(),
+        tailscale_ips: node.tailscale_ips.or(raw.tailscale_ips).unwrap_or_default(),
+        auth_url: raw.auth_url.filter(|url| !url.trim().is_empty()),
+        serve_active,
+        backend_state,
+    }
+}
+
+/// Whether `tailscale serve status --json` shows anything being served. The CLI
+/// prints `null`/`{}` when nothing is served, else a config with `TCP`/`Web` keys.
+fn serve_is_active(json: &str) -> bool {
+    match serde_json::from_str::<serde_json::Value>(json) {
+        Ok(serde_json::Value::Object(map)) => {
+            map.get("TCP").is_some_and(|value| !value.is_null())
+                || map.get("Web").is_some_and(|value| !value.is_null())
+        }
+        _ => false,
+    }
+}
+
+/// Extracts the interactive-login URL from `tailscale login` output. The CLI
+/// prints something like "To authenticate, visit:\n\n\thttps://login.tailscale.com/a/abc".
+fn extract_login_url(text: &str) -> Option<String> {
+    text.split_whitespace()
+        .find(|token| token.starts_with("https://") && token.contains("tailscale.com/"))
+        .map(|token| token.trim_end_matches(['.', ',', ')']).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+        "BackendState": "Running",
+        "AuthURL": "",
+        "TailscaleIPs": ["100.101.102.103", "fd7a::1"],
+        "Self": {
+            "HostName": "seraphim",
+            "DNSName": "seraphim.tail1234.ts.net.",
+            "Online": true,
+            "TailscaleIPs": ["100.101.102.103"]
+        },
+        "CurrentTailnet": { "Name": "acme.org" }
+    }"#;
+
+    #[test]
+    fn parses_a_running_node_into_a_url_and_state() {
+        let status = parse_status(SAMPLE, true, true);
+        assert!(status.connected);
+        assert!(status.online);
+        assert!(!status.needs_login);
+        assert_eq!(status.hostname, "seraphim");
+        // The trailing dot is stripped and the URL is the HTTPS serve address.
+        assert_eq!(status.dns_name, "seraphim.tail1234.ts.net");
+        assert_eq!(
+            status.url.as_deref(),
+            Some("https://seraphim.tail1234.ts.net")
+        );
+        assert_eq!(status.tailnet, "acme.org");
+        assert_eq!(status.tailscale_ips, vec!["100.101.102.103"]);
+        assert!(status.serve_active);
+        assert!(status.auth_url.is_none());
+        assert_eq!(status.backend_state, "Running");
+    }
+
+    #[test]
+    fn flags_a_node_that_needs_login_and_surfaces_its_url() {
+        let json = r#"{ "BackendState": "NeedsLogin",
+            "AuthURL": "https://login.tailscale.com/a/abc123" }"#;
+        let status = parse_status(json, true, false);
+        assert!(!status.connected);
+        assert!(status.needs_login);
+        assert_eq!(
+            status.auth_url.as_deref(),
+            Some("https://login.tailscale.com/a/abc123")
+        );
+        // No Self node, so no URL.
+        assert!(status.url.is_none());
+    }
+
+    #[test]
+    fn garbage_status_does_not_panic() {
+        let status = parse_status("not json", true, false);
+        assert!(!status.connected);
+        assert_eq!(status.backend_state, "");
+    }
+
+    #[test]
+    fn serve_active_detects_a_served_config() {
+        assert!(serve_is_active(
+            r#"{ "TCP": { "443": {} }, "Web": { "x": {} } }"#
+        ));
+        assert!(!serve_is_active("{}"));
+        assert!(!serve_is_active("null"));
+        assert!(!serve_is_active(r#"{ "TCP": null }"#));
+    }
+
+    #[test]
+    fn extracts_the_login_url_from_cli_output() {
+        let output = "\nTo authenticate, visit:\n\n\thttps://login.tailscale.com/a/abc123\n\n";
+        assert_eq!(
+            extract_login_url(output).as_deref(),
+            Some("https://login.tailscale.com/a/abc123")
+        );
+        assert!(extract_login_url("Success.").is_none());
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       API_BIND: 0.0.0.0:27182
       # Name of the workspace container the API drives via `docker exec`.
       WORKSPACE_CONTAINER: seraphim-workspace
+      # Name of the Tailscale sidecar the API manages (status/up/down/reauth).
+      TAILSCALE_CONTAINER: seraphim-tailscale
       RUST_LOG: info,seraphim_api=debug
       # Self-update: the API launches an updater container that bind-mounts these
       # HOST paths to git pull + `docker compose up -d --build`. HOST_REPO_DIR is

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,6 +29,8 @@ import type {
   RuleSource,
   Settings,
   Stats,
+  TailscaleActionResponse,
+  TailscaleStatus,
   Task,
   TaskColumn,
   TaskDetail
@@ -360,6 +362,30 @@ export function provisionWorkspace() {
 
 export function resetAgent(purgeMemories: boolean) {
   return apiClient.post('agent/reset', { json: { purge_memories: purgeMemories } }).json()
+}
+
+// --- Tailscale ---------------------------------------------------------------
+
+export function getTailscaleStatus() {
+  return apiClient.get('tailscale/status').json<TailscaleStatus>()
+}
+
+export function tailscaleUp() {
+  return apiClient.post('tailscale/up').json<TailscaleActionResponse>()
+}
+
+export function tailscaleDown() {
+  return apiClient.post('tailscale/down').json<TailscaleActionResponse>()
+}
+
+// Start an interactive login to authenticate the node. `force` re-authenticates
+// an already-connected node (to get a fresh login URL / move it to a new tailnet).
+export function tailscaleReauth(force: boolean) {
+  return apiClient.post('tailscale/reauth', { json: { force } }).json<TailscaleActionResponse>()
+}
+
+export function tailscaleRestart() {
+  return apiClient.post('tailscale/restart').json<TailscaleActionResponse>()
 }
 
 // --- Automation rules --------------------------------------------------------

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -204,6 +204,31 @@ export type EnvVar = {
   is_secret: boolean
 }
 
+// The Tailscale sidecar node's state, for the management UI.
+export type TailscaleStatus = {
+  container_running: boolean
+  backend_state: string
+  connected: boolean
+  online: boolean
+  needs_login: boolean
+  hostname: string
+  dns_name: string
+  // The HTTPS URL the UI is reachable at over the tailnet, when known.
+  url: string | null
+  tailnet: string
+  tailscale_ips: string[]
+  // A pending login URL the operator should visit to authenticate, when present.
+  auth_url: string | null
+  serve_active: boolean
+}
+
+// A Tailscale management action's result plus the refreshed status.
+export type TailscaleActionResponse = {
+  ok: boolean
+  message: string
+  status: TailscaleStatus
+}
+
 export type Repository = {
   id: string
   full_name: string

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -8,6 +8,7 @@
     Repository,
     ReviewPolicy,
     Settings,
+    TailscaleStatus,
     TaskColumn
   } from '$lib/types'
   import type { EnvVarWrite, UpdateStatus } from '$lib/api'
@@ -41,7 +42,12 @@
     updateSettings,
     uploadSound,
     clearSound,
-    soundUrl
+    soundUrl,
+    getTailscaleStatus,
+    tailscaleUp,
+    tailscaleDown,
+    tailscaleReauth,
+    tailscaleRestart
   } from '$lib/api'
   import type { SoundKind } from '$lib/api'
   import * as Card from '$lib/components/ui/card'
@@ -71,6 +77,7 @@
     { id: 'statistics', label: 'Statistics' },
     { id: 'env', label: 'Environment variables' },
     { id: 'workspace', label: 'Workspace' },
+    { id: 'tailscale', label: 'Tailscale' },
     { id: 'updates', label: 'Updates' },
     { id: 'backup', label: 'Backup & restore' }
   ] as const
@@ -547,6 +554,80 @@
     workspaceMessage = 'Recreating + provisioning…'
     await recreateWorkspace()
     workspaceMessage = 'Workspace recreated; repos + config reprovisioned.'
+  }
+
+  // --- Tailscale management ---------------------------------------------------
+  let tailscale = $state<TailscaleStatus | null>(null)
+  let tailscaleLoading = $state(false)
+  let tailscaleBusy = $state(false)
+  let tailscaleMessage = $state<string | null>(null)
+  let reauthDialogOpen = $state(false)
+  let tailscaleRestartDialogOpen = $state(false)
+
+  function errorText(error: unknown): string {
+    return error instanceof Error ? error.message : 'unknown error'
+  }
+
+  async function loadTailscale() {
+    tailscaleLoading = true
+    try {
+      tailscale = await getTailscaleStatus()
+    } catch (error) {
+      tailscaleMessage = `Could not read Tailscale status: ${errorText(error)}`
+    } finally {
+      tailscaleLoading = false
+    }
+  }
+
+  // Lazy-load the status the first time the operator opens the Tailscale section
+  // (it execs into the container, so we don't pay for it on every settings visit).
+  $effect(() => {
+    if (active === 'tailscale' && !tailscale && !tailscaleLoading) {
+      loadTailscale()
+    }
+  })
+
+  async function runTailscaleAction(
+    action: () => Promise<{ ok: boolean; message: string; status: TailscaleStatus }>,
+    pending: string
+  ) {
+    tailscaleBusy = true
+    tailscaleMessage = pending
+    try {
+      const result = await action()
+      tailscale = result.status
+      tailscaleMessage = result.message
+    } catch (error) {
+      tailscaleMessage = `Failed: ${errorText(error)}`
+    } finally {
+      tailscaleBusy = false
+    }
+  }
+
+  const runTailscaleUp = () => runTailscaleAction(tailscaleUp, 'Connecting…')
+  const runTailscaleDown = () => runTailscaleAction(tailscaleDown, 'Disconnecting…')
+
+  function runTailscaleReauth() {
+    reauthDialogOpen = false
+    return runTailscaleAction(() => tailscaleReauth(true), 'Starting re-authentication…')
+  }
+
+  // When the node simply needs login (no force), get the URL without a warning.
+  const runTailscaleLogin = () =>
+    runTailscaleAction(() => tailscaleReauth(false), 'Requesting a login URL…')
+
+  function runTailscaleRestart() {
+    tailscaleRestartDialogOpen = false
+    return runTailscaleAction(tailscaleRestart, 'Restarting the container…')
+  }
+
+  async function copyToClipboard(text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      tailscaleMessage = 'Copied to clipboard.'
+    } catch (error) {
+      tailscaleMessage = `Could not copy: ${errorText(error)}`
+    }
   }
 
   // Hard reset: purge the agent's history/session (and optionally memories), then
@@ -1558,6 +1639,170 @@
             </AlertDialog.Footer>
           </AlertDialog.Content>
         </AlertDialog.Root>
+      </Card.Content>
+    </Card.Root>
+    {/if}
+
+    {#if active === 'tailscale'}
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>Tailscale</Card.Title>
+        <Card.Description>
+          Seraphim's UI is exposed over your tailnet by a Tailscale sidecar container. See its URL
+          and hosting status here, connect or disconnect it, restart it, or get a login link when it
+          needs to be authenticated.
+        </Card.Description>
+      </Card.Header>
+      <Card.Content class="space-y-4">
+        <div class="flex items-center gap-3">
+          <Button variant="outline" disabled={tailscaleLoading} onclick={loadTailscale}>
+            {tailscaleLoading ? 'Refreshing…' : 'Refresh'}
+          </Button>
+          {#if tailscaleMessage}
+            <span class="text-sm text-muted-foreground break-words">{tailscaleMessage}</span>
+          {/if}
+        </div>
+
+        {#if tailscale && !tailscale.container_running}
+          <div class="rounded-md border border-warning/40 bg-warning/5 p-3 text-sm">
+            The Tailscale container isn't running. Start the stack (<code
+              class="rounded bg-secondary px-1 py-0.5">docker compose up -d</code
+            >), or try Restart below.
+          </div>
+        {:else if tailscale}
+          <!-- Connection state + the tailnet URL. -->
+          <div class="space-y-3 rounded-md border border-border p-4">
+            <div class="flex flex-wrap items-center gap-2">
+              {#if tailscale.connected}
+                <Badge class="bg-success/15 text-success">Connected</Badge>
+              {:else if tailscale.needs_login}
+                <Badge class="bg-warning/15 text-warning">Needs authentication</Badge>
+              {:else}
+                <Badge variant="outline" class="text-muted-foreground">Disconnected</Badge>
+              {/if}
+              {#if tailscale.connected}
+                <Badge variant="outline" class={tailscale.online ? 'text-success' : 'text-muted-foreground'}>
+                  {tailscale.online ? 'Online' : 'Offline'}
+                </Badge>
+                <Badge variant="outline" class={tailscale.serve_active ? 'text-success' : 'text-muted-foreground'}>
+                  {tailscale.serve_active ? 'Hosting UI' : 'Not hosting'}
+                </Badge>
+              {/if}
+              {#if tailscale.backend_state}
+                <span class="text-xs text-muted-foreground">({tailscale.backend_state})</span>
+              {/if}
+            </div>
+
+            {#if tailscale.url}
+              <div>
+                <div class="text-xs uppercase tracking-wide text-muted-foreground">Tailnet URL</div>
+                <div class="mt-1 flex flex-wrap items-center gap-2">
+                  <a
+                    href={tailscale.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    class="font-mono text-sm text-primary hover:underline break-all"
+                  >
+                    {tailscale.url}
+                  </a>
+                  <Button variant="ghost" size="sm" onclick={() => copyToClipboard(tailscale!.url!)}>
+                    Copy
+                  </Button>
+                </div>
+              </div>
+            {/if}
+
+            <div class="grid grid-cols-1 gap-1 text-sm sm:grid-cols-2">
+              {#if tailscale.tailnet}
+                <div><span class="text-muted-foreground">Tailnet:</span> {tailscale.tailnet}</div>
+              {/if}
+              {#if tailscale.hostname}
+                <div><span class="text-muted-foreground">Hostname:</span> {tailscale.hostname}</div>
+              {/if}
+              {#if tailscale.tailscale_ips.length}
+                <div class="sm:col-span-2">
+                  <span class="text-muted-foreground">IPs:</span>
+                  <span class="font-mono text-xs">{tailscale.tailscale_ips.join(', ')}</span>
+                </div>
+              {/if}
+            </div>
+          </div>
+
+          <!-- A pending login URL the operator needs to visit to authenticate. -->
+          {#if tailscale.auth_url}
+            <div class="space-y-2 rounded-md border border-warning/50 bg-warning/5 p-4">
+              <div class="text-sm font-medium">This node needs to be authenticated.</div>
+              <div class="flex flex-wrap items-center gap-2">
+                <a
+                  href={tailscale.auth_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  class={buttonVariants({ variant: 'default', size: 'sm' })}
+                >
+                  Open login page
+                </a>
+                <Button variant="ghost" size="sm" onclick={() => copyToClipboard(tailscale!.auth_url!)}>
+                  Copy link
+                </Button>
+              </div>
+            </div>
+          {/if}
+        {/if}
+
+        <!-- Management actions. -->
+        <div class="flex flex-wrap items-center gap-2 border-t border-border pt-4">
+          {#if tailscale?.connected}
+            <Button variant="outline" disabled={tailscaleBusy} onclick={runTailscaleDown}>Disconnect</Button>
+          {:else}
+            <Button variant="outline" disabled={tailscaleBusy} onclick={runTailscaleUp}>Connect</Button>
+          {/if}
+
+          {#if tailscale?.needs_login && !tailscale?.auth_url}
+            <Button variant="outline" disabled={tailscaleBusy} onclick={runTailscaleLogin}>
+              Get login URL
+            </Button>
+          {/if}
+
+          <!-- Re-authenticate (force): disconnects until the new login completes. -->
+          <AlertDialog.Root bind:open={reauthDialogOpen}>
+            <AlertDialog.Trigger class={buttonVariants({ variant: 'outline' })} disabled={tailscaleBusy}>
+              Re-authenticate
+            </AlertDialog.Trigger>
+            <AlertDialog.Content>
+              <AlertDialog.Header>
+                <AlertDialog.Title>Re-authenticate this node?</AlertDialog.Title>
+                <AlertDialog.Description>
+                  This starts a fresh login and returns a new link to authenticate the node (for
+                  example to move it to a different Tailscale account). The node disconnects until the
+                  login is completed, so the tailnet URL is briefly unavailable.
+                </AlertDialog.Description>
+              </AlertDialog.Header>
+              <AlertDialog.Footer>
+                <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+                <AlertDialog.Action onclick={runTailscaleReauth}>Re-authenticate</AlertDialog.Action>
+              </AlertDialog.Footer>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
+
+          <AlertDialog.Root bind:open={tailscaleRestartDialogOpen}>
+            <AlertDialog.Trigger class={buttonVariants({ variant: 'outline' })} disabled={tailscaleBusy}>
+              Restart
+            </AlertDialog.Trigger>
+            <AlertDialog.Content>
+              <AlertDialog.Header>
+                <AlertDialog.Title>Restart the Tailscale container?</AlertDialog.Title>
+                <AlertDialog.Description>
+                  Restarts the sidecar in place (re-applying its serve config and auth key). The
+                  tailnet URL is briefly unavailable while it reconnects.
+                </AlertDialog.Description>
+              </AlertDialog.Header>
+              <AlertDialog.Footer>
+                <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+                <AlertDialog.Action onclick={runTailscaleRestart}>Restart</AlertDialog.Action>
+              </AlertDialog.Footer>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
+        </div>
       </Card.Content>
     </Card.Root>
     {/if}


### PR DESCRIPTION
Closes #52.

## What

Adds a **Settings → Tailscale** panel to see and manage the Tailscale sidecar that exposes Seraphim's UI over the tailnet. The API drives the existing `seraphim-tailscale` container the same way it drives the workspace: by exec-ing the `tailscale` CLI over the host Docker socket.

It covers everything the issue asked for:
- **The tailnet URL** (clickable, with copy).
- **Hosting status**: connection state, online, whether `tailscale serve` is actively hosting the UI, the tailnet, hostname, and IPs.
- **Enable / disable**: connect (`tailscale up`) and disconnect (`tailscale down`).
- **Auth / getting a new URL**: a login URL is surfaced when the node needs authentication, plus a **Re-authenticate** action that starts a fresh login and returns a new link.
- **Restart** the sidecar in place.

## Backend

New `api/src/tailscale` module + `api/src/http/tailscale.rs`:
- `GET /api/v1/tailscale/status` — parses `tailscale status --json` (and `serve status --json`) into a tolerant DTO: `url`, `connected`, `online`, `needs_login`, `serve_active`, `tailnet`, `hostname`, `tailscale_ips`, `auth_url`, `backend_state`, `container_running`. The parsing is pure and **unit-tested** (running node, needs-login node, garbage input, serve detection, login-URL extraction).
- `POST /api/v1/tailscale/{up,down,reauth,restart}` — each returns `{ ok, message, status }` so the UI updates in one round-trip.
- Commands run as root (the CLI needs the daemon socket), are timeout-bounded, and are best-effort: a request never hangs on a node waiting for interactive login (we capture the printed login URL within a short window and leave the login running so it stays valid). The container name is configurable via `TAILSCALE_CONTAINER` (default `seraphim-tailscale`), wired through `Config` and compose.

## Frontend

A new Tailscale settings section: a status panel with a state badge, the tailnet URL (copyable), online/hosting indicators, node details, and a prominent **authenticate** box with the login link when needed. Actions: Connect/Disconnect, Get login URL, Re-authenticate (behind a confirm, since force re-auth disconnects until login completes), Restart (confirm), and Refresh. Status loads lazily the first time the section is opened (it execs into the container, so it isn't fetched on every settings visit).

## Notes / decisions

- "Getting a new URL" and "auth if needed" are handled together as Tailscale's interactive-login URL (the documented `AuthURL` from status, plus a re-auth trigger) — the standard way to (re)authenticate a node and get a fresh login link. The fixed serve URL itself (`https://<host>.<tailnet>.ts.net`) is shown in the status.
- Re-authenticate and Restart briefly take the tailnet URL offline, so both are behind confirmation dialogs that say so.
- I couldn't exercise the live `tailscale` CLI in this environment, so the logic leans on stable, long-standing CLI surface (`status --json`, `up`, `down`, `login`) and the JSON parsing is unit-tested against real-shaped output.

## Validation
- Backend `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (no new warnings), `test` (70 passing, incl. 5 new); frontend `yarn check` and `yarn build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)