### PR TITLE
Resolve auto-merge conflicts instead of giving up (#167)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,10 +212,12 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    inside the availability schedule, it picks work by priority — (a) **resume** a
    task whose question the user just answered (`waiting_for_input` → deliver the
    answers via `prompt::build_resume`), (b) a PR with failing CI to fix
-   (`ci_failing`), (c) top of **To Do** (fresh issue → branch → Claude turn →
-   detect PR → **In Review**, or **park** as `waiting_for_input` if the agent
-   asked a question), then (d) when nothing else is queued, *revisit* a PR it gave
-   up on (`ci_blocked`), cooldown-gated (`REVISIT_COOLDOWN`, 15 min). The agent
+   (`ci_failing`), (c) a PR whose auto-merge failed on a conflict to resolve
+   (`merge_conflict` → `prompt::build_merge_conflict`: merge the base in, resolve,
+   keep migrations linear), (d) top of **To Do** (fresh issue → branch → Claude
+   turn → detect PR → **In Review**, or **park** as `waiting_for_input` if the
+   agent asked a question), then (e) when nothing else is queued, *revisit* a PR it
+   gave up on (`ci_blocked`), cooldown-gated (`REVISIT_COOLDOWN`, 15 min). The agent
    asks via the `seraphim-ask` CLI and records environment recommendations via the
    `seraphim-suggest` CLI (both baked into the workspace image), posting to
    `POST /agent/questions` and `POST /agent/suggestions`; the exec injects
@@ -226,8 +228,11 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    the linked issue with `state_reason: "completed"` when `close_issue_on_done` is
    set, the default; best-effort), else wait; red → hand back to the agent,
    bounded by `MAX_CI_FIX_ATTEMPTS` (3) before parking it `ci_blocked` for a
-   human. A failed merge (e.g. base conflict) also parks it `ci_blocked` rather
-   than retrying forever.
+   human. A failed auto-merge (almost always a base conflict because another PR
+   landed first) flags the task `merge_conflict` so the agent resolves it on its
+   branch instead of giving up, bounded by the same attempt budget; if the agent
+   pushes nothing (genuinely unresolvable) or the budget is exhausted, it falls
+   back to `ci_blocked` for a human.
 4. **defibrillator** (dead-agent management) — recovers turns that die mid-flight,
    which we call a **"heart attack"**: the agent hangs with no output, its stream
    breaks, or the turn aborts internally, leaving the card stranded `in_progress`

--- a/api/migrations/0030_merge_conflict_status.sql
+++ b/api/migrations/0030_merge_conflict_status.sql
@@ -1,0 +1,13 @@
+-- Auto-merge conflict recovery.
+--
+-- When a green PR fails to auto-merge (almost always a merge conflict with the
+-- base because another PR landed first), the agent now resolves it instead of
+-- giving up. A new operational sub-state marks such a PR so the agent picks it up
+-- proactively, re-engages on its branch (merge the base in, resolve, push), and
+-- lets the review loop re-merge it. Bounded by the same fix-attempt budget as CI;
+-- once exhausted (or if the agent can't resolve it) it falls back to ci_blocked
+-- for a human.
+--
+-- Adding an enum value is transaction-safe on Postgres 12+ as long as the value
+-- isn't used in this same migration (it isn't).
+ALTER TYPE task_status ADD VALUE IF NOT EXISTS 'merge_conflict'; -- auto-merge blocked; agent to resolve

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -95,6 +95,9 @@ pub enum TaskStatus {
     /// The agent stopped fixing CI (out of scope, or the retry cap hit); the PR
     /// is left in review for a human.
     CiBlocked,
+    /// Auto-merge failed (typically a conflict with the base because another PR
+    /// landed first); queued for the agent to resolve and push, then re-merge.
+    MergeConflict,
     Merging,
     Done,
     Failed,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1254,6 +1254,21 @@ pub async fn pick_next_ci_fix(pool: &PgPool) -> sqlx::Result<Option<Task>> {
     .await
 }
 
+/// The next PR whose auto-merge failed on a conflict and that the agent should
+/// resolve: top of `In Review` flagged `merge_conflict`, not on hold.
+///
+/// Unlike [`pick_next_revisit`] this has no cooldown: a fresh conflict is handed
+/// back to the agent promptly (and ahead of new To Do work) so a PR that just
+/// fell out of mergeability is unblocked rather than left to the idle revisit.
+pub async fn pick_next_merge_conflict(pool: &PgPool) -> sqlx::Result<Option<Task>> {
+    sqlx::query_as::<_, Task>(
+        "SELECT * FROM tasks WHERE board_column = 'in_review' AND status = 'merge_conflict' \
+         AND hold = FALSE ORDER BY position ASC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+}
+
 /// Increments a task's CI-fix attempt counter, returning the new count.
 pub async fn bump_ci_fix_attempt(pool: &PgPool, id: Uuid) -> sqlx::Result<i32> {
     sqlx::query_scalar(
@@ -1299,6 +1314,25 @@ pub async fn block_task_ci(pool: &PgPool, id: Uuid, note: &str) -> sqlx::Result<
     )
     .bind(id)
     .bind(TaskStatus::CiBlocked)
+    .bind(note)
+    .fetch_one(pool)
+    .await
+}
+
+/// Flags a PR whose auto-merge failed (typically a conflict with the base) for
+/// the agent to resolve. The card keeps its `in_review` lane and PR; the status
+/// and note change so the agent picks it up proactively.
+///
+/// Unlike [`block_task_ci`], this does not set `finished_at`: the task is not
+/// finished, just handed back. `last_activity_at` is refreshed so the card sorts
+/// as freshly touched and any later idle-revisit cooldown is measured from now.
+pub async fn flag_merge_conflict(pool: &PgPool, id: Uuid, note: &str) -> sqlx::Result<Task> {
+    sqlx::query_as::<_, Task>(
+        "UPDATE tasks SET status = $2, error = $3, last_activity_at = now(), updated_at = now() \
+         WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(TaskStatus::MergeConflict)
     .bind(note)
     .fetch_one(pool)
     .await

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -107,6 +107,9 @@ enum WorkMode {
     Resume,
     /// An open PR with failing CI: re-engage on its branch to fix the checks.
     FixCi,
+    /// A PR whose auto-merge failed on a conflict: re-engage to merge the base in
+    /// and resolve it, then let the review loop re-merge.
+    ResolveConflict,
     /// A PR the agent gave up on (CI or merge conflict), retried while idle.
     Revisit,
 }
@@ -567,6 +570,12 @@ async fn next_actionable_task(state: &AppState) -> Result<Option<(Task, WorkMode
     if let Some(task) = queries::pick_next_ci_fix(&state.db).await? {
         return Ok(Some((task, WorkMode::FixCi)));
     }
+    // Resolving a conflict that blocked auto-merge also takes priority over fresh
+    // work, so a PR that just lost mergeability is unblocked promptly rather than
+    // abandoned while the agent moves on to the next issue.
+    if let Some(task) = queries::pick_next_merge_conflict(&state.db).await? {
+        return Ok(Some((task, WorkMode::ResolveConflict)));
+    }
     // A blocking task in progress (being worked or parked waiting for input)
     // serializes the queue: pull no new To Do work until it finishes. Resumes
     // and CI fixes above continue existing in-flight work and are not gated.
@@ -589,8 +598,11 @@ async fn work_task(state: &AppState, task: Task, mode: WorkMode) -> Result<()> {
     match mode {
         WorkMode::Fresh => work_fresh(state, task, false).await,
         WorkMode::Resume => work_fresh(state, task, true).await,
-        WorkMode::FixCi => work_ci_fix(state, task, false).await,
-        WorkMode::Revisit => work_ci_fix(state, task, true).await,
+        // Every "re-engage on an existing PR" mode shares one flow; the mode only
+        // chooses the prompt and whether the attempt budget is reset.
+        WorkMode::FixCi | WorkMode::ResolveConflict | WorkMode::Revisit => {
+            work_pr_fix(state, task, mode).await
+        }
     }
 }
 
@@ -708,17 +720,19 @@ async fn work_fresh(state: &AppState, task: Task, resume: bool) -> Result<()> {
     Ok(())
 }
 
-/// Re-engages the agent on an open PR that's failing CI (`revisit = false`) or
-/// one it had given up on and is being retried while idle (`revisit = true`).
+/// Re-engages the agent on an open PR that needs another turn: failing CI
+/// ([`WorkMode::FixCi`]), a conflict that blocked auto-merge
+/// ([`WorkMode::ResolveConflict`]), or a PR it had given up on, retried while idle
+/// ([`WorkMode::Revisit`]).
 ///
-/// Checks out the PR's existing branch, runs one turn, and decides what happens
-/// next by whether the agent pushed: a new commit returns the task to review for
-/// a re-check; no new commit means the agent judged it out of scope, so the PR
-/// is left for a human and the agent moves on. A revisit also resets the CI-fix
-/// counter so the renewed effort gets the full retry budget, and its prompt
-/// names merge conflicts (the usual reason auto-merge blocked) as a likely cause.
-async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> {
-    info!(task_id = %task.id, attempts = task.ci_fix_attempts, revisit, "fixing pull request");
+/// Checks out the PR's existing branch, runs one turn with the prompt for `mode`,
+/// and decides what happens next by whether the agent pushed: a new commit returns
+/// the task to review for a re-check (or a re-merge); no new commit means the agent
+/// judged it out of scope, so the PR is left for a human and the agent moves on. A
+/// revisit also resets the fix-attempt counter so the renewed effort gets the full
+/// budget again.
+async fn work_pr_fix(state: &AppState, task: Task, mode: WorkMode) -> Result<()> {
+    info!(task_id = %task.id, attempts = task.ci_fix_attempts, ?mode, "fixing pull request");
 
     let Some(repo_id) = task.repo_id else {
         return block(state, &task, "no repository is configured for this issue").await;
@@ -734,7 +748,7 @@ async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> 
 
     // A revisit is a fresh effort: clear the exhausted counter so the renewed
     // fix cycle gets the full retry budget again.
-    if revisit {
+    if mode == WorkMode::Revisit {
         queries::reset_ci_fix_attempts(&state.db, task.id).await?;
     }
 
@@ -761,27 +775,42 @@ async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> 
         .await
         .ok();
 
-    // Enumerate the failing checks (best-effort) to focus the agent.
-    let failing = match git::find_open_pr_for_branch(&github, owner, repo_name, &branch).await? {
-        Some(pull) => match git::ci_status(&github, owner, repo_name, &pull.head_sha).await {
-            Ok(git::CiStatus::Failing(checks)) => checks,
-            _ => Vec::new(),
-        },
-        None => Vec::new(),
-    };
-
     let comments = fetch_issue_comments(state, &repo, &task).await;
-    let prompt = if revisit {
-        prompt::build_revisit(
+    let prompt = match mode {
+        WorkMode::FixCi => {
+            // Enumerate the failing checks (best-effort) to focus the agent.
+            let failing = match git::find_open_pr_for_branch(&github, owner, repo_name, &branch)
+                .await?
+            {
+                Some(pull) => match git::ci_status(&github, owner, repo_name, &pull.head_sha).await
+                {
+                    Ok(git::CiStatus::Failing(checks)) => checks,
+                    _ => Vec::new(),
+                },
+                None => Vec::new(),
+            };
+            prompt::build_ci_fix(&settings, &repo, &task, &branch, &failing, &comments)
+        }
+        WorkMode::ResolveConflict => prompt::build_merge_conflict(
             &settings,
             &repo,
             &task,
             &branch,
             task.error.as_deref().unwrap_or_default(),
             &comments,
-        )
-    } else {
-        prompt::build_ci_fix(&settings, &repo, &task, &branch, &failing, &comments)
+        ),
+        WorkMode::Revisit => prompt::build_revisit(
+            &settings,
+            &repo,
+            &task,
+            &branch,
+            task.error.as_deref().unwrap_or_default(),
+            &comments,
+        ),
+        // work_task only routes the three PR-fix modes here.
+        WorkMode::Fresh | WorkMode::Resume => {
+            unreachable!("work_pr_fix is only called for PR-fix modes")
+        }
     };
     let attempt = queries::bump_ci_fix_attempt(&state.db, task.id).await?;
     let outcome = run_agent_turn(state, &settings, &task, prompt).await?;
@@ -816,20 +845,27 @@ async fn work_ci_fix(state: &AppState, task: Task, revisit: bool) -> Result<()> 
     };
 
     if !pushed {
-        return block(
-            state,
-            &task,
-            "The agent made no changes for the failing CI (likely pre-existing or out of scope). \
-             Left for human review.",
-        )
-        .await;
+        // Nothing pushed means the agent judged there was nothing it could (or
+        // should) do, so the PR is left for a human with a mode-appropriate note.
+        let note = match mode {
+            WorkMode::ResolveConflict => {
+                "The agent could not resolve the merge conflict on its own (it may need a \
+                 human decision or be out of scope). Left for human review."
+            }
+            _ => {
+                "The agent made no changes for the failing CI (likely pre-existing or out of \
+                 scope). Left for human review."
+            }
+        };
+        return block(state, &task, note).await;
     }
 
-    // Fix pushed: back to review so the loop re-checks CI on the new commit.
+    // Pushed: back to review so the loop re-checks CI and re-attempts the merge on
+    // the new commit.
     queries::move_task(&state.db, task.id, TaskColumn::InReview, task.position).await?;
     queries::set_task_status(&state.db, task.id, TaskStatus::AwaitingReview).await?;
     state.notify_board();
-    info!(task_id = %task.id, attempt, "pushed CI fix; awaiting re-check");
+    info!(task_id = %task.id, attempt, "pushed a fix; awaiting re-check");
     Ok(())
 }
 
@@ -1287,16 +1323,29 @@ async fn review_once(state: &AppState) -> Result<()> {
                         // issue) never affects the completed task.
                         close_linked_issue(&github, &settings, &task, owner, repo_name).await;
                     }
-                    // A merge can fail for reasons retrying won't fix (conflicts
-                    // with the base, restricted merge settings). Record it and
-                    // stop auto-retrying so the loop doesn't spin; a human takes
-                    // over from the In Review lane.
+                    // A failed auto-merge is almost always a merge conflict with
+                    // the base (another PR landed first). Rather than give up, hand
+                    // it back to the agent to merge the base in and resolve, bounded
+                    // by the same fix-attempt budget as CI. The agent's own "nothing
+                    // to push" path (in `work_pr_fix`) catches the genuinely
+                    // unresolvable cases (e.g. restricted merge settings) and leaves
+                    // them for a human; once the budget is exhausted we block here.
                     Err(error) => {
-                        let note = format!(
-                            "Auto-merge failed: {error}. The PR likely conflicts with its base \
-                             branch or merging is restricted; resolve it manually.",
-                        );
-                        block(state, &task, &note).await?;
+                        if task.ci_fix_attempts < MAX_CI_FIX_ATTEMPTS {
+                            let note = format!(
+                                "Auto-merge failed: {error}. Re-engaging the agent to resolve \
+                                 the conflict with the base branch.",
+                            );
+                            queries::flag_merge_conflict(&state.db, task.id, &note).await?;
+                            state.notify_board();
+                        } else {
+                            let note = format!(
+                                "Auto-merge still failing after {MAX_CI_FIX_ATTEMPTS} resolution \
+                                 attempts: {error}. The PR likely conflicts with its base branch \
+                                 or merging is restricted; resolve it manually.",
+                            );
+                            block(state, &task, &note).await?;
+                        }
                     }
                 }
             }

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -98,6 +98,58 @@ pub fn build_ci_fix(
     prompt
 }
 
+/// Builds the instruction text to resolve a merge conflict that blocked the PR's
+/// auto-merge.
+///
+/// Sent when a green PR fails to auto-merge, which almost always means another
+/// pull request landed on the base first and the branch now conflicts. The agent
+/// works the existing `branch`: merge the base in, resolve the conflicts, verify
+/// any migrations stay linear, and push, after which the review loop re-merges.
+/// `reason` is the note recorded when the merge failed.
+pub fn build_merge_conflict(
+    settings: &Settings,
+    repo: &Repository,
+    task: &Task,
+    branch: &str,
+    reason: &str,
+    comments: &[IssueComment],
+) -> String {
+    let repo_path = format!("/workspace/{}", repo_dir_name(&repo.full_name));
+    let blocker = if reason.trim().is_empty() {
+        "(no reason was recorded)".to_string()
+    } else {
+        reason.trim().to_string()
+    };
+    let mut prompt = context_header(settings, repo, task, comments);
+
+    prompt.push_str(&format!(
+        "# Resolving a merge conflict\n\
+         - Auto-merge of this issue's pull request was blocked: {blocker}\n\
+         - This almost always means another pull request merged into `{default}` first and your \
+         branch now conflicts with it. Resolve it yourself rather than leaving it for a human.\n\
+         - Your cwd is `/workspace`. The focus repo `{repo}` is at `{repo_path}`, already checked \
+         out on branch `{branch}` with your earlier commits.\n\
+         - Bring the latest base in and resolve the conflict: \
+         `git fetch origin && git merge origin/{default}`, fix every conflicted file, and complete \
+         the merge. (Use a merge, not a rebase, so you don't have to force-push.)\n\
+         {migrations}\
+         - Run the project's build/tests/linters to confirm the merge is clean, then commit and \
+         push. Do not open a new pull request; the existing one updates automatically.\n\
+         - If the conflict is genuinely out of scope or you cannot resolve it safely, leave a \
+         brief comment on the PR explaining why, and stop without committing.\n\
+         - After pushing, stop and finish with a short summary. Do not wait for CI; Seraphim \
+         re-checks the PR and re-merges it (or brings you back) automatically.\n",
+        blocker = blocker,
+        default = repo.default_branch,
+        repo = repo.full_name,
+        repo_path = repo_path,
+        branch = branch,
+        migrations = MIGRATION_LINEARITY,
+    ));
+
+    prompt
+}
+
 /// Builds the instruction text to revisit a PR the agent had given up on.
 ///
 /// Unlike [`build_ci_fix`], this names merge conflicts as a likely cause (the
@@ -129,6 +181,7 @@ pub fn build_revisit(
          - If it conflicts with the base, bring the latest base in and resolve it: \
          `git fetch origin && git merge origin/{default}` (or rebase), fix the conflicts, and \
          continue.\n\
+         {migrations}\
          - Investigate any failing checks with `gh pr checks` and `gh run view --log-failed`, then \
          fix them.\n\
          - Run the project's build/tests/linters, commit, and push. Do not open a new pull \
@@ -140,6 +193,7 @@ pub fn build_revisit(
         repo = repo.full_name,
         repo_path = repo_path,
         branch = branch,
+        migrations = MIGRATION_LINEARITY,
     ));
 
     prompt
@@ -243,6 +297,19 @@ fn render_discussion(comments: &[IssueComment]) -> String {
 
     section
 }
+
+/// Guidance, shared by the conflict-resolution prompts, on keeping database
+/// migrations in a single linear order after merging the base branch in.
+///
+/// Two PRs that each add a migration are fine in isolation, but once both land
+/// the branch holds migrations authored in parallel; without a check they can end
+/// up out of order, duplicated, or numbered to collide. The agent verifies the
+/// migrations within its own scope still form one linear sequence.
+const MIGRATION_LINEARITY: &str = "\
+    - If your branch adds database migrations, double-check them after merging the base in: \
+    another PR may have added migrations too. Make sure the migrations in your scope still form a \
+    single linear sequence (correct ordering and numbering, no duplicate or colliding versions), \
+    and renumber yours onto the latest if they now clash.\n";
 
 /// Guidance, appended to every task prompt, on recommending setup improvements.
 const ENVIRONMENT_SUGGESTIONS: &str = "\n\
@@ -352,6 +419,55 @@ mod tests {
         }
     }
 
+    /// A minimal `Settings` for the prompt builders. Only `org_name` and
+    /// `global_instructions` reach the prompt; the rest are inert defaults.
+    fn sample_settings() -> Settings {
+        use crate::db::models::{JiraDeployment, NetworkAccessLevel, ReviewPolicy};
+        Settings {
+            org_name: "JalapenoLabs".to_string(),
+            global_instructions: String::new(),
+            default_review_policy: ReviewPolicy::None,
+            agent_paused: false,
+            claude_model: String::new(),
+            workspace_image_tag: String::new(),
+            base_setup_script: String::new(),
+            config_repo_url: String::new(),
+            default_branch_template: String::new(),
+            config_repo_error: None,
+            current_session_id: None,
+            updated_at: chrono::Utc::now(),
+            claude_token_set: false,
+            github_token_set: false,
+            availability_enabled: false,
+            availability_timezone: "UTC".to_string(),
+            availability_windows: Json(Vec::new()),
+            availability_skip_dates: Json(Vec::new()),
+            network_access_level: NetworkAccessLevel::Full,
+            network_access_domains: Json(Vec::new()),
+            network_access_include_defaults: true,
+            usage_limit_pause_enabled: false,
+            usage_limit_threshold: 80,
+            usage_paused_until: None,
+            post_thoughts_enabled: false,
+            close_issue_on_done: true,
+            jira_enabled: false,
+            jira_deployment: JiraDeployment::Cloud,
+            jira_base_url: String::new(),
+            jira_email: String::new(),
+            jira_token_set: false,
+            github_webhook_secret_set: false,
+            jira_webhook_secret_set: false,
+            attention_sound_enabled: true,
+            completion_sound_enabled: true,
+            attention_sound_custom: false,
+            completion_sound_custom: false,
+            jira_token_preview: None,
+            claude_token_preview: None,
+            github_token_preview: None,
+            cooldown_until: None,
+        }
+    }
+
     fn sample_repo() -> Repository {
         Repository {
             id: uuid::Uuid::nil(),
@@ -431,6 +547,43 @@ mod tests {
         assert!(prompt.contains("declined to choose"));
         assert!(prompt.contains("let's talk it over"));
         assert!(prompt.contains("seraphim-ask"));
+    }
+
+    #[test]
+    fn merge_conflict_prompt_directs_a_base_merge_and_linear_migrations() {
+        let settings = sample_settings();
+        let prompt = build_merge_conflict(
+            &settings,
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            "Auto-merge failed: not mergeable.",
+            &[],
+        );
+
+        // It reorients the agent to the conflict and the exact recovery command.
+        assert!(prompt.contains("Resolving a merge conflict"));
+        assert!(prompt.contains("Auto-merge failed: not mergeable."));
+        assert!(prompt.contains("git merge origin/v3.0.0"));
+        // It carries the migration-linearity guidance the issue asked for.
+        assert!(prompt.contains("migrations"));
+        assert!(prompt.contains("single linear sequence"));
+        // It must not tell the agent to open a new PR; the existing one updates.
+        assert!(prompt.contains("Do not open a new pull request"));
+    }
+
+    #[test]
+    fn revisit_prompt_also_carries_migration_guidance() {
+        let settings = sample_settings();
+        let prompt = build_revisit(
+            &settings,
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            "set aside as stuck",
+            &[],
+        );
+        assert!(prompt.contains("single linear sequence"));
     }
 
     #[test]

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -11,6 +11,7 @@ export type TaskStatus =
   | 'awaiting_review'
   | 'ci_failing'
   | 'ci_blocked'
+  | 'merge_conflict'
   | 'merging'
   | 'done'
   | 'failed'
@@ -25,6 +26,7 @@ export const STATUS_LABELS = {
   awaiting_review: 'awaiting review',
   ci_failing: 'CI failing',
   ci_blocked: 'CI blocked',
+  merge_conflict: 'resolving conflict',
   merging: 'merging',
   done: 'done',
   failed: 'failed'
@@ -40,6 +42,7 @@ export const STATUS_BADGE = {
   awaiting_review: 'border-warning/40 text-warning',
   ci_failing: 'border-warning/40 text-warning',
   ci_blocked: 'border-destructive/40 text-destructive',
+  merge_conflict: 'border-warning/40 text-warning',
   merging: 'border-primary/40 text-primary',
   done: 'border-success/40 text-success',
   failed: 'border-destructive/40 text-destructive'


### PR DESCRIPTION
Closes #167

## Problem

When a PR merged while the agent was mid-work, by the time the agent's own PR reached In Review it could conflict with `develop`. The review loop reported the failure correctly:

```
Auto-merge failed: ... The PR likely conflicts with its base branch or merging is restricted; resolve it manually.
```

but then parked the task `ci_blocked` and gave up. That state was only retried by the lowest-priority idle "revisit" path, gated behind a 15-minute cooldown and only when the agent had nothing else queued. With a steady To Do queue that revisit never fired, so the conflicted PR was abandoned while the agent moved on to the next item.

## Fix

Treat a failed auto-merge as actionable, prioritized work the agent can unblock itself, rather than a dead end needing a human.

- New `merge_conflict` task status (migration `0030`) that the agent picks up **proactively**, right after CI fixes and ahead of pulling fresh To Do work, so a PR that just lost mergeability is unblocked promptly.
- The review loop now flags `merge_conflict` on a failed auto-merge (bounded by the same `MAX_CI_FIX_ATTEMPTS` budget as CI fixes) instead of immediately blocking. Only an exhausted budget falls back to `ci_blocked` for a human.
- A dedicated `build_merge_conflict` prompt re-engages the agent on the existing branch: `git fetch origin && git merge origin/<base>`, resolve every conflict, run build/tests/linters, and push. The review loop then re-checks and re-merges. If the agent pushes nothing (genuinely unresolvable, e.g. a restricted merge), the existing "nothing pushed -> leave for a human" path hands it off cleanly with no wasted loops.
- Per the issue, the conflict-resolution prompts (both the new merge-conflict prompt and the existing revisit prompt) now tell the agent to double-check database migrations and keep them in a single linear order after merging the base in.

`work_ci_fix` is generalized into `work_pr_fix(mode)`, shared by the CI-fix, conflict-resolution, and revisit flows.

## Testing

- `cargo +1.88 fmt`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (67 passed, including two new prompt tests covering the merge-conflict and revisit guidance).
- `npm run check` and `npm run build` for the frontend (the new `merge_conflict` status is added to the UI status type, label "resolving conflict", and badge).