### PR TITLE
Switch form checkboxes to toggle switches (#165)

### DIFF
--- a/frontend/src/lib/components/SearchFilterPanel.svelte
+++ b/frontend/src/lib/components/SearchFilterPanel.svelte
@@ -7,6 +7,7 @@
   import { COLUMNS, STATUS_LABELS } from '$lib/types'
   import { countActiveFilters, distinctAuthors, emptyFilters, type SearchFilters } from '$lib/search'
   import { Input } from './ui/input'
+  import { Switch } from './ui/switch'
 
   let {
     tasks = [],
@@ -71,12 +72,19 @@
       {#if authors.length}
         <div class="flex flex-col gap-0.5">
           {#each authors as author (author.login)}
-            <label class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-secondary">
-              <input
-                type="checkbox"
-                class="accent-primary"
+            <button
+              type="button"
+              role="switch"
+              aria-checked={filters.authors.includes(author.login)}
+              onclick={() => toggleAuthor(author.login)}
+              class="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-secondary"
+            >
+              <Switch
+                size="sm"
                 checked={filters.authors.includes(author.login)}
-                onchange={() => toggleAuthor(author.login)}
+                tabindex={-1}
+                aria-hidden="true"
+                class="pointer-events-none"
               />
               {#if author.avatarUrl}
                 <img
@@ -87,7 +95,7 @@
                 />
               {/if}
               <span class="truncate text-sm text-foreground">{author.login}</span>
-            </label>
+            </button>
           {/each}
         </div>
       {:else}
@@ -100,15 +108,22 @@
       <h3 class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Status</h3>
       <div class="flex flex-col gap-0.5">
         {#each statusOptions as [status, label] (status)}
-          <label class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-secondary">
-            <input
-              type="checkbox"
-              class="accent-primary"
+          <button
+            type="button"
+            role="switch"
+            aria-checked={filters.statuses.includes(status)}
+            onclick={() => toggleStatus(status)}
+            class="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-secondary"
+          >
+            <Switch
+              size="sm"
               checked={filters.statuses.includes(status)}
-              onchange={() => toggleStatus(status)}
+              tabindex={-1}
+              aria-hidden="true"
+              class="pointer-events-none"
             />
             <span class="text-sm text-foreground">{label}</span>
-          </label>
+          </button>
         {/each}
       </div>
     </section>
@@ -118,15 +133,22 @@
       <h3 class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Column</h3>
       <div class="flex flex-col gap-0.5">
         {#each COLUMNS as column (column.key)}
-          <label class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-secondary">
-            <input
-              type="checkbox"
-              class="accent-primary"
+          <button
+            type="button"
+            role="switch"
+            aria-checked={filters.columns.includes(column.key)}
+            onclick={() => toggleColumn(column.key)}
+            class="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-secondary"
+          >
+            <Switch
+              size="sm"
               checked={filters.columns.includes(column.key)}
-              onchange={() => toggleColumn(column.key)}
+              tabindex={-1}
+              aria-hidden="true"
+              class="pointer-events-none"
             />
             <span class="text-sm text-foreground">{column.label}</span>
-          </label>
+          </button>
         {/each}
       </div>
     </section>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1406,14 +1406,22 @@
                 {/if}
                 <div class="flex flex-wrap gap-3">
                   {#each repos as repo (repo.id)}
-                    <label class="flex items-center gap-1.5 text-sm">
-                      <input
-                        type="checkbox"
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={edit.repoIds.includes(repo.id)}
+                      onclick={() => toggleBoardRepo(board.id, repo.id)}
+                      class="flex cursor-pointer items-center gap-1.5 text-sm"
+                    >
+                      <Switch
+                        size="sm"
                         checked={edit.repoIds.includes(repo.id)}
-                        onchange={() => toggleBoardRepo(board.id, repo.id)}
+                        tabindex={-1}
+                        aria-hidden="true"
+                        class="pointer-events-none"
                       />
                       {repo.full_name}
-                    </label>
+                    </button>
                   {/each}
                 </div>
               </div>

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -18,6 +18,7 @@
   import { PaneGroup, type PaneGroupAPI } from 'paneforge'
 
   import { Badge } from '$lib/components/ui/badge'
+  import { Switch } from '$lib/components/ui/switch'
   import { Textarea } from '$lib/components/ui/textarea'
   import * as Alert from '$lib/components/ui/alert'
   import * as AlertDialog from '$lib/components/ui/alert-dialog'
@@ -437,12 +438,18 @@
         <ul class="mt-2 divide-y divide-border">
           {#each suggestions as suggestion (suggestion.id)}
             <li class="flex items-start justify-between gap-3 py-2">
-              <label class="flex min-w-0 flex-1 cursor-pointer items-start gap-2">
-                <input
-                  type="checkbox"
+              <button
+                type="button"
+                role="switch"
+                aria-checked={suggestion.acknowledged}
+                onclick={() => toggleSuggestion(suggestion)}
+                class="flex min-w-0 flex-1 cursor-pointer items-start gap-2 text-left"
+              >
+                <Switch
                   checked={suggestion.acknowledged}
-                  onchange={() => toggleSuggestion(suggestion)}
-                  class="mt-0.5"
+                  tabindex={-1}
+                  aria-hidden="true"
+                  class="mt-0.5 pointer-events-none"
                 />
                 <span class="flex min-w-0 flex-col gap-0.5">
                   <span
@@ -458,7 +465,7 @@
                     >
                   {/if}
                 </span>
-              </label>
+              </button>
               {#if !suggestion.acknowledged && task}
                 <SuggestionCreateButton
                   {suggestion}


### PR DESCRIPTION
Closes #165.

## Problem

Form checkboxes did not visually distinguish checked from unchecked, so you couldn't tell a selected option from an unselected one. The issue also asks to switch to toggle switches, which the project already uses elsewhere (the `Switch` component) and which the operator prefers.

## Change

Replaced every form checkbox in the app with the existing `Switch` (toggle) component. A toggle clearly shows on/off via its thumb position and color, which fixes the "can't tell the state" bug and satisfies the preference in one go.

Converted (3 files, 5 controls):
- **Navbar search filter panel** (`SearchFilterPanel.svelte`): the author, status, and board-column multi-selects.
- **Task page** (`task/[id]/+page.svelte`): the environment-recommendation acknowledge toggles.
- **Settings** (`settings/+page.svelte`): the Jira board repo multi-select. (The rest of Settings already used `Switch`.)

Each converted row keeps full-row click and stays accessible: the row is a `<button role="switch" aria-checked={...}>` (so mouse, Enter, and Space all toggle it, and screen readers announce the on/off state), and the `Switch` inside is a decorative `pointer-events-none`, `aria-hidden` indicator that reflects the state.

The only remaining checkbox construct is the shadcn `dropdown-menu` checkbox-item library component, which is unused in the app and is a menu element (not a form checkbox), so it is intentionally left alone.

## Validation
- `yarn check` (svelte-check: 0 errors, 0 warnings) and `yarn build` pass. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)