### PR TITLE
First-class Claude authentication: subscription OAuth + API key

### DIFF
--- a/api/migrations/0031_claude_oauth.sql
+++ b/api/migrations/0031_claude_oauth.sql
@@ -1,0 +1,20 @@
+-- Claude subscription OAuth login.
+--
+-- The long-lived inference token the agent runs on continues to live in
+-- `claude_oauth_token` (injected as CLAUDE_CODE_OAUTH_TOKEN, or ANTHROPIC_API_KEY
+-- in api_key mode). These columns add the auth mode and the short-lived,
+-- refreshing OAuth credentials used ONLY to poll /api/oauth/usage for the
+-- subscription usage gauge. They are kept separate so the agent's inference never
+-- depends on the refresh loop.
+--
+-- `claude_auth_mode` defaults to 'subscription' so existing installs (a manual
+-- setup-token in claude_oauth_token) keep using CLAUDE_CODE_OAUTH_TOKEN unchanged.
+
+CREATE TYPE claude_auth_mode AS ENUM ('subscription', 'api_key');
+
+ALTER TABLE settings
+    ADD COLUMN claude_auth_mode claude_auth_mode NOT NULL DEFAULT 'subscription',
+    ADD COLUMN claude_usage_access_token TEXT NOT NULL DEFAULT '',
+    ADD COLUMN claude_usage_refresh_token TEXT NOT NULL DEFAULT '',
+    ADD COLUMN claude_usage_expires_at TIMESTAMPTZ,
+    ADD COLUMN claude_usage_scopes TEXT NOT NULL DEFAULT '';

--- a/api/src/claude/exec.rs
+++ b/api/src/claude/exec.rs
@@ -12,6 +12,7 @@ use eyre::{eyre, Result};
 use futures::{Stream, StreamExt};
 
 use super::events::{parse_line, AgentEvent};
+use crate::db::models::ClaudeAuthMode;
 
 /// Everything needed to run one turn of the long-lived conversation.
 #[derive(Debug, Clone)]
@@ -26,7 +27,11 @@ pub struct TurnArgs {
     pub resume_session_id: Option<String>,
     /// Model id, e.g. `claude-opus-4-8[1m]`.
     pub model: String,
-    /// Subscription OAuth token, injected into the exec env (not the container).
+    /// How [`Self::oauth_token`] is injected: a subscription token becomes
+    /// `CLAUDE_CODE_OAUTH_TOKEN`; an API key becomes `ANTHROPIC_API_KEY`.
+    pub auth_mode: ClaudeAuthMode,
+    /// The Claude credential (subscription token or API key), injected into the
+    /// exec env per [`Self::auth_mode`] (never baked into the container).
     pub oauth_token: String,
     /// GitHub token, so the agent's `gh`/`git` are authed for this turn.
     pub github_token: String,
@@ -44,8 +49,12 @@ pub struct TurnArgs {
 /// any user-defined variables. User variables come last so they cannot shadow
 /// the tokens and wiring we control.
 fn build_env(args: &TurnArgs) -> Vec<String> {
+    let credential = match args.auth_mode {
+        ClaudeAuthMode::Subscription => format!("CLAUDE_CODE_OAUTH_TOKEN={}", args.oauth_token),
+        ClaudeAuthMode::ApiKey => format!("ANTHROPIC_API_KEY={}", args.oauth_token),
+    };
     let mut env = vec![
-        format!("CLAUDE_CODE_OAUTH_TOKEN={}", args.oauth_token),
+        credential,
         format!("GH_TOKEN={}", args.github_token),
         format!("SERAPHIM_TASK_ID={}", args.task_id),
         format!("SERAPHIM_API_URL={}", args.internal_api_url),
@@ -160,6 +169,7 @@ mod tests {
             prompt: "do the thing".to_string(),
             resume_session_id: Some("sess-1".to_string()),
             model: "claude-opus-4-8[1m]".to_string(),
+            auth_mode: ClaudeAuthMode::Subscription,
             oauth_token: "tok".to_string(),
             github_token: "gh".to_string(),
             task_id: "task-1".to_string(),
@@ -182,6 +192,7 @@ mod tests {
             prompt: "start".to_string(),
             resume_session_id: None,
             model: "claude-opus-4-8[1m]".to_string(),
+            auth_mode: ClaudeAuthMode::Subscription,
             oauth_token: "tok".to_string(),
             github_token: "gh".to_string(),
             task_id: "task-1".to_string(),

--- a/api/src/claude/mod.rs
+++ b/api/src/claude/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod events;
 pub mod exec;
+pub mod oauth;
 
 pub use events::{AgentEventKind, UsageTracker};
 pub use exec::{run_turn, TurnArgs};

--- a/api/src/claude/oauth.rs
+++ b/api/src/claude/oauth.rs
@@ -1,0 +1,369 @@
+//! Claude.ai subscription OAuth: the same Authorization-Code + PKCE flow the
+//! Claude Code CLI uses (`claude setup-token` / `claude auth login`), so an
+//! operator can connect their subscription from Seraphim's UI instead of pasting
+//! a `setup-token`.
+//!
+//! One consent yields two things, deliberately separated:
+//! - a **long-lived inference token** (minted via `create_api_key`), which the
+//!   agent runs on - rock-solid, never depends on a refresh loop; and
+//! - the short-lived **access/refresh** pair, used *only* to poll
+//!   `/api/oauth/usage` for the subscription usage gauge (`user:profile` scope).
+//!
+//! The endpoints, client id, scopes, and redirect were taken from the authorize
+//! URL `claude setup-token` prints. A few request/response shapes (the
+//! `create_api_key` token field, the exact `/api/oauth/usage` body) are not fully
+//! pinned down and are parsed defensively; they are verified during the live
+//! end-to-end test. Such spots are flagged with `WIRE:` comments.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use eyre::{eyre, Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+/// Claude Code's public OAuth client (the same one `claude` uses; visible in the
+/// authorize URL `claude setup-token` prints).
+const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
+const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
+const REDIRECT_URI: &str = "https://platform.claude.com/oauth/code/callback";
+const CREATE_API_KEY_URL: &str = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
+const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+/// Beta header required on the OAuth-authenticated Anthropic endpoints.
+const OAUTH_BETA: &str = "oauth-2025-04-20";
+/// Full scope: `user:inference` (run the agent + mint the long-lived key),
+/// `user:profile` (required by `/api/oauth/usage`), and `org:create_api_key`
+/// (authorizes the mint step).
+const SCOPES: &str = "org:create_api_key user:profile user:inference";
+
+/// The PKCE secrets for one in-flight authorization, held until the operator
+/// pastes the code back.
+#[derive(Debug, Clone)]
+pub struct PendingAuth {
+    pub verifier: String,
+    pub state: String,
+}
+
+/// Tokens returned by an OAuth code-exchange or refresh.
+#[derive(Debug, Clone)]
+pub struct Tokens {
+    pub access_token: String,
+    /// Empty if the endpoint did not rotate the refresh token (keep the old one).
+    pub refresh_token: String,
+    /// Seconds until the access token expires.
+    pub expires_in: i64,
+    pub scopes: String,
+}
+
+/// A subscription usage snapshot (rolling-window utilization percentages).
+#[derive(Debug, Clone, Default)]
+pub struct Usage {
+    pub five_hour_utilization: Option<f64>,
+    /// Unix seconds.
+    pub five_hour_resets_at: Option<i64>,
+    pub seven_day_utilization: Option<f64>,
+    pub seven_day_resets_at: Option<i64>,
+}
+
+/// Builds the consent URL for a new authorization and the PKCE secrets to hold
+/// until the operator pastes the code back. No network.
+pub fn start() -> (String, PendingAuth) {
+    let verifier = url_safe(&random_bytes_32());
+    let challenge = url_safe(&sha256(verifier.as_bytes()));
+    let state = url_safe(uuid::Uuid::new_v4().as_bytes());
+    let url = format!(
+        "{AUTHORIZE_URL}?code=true&client_id={CLIENT_ID}&response_type=code\
+         &redirect_uri={redirect}&scope={scope}&code_challenge={challenge}\
+         &code_challenge_method=S256&state={state}",
+        redirect = percent_encode(REDIRECT_URI),
+        scope = percent_encode(SCOPES),
+    );
+    (url, PendingAuth { verifier, state })
+}
+
+/// Exchanges the pasted authorization code for tokens.
+///
+/// The callback page shows the value as `<code>#<state>`; we accept either that
+/// or a bare code.
+pub async fn exchange_code(
+    code_input: &str,
+    verifier: &str,
+    expected_state: &str,
+) -> Result<Tokens> {
+    let (code, state) = split_code(code_input);
+    // PKCE already protects the exchange; the state echo is an extra CSRF guard
+    // when the operator pastes the full `<code>#<state>` the callback page shows.
+    if !expected_state.is_empty() && !state.is_empty() && state != expected_state {
+        return Err(eyre!("authorization state mismatch; restart the login"));
+    }
+    token_request(&json!({
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "state": state,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": verifier,
+    }))
+    .await
+}
+
+/// Trades a refresh token for a fresh access token (and possibly a rotated
+/// refresh token).
+pub async fn refresh(refresh_token: &str) -> Result<Tokens> {
+    token_request(&json!({
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "refresh_token": refresh_token,
+    }))
+    .await
+}
+
+/// Mints the long-lived inference token the agent runs on (what `setup-token`
+/// produces), using a freshly-exchanged OAuth access token.
+pub async fn mint_inference_token(access_token: &str) -> Result<String> {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(CREATE_API_KEY_URL)
+        .bearer_auth(access_token)
+        .header("anthropic-beta", OAUTH_BETA)
+        .json(&json!({}))
+        .send()
+        .await
+        .wrap_err("create_api_key request failed")?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(eyre!("create_api_key returned {status}: {text}"));
+    }
+    let value: Value = serde_json::from_str(&text)
+        .wrap_err_with(|| format!("unexpected create_api_key response: {text}"))?;
+    // WIRE: the long-lived key's field name is unconfirmed; try the likely ones.
+    ["raw_key", "key", "token", "api_key", "raw_api_key"]
+        .into_iter()
+        .find_map(|field| value.get(field).and_then(Value::as_str))
+        .map(str::to_string)
+        .ok_or_else(|| eyre!("create_api_key response had no recognizable token field: {text}"))
+}
+
+/// Polls the subscription usage. Returns a distinct error on 429 so the caller
+/// can back off (the endpoint rate-limits aggressively).
+pub async fn fetch_usage(access_token: &str) -> Result<Usage> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(USAGE_URL)
+        .bearer_auth(access_token)
+        .header("anthropic-beta", OAUTH_BETA)
+        .send()
+        .await
+        .wrap_err("usage request failed")?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if status.as_u16() == 429 {
+        return Err(eyre!("usage endpoint rate limited (429)"));
+    }
+    if !status.is_success() {
+        return Err(eyre!("usage endpoint returned {status}: {text}"));
+    }
+    let value: Value = serde_json::from_str(&text)
+        .wrap_err_with(|| format!("unexpected usage response: {text}"))?;
+    Ok(parse_usage(&value))
+}
+
+// --- helpers -----------------------------------------------------------------
+
+async fn token_request(body: &Value) -> Result<Tokens> {
+    #[derive(Deserialize)]
+    struct Response {
+        access_token: String,
+        #[serde(default)]
+        refresh_token: String,
+        #[serde(default)]
+        expires_in: i64,
+        #[serde(default)]
+        scope: String,
+    }
+    let client = reqwest::Client::new();
+    let response = client
+        .post(TOKEN_URL)
+        .header("anthropic-beta", OAUTH_BETA)
+        .json(body)
+        .send()
+        .await
+        .wrap_err("oauth token request failed")?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(eyre!("oauth token endpoint returned {status}: {text}"));
+    }
+    let parsed: Response = serde_json::from_str(&text)
+        .wrap_err_with(|| format!("unexpected token response: {text}"))?;
+    Ok(Tokens {
+        access_token: parsed.access_token,
+        refresh_token: parsed.refresh_token,
+        // Default to one hour if the endpoint omits it; the refresh loop refreshes
+        // ahead of expiry regardless.
+        expires_in: if parsed.expires_in > 0 {
+            parsed.expires_in
+        } else {
+            3600
+        },
+        scopes: parsed.scope,
+    })
+}
+
+/// Splits a pasted `<code>#<state>` (or a bare code) into its parts.
+fn split_code(input: &str) -> (&str, &str) {
+    let trimmed = input.trim();
+    trimmed.split_once('#').unwrap_or((trimmed, ""))
+}
+
+/// Parses the usage payload, tolerating the two shapes seen in the wild: the
+/// claude.ai org shape (`{five_hour:{utilization, resets_at}}`) and the
+/// status-line shape (`{rate_limits:{five_hour:{used_percentage, resets_at}}}`).
+fn parse_usage(value: &Value) -> Usage {
+    let root = value.get("rate_limits").unwrap_or(value);
+    let window = |name: &str| -> (Option<f64>, Option<i64>) {
+        let Some(window) = root.get(name) else {
+            return (None, None);
+        };
+        let utilization = window
+            .get("utilization")
+            .or_else(|| window.get("used_percentage"))
+            .and_then(Value::as_f64);
+        let resets_at = window
+            .get("resets_at")
+            .or_else(|| window.get("resetsAt"))
+            .and_then(parse_epoch_seconds);
+        (utilization, resets_at)
+    };
+    let (five_hour_utilization, five_hour_resets_at) = window("five_hour");
+    let (seven_day_utilization, seven_day_resets_at) = window("seven_day");
+    Usage {
+        five_hour_utilization,
+        five_hour_resets_at,
+        seven_day_utilization,
+        seven_day_resets_at,
+    }
+}
+
+/// A reset time may arrive as unix seconds (integer) or an ISO-8601 string.
+fn parse_epoch_seconds(value: &Value) -> Option<i64> {
+    if let Some(seconds) = value.as_i64() {
+        return Some(seconds);
+    }
+    let text = value.as_str()?;
+    chrono::DateTime::parse_from_rfc3339(text)
+        .ok()
+        .map(|datetime| datetime.timestamp())
+}
+
+fn random_bytes_32() -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    bytes[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    bytes
+}
+
+fn sha256(input: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+    hasher.finalize().into()
+}
+
+fn url_safe(bytes: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// RFC 3986 percent-encoding of everything outside the unreserved set.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                out.push('%');
+                out.push(HEX[usize::from(byte >> 4)] as char);
+                out.push(HEX[usize::from(byte & 0x0f)] as char);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_builds_a_valid_pkce_url() {
+        let (url, pending) = start();
+        assert!(url.starts_with(AUTHORIZE_URL));
+        assert!(url.contains(&format!("client_id={CLIENT_ID}")));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains(&format!("state={}", pending.state)));
+
+        // The challenge in the URL must be base64url(sha256(verifier)).
+        let expected_challenge = url_safe(&sha256(pending.verifier.as_bytes()));
+        assert!(
+            url.contains(&format!("code_challenge={expected_challenge}")),
+            "challenge in URL does not match the verifier"
+        );
+        // Two authorizations differ.
+        let (_, other) = start();
+        assert_ne!(pending.verifier, other.verifier);
+    }
+
+    #[test]
+    fn split_code_handles_both_forms() {
+        assert_eq!(split_code("abc#xyz"), ("abc", "xyz"));
+        assert_eq!(split_code("  abc#xyz  "), ("abc", "xyz"));
+        assert_eq!(split_code("just-a-code"), ("just-a-code", ""));
+    }
+
+    #[test]
+    fn percent_encode_escapes_reserved() {
+        assert_eq!(percent_encode("a b:c"), "a%20b%3Ac");
+        assert_eq!(percent_encode("plain-_.~"), "plain-_.~");
+        assert_eq!(
+            percent_encode("org:create_api_key user:profile"),
+            "org%3Acreate_api_key%20user%3Aprofile"
+        );
+    }
+
+    #[test]
+    fn parse_usage_handles_claude_ai_shape() {
+        let value = json!({
+            "five_hour": { "utilization": 34, "resets_at": "2026-06-12T06:39:59+00:00" },
+            "seven_day": { "utilization": 15, "resets_at": "2026-06-18T19:59:59+00:00" },
+        });
+        let usage = parse_usage(&value);
+        assert_eq!(usage.five_hour_utilization, Some(34.0));
+        assert_eq!(usage.seven_day_utilization, Some(15.0));
+        assert!(usage.five_hour_resets_at.is_some());
+    }
+
+    #[test]
+    fn parse_usage_handles_statusline_shape() {
+        let value = json!({
+            "rate_limits": {
+                "five_hour": { "used_percentage": 34.0, "resets_at": 1_781_246_400_i64 },
+                "seven_day": { "used_percentage": 15.0, "resets_at": 1_781_700_000_i64 },
+            }
+        });
+        let usage = parse_usage(&value);
+        assert_eq!(usage.five_hour_utilization, Some(34.0));
+        assert_eq!(usage.five_hour_resets_at, Some(1_781_246_400));
+        assert_eq!(usage.seven_day_resets_at, Some(1_781_700_000));
+    }
+
+    #[test]
+    fn parse_usage_tolerates_missing_windows() {
+        let usage = parse_usage(&json!({}));
+        assert_eq!(usage.five_hour_utilization, None);
+        assert_eq!(usage.five_hour_resets_at, None);
+    }
+}

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -53,6 +53,20 @@ pub enum NetworkAccessLevel {
     Custom,
 }
 
+/// How the agent authenticates to Claude.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "claude_auth_mode", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ClaudeAuthMode {
+    /// A Claude subscription token (the long-lived inference token, from the
+    /// OAuth login or a manual `setup-token`), injected as
+    /// `CLAUDE_CODE_OAUTH_TOKEN`. The default and the historical behavior.
+    Subscription,
+    /// An Anthropic API key, injected as `ANTHROPIC_API_KEY`. No subscription
+    /// usage gauge applies in this mode.
+    ApiKey,
+}
+
 /// Which Jira deployment we are talking to, which decides both the auth scheme
 /// and the REST API version. Cloud uses Basic auth (email + API token) and REST
 /// v3; Server / Data Center uses a Bearer personal access token and REST v2.
@@ -169,6 +183,12 @@ pub struct Settings {
     pub updated_at: DateTime<Utc>,
     /// Whether a Claude OAuth token is stored (the token itself is never sent).
     pub claude_token_set: bool,
+    /// How the agent authenticates to Claude (subscription token vs API key).
+    pub claude_auth_mode: ClaudeAuthMode,
+    /// Whether subscription usage credentials are stored (the refreshing
+    /// access/refresh pair used only to poll the usage gauge). Only meaningful in
+    /// `subscription` mode; the tokens themselves are never sent.
+    pub claude_usage_token_set: bool,
     /// Whether a GitHub token is stored (the token itself is never sent).
     pub github_token_set: bool,
     /// When true, the agent only works during [`Self::availability_windows`].
@@ -244,6 +264,16 @@ pub struct Settings {
     /// value on [`crate::state::AppState`].
     #[sqlx(default)]
     pub cooldown_until: Option<DateTime<Utc>>,
+}
+
+/// The refreshing OAuth credentials used solely to poll the subscription usage
+/// gauge. All-empty when no subscription login is configured. Never serialized to
+/// clients.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ClaudeUsageCredentials {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 /// A user-defined environment variable injected into the agent's execs.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,10 +12,10 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnswerKind, AutomationRule, AvailabilityWindow, EnvSuggestion, EnvVar, EnvVarWrite,
-    HeartAttack, InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingQuestion,
-    Question, QuestionOption, QuestionStatus, RepoDeletionImpact, Repository, ReviewPolicy,
-    Settings, SourceKind, StatsAggregate, Task, TaskColumn, TaskStatus, Turn,
+    AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials, EnvSuggestion, EnvVar,
+    EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel,
+    PendingQuestion, Question, QuestionOption, QuestionStatus, RepoDeletionImpact, Repository,
+    ReviewPolicy, Settings, SourceKind, StatsAggregate, Task, TaskColumn, TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -29,6 +29,8 @@ const SETTINGS_COLUMNS: &str =
      claude_model, workspace_image_tag, base_setup_script, config_repo_url, \
      default_branch_template, config_repo_error, current_session_id, updated_at, \
      (claude_oauth_token <> '') AS claude_token_set, \
+     claude_auth_mode, \
+     (claude_usage_refresh_token <> '') AS claude_usage_token_set, \
      (github_token <> '') AS github_token_set, \
      availability_enabled, availability_timezone, availability_windows, \
      availability_skip_dates, network_access_level, network_access_domains, \
@@ -263,6 +265,82 @@ pub async fn set_tokens(
     Ok(())
 }
 
+/// The refreshing OAuth credentials used to poll the subscription usage gauge
+/// (all-empty when no subscription login is configured). Internal use only.
+pub async fn get_usage_credentials(pool: &PgPool) -> sqlx::Result<ClaudeUsageCredentials> {
+    sqlx::query_as::<_, ClaudeUsageCredentials>(
+        "SELECT claude_usage_access_token AS access_token, \
+         claude_usage_refresh_token AS refresh_token, \
+         claude_usage_expires_at AS expires_at FROM settings WHERE id = 1",
+    )
+    .fetch_one(pool)
+    .await
+}
+
+/// Persists a completed subscription OAuth login: the long-lived inference token
+/// the agent runs on, plus the refreshing usage credentials, switching auth mode
+/// to `subscription`.
+pub async fn set_subscription_credentials(
+    pool: &PgPool,
+    inference_token: &str,
+    access_token: &str,
+    refresh_token: &str,
+    expires_at: DateTime<Utc>,
+    scopes: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE settings SET claude_oauth_token = $1, claude_auth_mode = 'subscription', \
+         claude_usage_access_token = $2, claude_usage_refresh_token = $3, \
+         claude_usage_expires_at = $4, claude_usage_scopes = $5, updated_at = now() \
+         WHERE id = 1",
+    )
+    .bind(inference_token)
+    .bind(access_token)
+    .bind(refresh_token)
+    .bind(expires_at)
+    .bind(scopes)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Updates the usage access token (and the rotated refresh token, if the endpoint
+/// returned a new one) after a refresh. An empty `refresh_token` keeps the stored
+/// one.
+pub async fn set_usage_tokens(
+    pool: &PgPool,
+    access_token: &str,
+    refresh_token: &str,
+    expires_at: DateTime<Utc>,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE settings SET claude_usage_access_token = $1, \
+         claude_usage_refresh_token = COALESCE(NULLIF($2, ''), claude_usage_refresh_token), \
+         claude_usage_expires_at = $3, updated_at = now() WHERE id = 1",
+    )
+    .bind(access_token)
+    .bind(refresh_token)
+    .bind(expires_at)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Switches to API-key auth: stores the key as the inference credential and clears
+/// the subscription usage credentials (the gauge does not apply).
+pub async fn set_api_key(pool: &PgPool, api_key: &str) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE settings SET claude_oauth_token = $1, claude_auth_mode = 'api_key', \
+         claude_usage_access_token = '', claude_usage_refresh_token = '', \
+         claude_usage_expires_at = NULL, claude_usage_scopes = '', updated_at = now() \
+         WHERE id = 1",
+    )
+    .bind(api_key)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 // --- Notification sounds ------------------------------------------------------
 //
 // The custom audio clips live on the settings row but are streamed by a dedicated
@@ -335,7 +413,11 @@ pub async fn list_secret_values(pool: &PgPool) -> sqlx::Result<Vec<String>> {
          UNION ALL \
          SELECT github_token FROM settings WHERE id = 1 AND github_token <> '' \
          UNION ALL \
-         SELECT jira_api_token FROM settings WHERE id = 1 AND jira_api_token <> ''",
+         SELECT jira_api_token FROM settings WHERE id = 1 AND jira_api_token <> '' \
+         UNION ALL \
+         SELECT claude_usage_access_token FROM settings WHERE id = 1 AND claude_usage_access_token <> '' \
+         UNION ALL \
+         SELECT claude_usage_refresh_token FROM settings WHERE id = 1 AND claude_usage_refresh_token <> ''",
     )
     .fetch_all(pool)
     .await?;

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -108,6 +108,15 @@ pub fn router(state: AppState) -> Router {
         .route("/notepad", get(notepad::get).put(notepad::set))
         .route("/settings/tokens", post(settings::set_tokens))
         .route(
+            "/settings/claude/oauth/start",
+            post(settings::claude_oauth_start),
+        )
+        .route(
+            "/settings/claude/oauth/finish",
+            post(settings::claude_oauth_finish),
+        )
+        .route("/settings/claude/api-key", post(settings::claude_api_key))
+        .route(
             "/settings/sounds/:kind",
             get(settings::get_sound)
                 .post(settings::upload_sound)

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -130,6 +130,77 @@ pub async fn set_tokens(
     Ok(Json(settings_view(&state).await?))
 }
 
+// --- Claude authentication ---------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct OauthStartResponse {
+    /// The consent URL to open in a new tab.
+    pub authorize_url: String,
+}
+
+/// `POST /api/v1/settings/claude/oauth/start` - begins a Claude subscription
+/// OAuth login. Returns the consent URL; the PKCE secrets are held server-side
+/// until the operator pastes the resulting code back via `.../oauth/finish`.
+pub async fn claude_oauth_start(
+    State(state): State<AppState>,
+) -> ApiResult<Json<OauthStartResponse>> {
+    let (authorize_url, pending) = crate::claude::oauth::start();
+    state.set_pending_oauth(pending);
+    Ok(Json(OauthStartResponse { authorize_url }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OauthFinishRequest {
+    /// The value from the consent callback page (`<code>#<state>` or a bare code).
+    pub code: String,
+}
+
+/// `POST /api/v1/settings/claude/oauth/finish` - completes the login: exchanges
+/// the pasted code, mints the long-lived inference token the agent runs on, and
+/// stores it alongside the refreshing usage credentials (switching to
+/// subscription mode).
+pub async fn claude_oauth_finish(
+    State(state): State<AppState>,
+    Json(body): Json<OauthFinishRequest>,
+) -> ApiResult<Json<Settings>> {
+    let pending = state
+        .take_pending_oauth()
+        .ok_or_else(|| eyre::eyre!("no Claude login is in progress; start one first"))?;
+    let tokens =
+        crate::claude::oauth::exchange_code(&body.code, &pending.verifier, &pending.state).await?;
+    let inference_token = crate::claude::oauth::mint_inference_token(&tokens.access_token).await?;
+    let expires_at = chrono::Utc::now() + chrono::Duration::seconds(tokens.expires_in);
+    queries::set_subscription_credentials(
+        &state.db,
+        &inference_token,
+        &tokens.access_token,
+        &tokens.refresh_token,
+        expires_at,
+        &tokens.scopes,
+    )
+    .await?;
+    Ok(Json(settings_view(&state).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ApiKeyRequest {
+    pub api_key: String,
+}
+
+/// `POST /api/v1/settings/claude/api-key` - stores an Anthropic API key and
+/// switches the agent to API-key auth (no subscription usage gauge applies).
+pub async fn claude_api_key(
+    State(state): State<AppState>,
+    Json(body): Json<ApiKeyRequest>,
+) -> ApiResult<Json<Settings>> {
+    let key = body.api_key.trim();
+    if key.is_empty() {
+        return Err(eyre::eyre!("the API key is empty").into());
+    }
+    queries::set_api_key(&state.db, key).await?;
+    Ok(Json(settings_view(&state).await?))
+}
+
 // --- Notification sounds ------------------------------------------------------
 
 /// The biggest custom clip we accept. Notification sounds are short, so this is

--- a/api/src/http/stats.rs
+++ b/api/src/http/stats.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use super::ApiResult;
 use crate::db::models::{Settings, StatsAggregate};
 use crate::db::queries;
-use crate::state::{AppState, LiveUsage};
+use crate::state::{AppState, LiveUsage, SubscriptionUsage};
 
 #[derive(Debug, Serialize)]
 pub struct StatsResponse {
@@ -46,6 +46,10 @@ pub struct StatsResponse {
     /// The rate-limit status (e.g. "allowed") when the stream reports no numeric
     /// utilization, so the UI can show a status instead of a misleading 0%.
     pub usage_status: Option<String>,
+    /// Subscription 7-day usage utilization (0-100) and its reset, when a
+    /// subscription login is configured (polled from `/api/oauth/usage`).
+    pub usage_seven_day_utilization: Option<f64>,
+    pub usage_seven_day_resets_at: Option<i64>,
     pub turns: i64,
 }
 
@@ -113,10 +117,29 @@ fn build_response(
     latest_usage: Option<&Value>,
     rate_limit: Option<&Value>,
     live_usage: Option<LiveUsage>,
+    usage: Option<SubscriptionUsage>,
 ) -> StatsResponse {
     let input_total = agg.input_tokens + agg.cache_creation_tokens + agg.cache_read_tokens;
-    let (usage_utilization, usage_resets_at, usage_status) =
+    let (rate_utilization, rate_resets_at, usage_status) =
         rate_limit.map_or((None, None, None), rate_limit_fields);
+    // Prefer the polled subscription usage (the real 5-hour percentage from
+    // /api/oauth/usage) over the stream's status-only rate-limit event, which
+    // carries no number. Fall back to the rate-limit fields when no subscription
+    // login is configured.
+    let usage_utilization = usage
+        .as_ref()
+        .and_then(|snapshot| snapshot.five_hour_utilization)
+        .or(rate_utilization);
+    let usage_resets_at = usage
+        .as_ref()
+        .and_then(|snapshot| snapshot.five_hour_resets_at)
+        .or(rate_resets_at);
+    let usage_seven_day_utilization = usage
+        .as_ref()
+        .and_then(|snapshot| snapshot.seven_day_utilization);
+    let usage_seven_day_resets_at = usage
+        .as_ref()
+        .and_then(|snapshot| snapshot.seven_day_resets_at);
 
     // Overlay the in-progress turn's live usage (if any) on top of the persisted,
     // completed-turn totals so the counter ticks mid-turn. Only output is added to
@@ -141,6 +164,8 @@ fn build_response(
         usage_utilization,
         usage_resets_at,
         usage_status,
+        usage_seven_day_utilization,
+        usage_seven_day_resets_at,
         turns: agg.turns,
     }
 }
@@ -160,6 +185,7 @@ pub async fn global(State(state): State<AppState>) -> ApiResult<Json<StatsRespon
         rate_limit.as_ref(),
         // One shared agent, so any in-progress turn's live usage counts globally.
         state.live_usage(),
+        state.usage(),
     )))
 }
 
@@ -181,6 +207,7 @@ pub async fn task(
         rate_limit.as_ref(),
         // Only overlay the live counter when the running turn is this task's.
         state.live_usage().filter(|usage| usage.task_id == id),
+        state.usage(),
     )))
 }
 

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -619,6 +619,8 @@ mod tests {
             current_session_id: None,
             updated_at: Utc::now(),
             claude_token_set: false,
+            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,
             availability_timezone: "UTC".to_string(),

--- a/api/src/orchestrator/availability.rs
+++ b/api/src/orchestrator/availability.rs
@@ -98,6 +98,8 @@ mod tests {
             current_session_id: None,
             updated_at: Utc::now(),
             claude_token_set: false,
+            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: enabled,
             availability_timezone: timezone.to_string(),

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -13,6 +13,7 @@ mod availability;
 mod network;
 mod prompt;
 mod provision;
+mod subscription;
 mod thoughts;
 mod usage;
 
@@ -121,6 +122,7 @@ pub fn spawn(state: AppState) {
     tokio::spawn(sync_loop(state.clone()));
     tokio::spawn(review_loop(state.clone()));
     tokio::spawn(defibrillator_loop(state.clone()));
+    tokio::spawn(subscription::usage_loop(state.clone()));
     tokio::spawn(agent_loop(state));
 }
 
@@ -1017,6 +1019,7 @@ async fn stream_turn(
         prompt,
         resume_session_id: settings.current_session_id.clone(),
         model: settings.claude_model.clone(),
+        auth_mode: settings.claude_auth_mode,
         oauth_token: queries::get_claude_token(&state.db).await?,
         github_token: queries::get_github_token(&state.db).await?,
         task_id: task.id.to_string(),

--- a/api/src/orchestrator/network.rs
+++ b/api/src/orchestrator/network.rs
@@ -241,6 +241,8 @@ mod tests {
             current_session_id: None,
             updated_at: Utc::now(),
             claude_token_set: false,
+            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,
             availability_timezone: "UTC".to_string(),

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -437,6 +437,8 @@ mod tests {
             current_session_id: None,
             updated_at: chrono::Utc::now(),
             claude_token_set: false,
+            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,
             availability_timezone: "UTC".to_string(),

--- a/api/src/orchestrator/subscription.rs
+++ b/api/src/orchestrator/subscription.rs
@@ -1,0 +1,91 @@
+//! Background polling of the Claude subscription usage gauge.
+//!
+//! Only the usage gauge depends on this loop; the agent's inference runs on the
+//! stable long-lived token and is never affected. When subscription credentials
+//! are configured, the loop refreshes the short-lived access token as needed and
+//! polls `/api/oauth/usage`, caching the result on [`AppState`] for the stats
+//! endpoints. The endpoint rate-limits aggressively, so polling is infrequent and
+//! a failed poll simply leaves the last good snapshot in place.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use eyre::{eyre, Result};
+use tokio::time::sleep;
+use tracing::debug;
+
+use crate::claude::oauth;
+use crate::db::models::{ClaudeAuthMode, ClaudeUsageCredentials};
+use crate::db::queries;
+use crate::state::{AppState, SubscriptionUsage};
+
+/// How often the subscription usage is polled. Deliberately infrequent: the
+/// `/api/oauth/usage` endpoint returns 429 under even modest polling, and the
+/// number moves slowly, so a five-minute cadence keeps the gauge fresh enough
+/// without tripping the limit.
+const USAGE_POLL: Duration = Duration::from_secs(300);
+
+/// Refresh the usage access token this far before its expiry, so a poll never
+/// races the expiry boundary.
+const REFRESH_SKEW_MINUTES: i64 = 2;
+
+/// Polls the subscription usage forever, caching each result on [`AppState`].
+pub async fn usage_loop(state: AppState) {
+    loop {
+        if let Err(error) = poll_once(&state).await {
+            // A 429 or transient failure: keep the last snapshot and try next tick.
+            debug!(error = %error, "subscription usage poll skipped");
+        }
+        sleep(USAGE_POLL).await;
+    }
+}
+
+async fn poll_once(state: &AppState) -> Result<()> {
+    let settings = queries::get_settings(&state.db).await?;
+    if settings.claude_auth_mode != ClaudeAuthMode::Subscription || !settings.claude_usage_token_set
+    {
+        // No subscription usage credentials (API-key mode, or not logged in): make
+        // sure no stale snapshot lingers, and skip the network call.
+        state.set_usage(None);
+        return Ok(());
+    }
+
+    let credentials = queries::get_usage_credentials(&state.db).await?;
+    let access_token = ensure_fresh_access(state, &credentials).await?;
+    let usage = oauth::fetch_usage(&access_token).await?;
+    state.set_usage(Some(SubscriptionUsage {
+        five_hour_utilization: usage.five_hour_utilization,
+        five_hour_resets_at: usage.five_hour_resets_at,
+        seven_day_utilization: usage.seven_day_utilization,
+        seven_day_resets_at: usage.seven_day_resets_at,
+    }));
+    Ok(())
+}
+
+/// Returns a usable access token, refreshing and persisting it first if it is
+/// expired (or within [`REFRESH_SKEW_MINUTES`] of expiry).
+async fn ensure_fresh_access(
+    state: &AppState,
+    credentials: &ClaudeUsageCredentials,
+) -> Result<String> {
+    let near_expiry = credentials.expires_at.is_none_or(|expires_at| {
+        expires_at <= Utc::now() + chrono::Duration::minutes(REFRESH_SKEW_MINUTES)
+    });
+    if !near_expiry && !credentials.access_token.is_empty() {
+        return Ok(credentials.access_token.clone());
+    }
+    if credentials.refresh_token.is_empty() {
+        return Err(eyre!("no refresh token to refresh the usage access token"));
+    }
+
+    let tokens = oauth::refresh(&credentials.refresh_token).await?;
+    let expires_at = Utc::now() + chrono::Duration::seconds(tokens.expires_in);
+    queries::set_usage_tokens(
+        &state.db,
+        &tokens.access_token,
+        &tokens.refresh_token,
+        expires_at,
+    )
+    .await?;
+    Ok(tokens.access_token)
+}

--- a/api/src/orchestrator/thoughts.rs
+++ b/api/src/orchestrator/thoughts.rs
@@ -81,6 +81,7 @@ async fn summarize(
         // disturb) the shared task session.
         resume_session_id: None,
         model: settings.claude_model.clone(),
+        auth_mode: settings.claude_auth_mode,
         oauth_token: queries::get_claude_token(&state.db).await?,
         github_token: queries::get_github_token(&state.db).await?,
         // A summary turn doesn't act as the task, so it gets no helper wiring.

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -11,6 +11,7 @@ use sqlx::PgPool;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+use crate::claude::oauth::PendingAuth;
 use crate::db::queries;
 use crate::docker::Workspace;
 use crate::jira::{JiraClient, JiraConfig};
@@ -70,6 +71,18 @@ pub struct LiveUsage {
     pub context_tokens: i64,
 }
 
+/// A cached subscription usage snapshot for the gauge, polled from
+/// `/api/oauth/usage`. `None` when no subscription login is configured or no poll
+/// has succeeded yet. Utilization values are percentages (0-100); reset times are
+/// unix seconds.
+#[derive(Debug, Clone, Serialize)]
+pub struct SubscriptionUsage {
+    pub five_hour_utilization: Option<f64>,
+    pub five_hour_resets_at: Option<i64>,
+    pub seven_day_utilization: Option<f64>,
+    pub seven_day_resets_at: Option<i64>,
+}
+
 /// Clonable, shared state handed to every request handler and background task.
 #[derive(Clone)]
 pub struct AppState {
@@ -87,6 +100,13 @@ pub struct AppState {
     /// Ephemeral (like [`Self::cooldown_until`]); the stats endpoints overlay it on
     /// the persisted totals so the counter ticks during generation.
     live_usage: Arc<RwLock<Option<LiveUsage>>>,
+    /// The PKCE secrets for an in-flight Claude subscription OAuth login, held
+    /// between starting the flow (which returns the consent URL) and the operator
+    /// pasting the code back. Ephemeral; only one login is in flight at a time.
+    pending_oauth: Arc<RwLock<Option<PendingAuth>>>,
+    /// The latest polled subscription usage snapshot, refreshed by the usage loop
+    /// and read by the stats gauges. `None` until a poll succeeds.
+    usage: Arc<RwLock<Option<SubscriptionUsage>>>,
     /// Bumped by a hard reset. A turn captures it at the start and abandons its
     /// post-turn handling (session persist, task move) if it changed, so a reset
     /// that lands mid-turn is never undone by the turn it interrupted.
@@ -140,6 +160,8 @@ impl AppState {
             internal_api_url,
             cooldown_until: Arc::new(RwLock::new(None)),
             live_usage: Arc::new(RwLock::new(None)),
+            pending_oauth: Arc::new(RwLock::new(None)),
+            usage: Arc::new(RwLock::new(None)),
             reset_epoch: Arc::new(AtomicU64::new(0)),
             update,
             update_status: Arc::new(RwLock::new(update_status)),
@@ -194,6 +216,29 @@ impl AppState {
     /// the SSE tick rather than emitting on every update.
     pub fn set_live_usage(&self, usage: Option<LiveUsage>) {
         *self.live_usage.write().expect("live usage lock poisoned") = usage;
+    }
+
+    /// Stashes the PKCE secrets for an in-flight subscription OAuth login.
+    pub fn set_pending_oauth(&self, pending: PendingAuth) {
+        *self.pending_oauth.write().expect("oauth lock poisoned") = Some(pending);
+    }
+
+    /// Consumes the in-flight OAuth secrets (so a code can't be redeemed twice).
+    pub fn take_pending_oauth(&self) -> Option<PendingAuth> {
+        self.pending_oauth
+            .write()
+            .expect("oauth lock poisoned")
+            .take()
+    }
+
+    /// The latest polled subscription usage snapshot, if any.
+    pub fn usage(&self) -> Option<SubscriptionUsage> {
+        self.usage.read().expect("usage lock poisoned").clone()
+    }
+
+    /// Replaces (or clears with `None`) the cached subscription usage snapshot.
+    pub fn set_usage(&self, usage: Option<SubscriptionUsage>) {
+        *self.usage.write().expect("usage lock poisoned") = usage;
     }
 
     /// Builds a GitHub client from the token stored in the database. Built on

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -277,6 +277,27 @@ export function setTokens(body: TokensRequest) {
   return apiClient.post('settings/tokens', { json: body }).json<Settings>()
 }
 
+// --- Claude authentication ---------------------------------------------------
+
+export type OauthStartResponse = {
+  authorize_url: string
+}
+
+// Begins a Claude subscription OAuth login; returns the consent URL to open.
+export function startClaudeOauth() {
+  return apiClient.post('settings/claude/oauth/start').json<OauthStartResponse>()
+}
+
+// Completes the login with the code pasted from the consent callback page.
+export function finishClaudeOauth(code: string) {
+  return apiClient.post('settings/claude/oauth/finish', { json: { code } }).json<Settings>()
+}
+
+// Stores an Anthropic API key and switches the agent to API-key auth.
+export function setClaudeApiKey(apiKey: string) {
+  return apiClient.post('settings/claude/api-key', { json: { api_key: apiKey } }).json<Settings>()
+}
+
 // --- Jira --------------------------------------------------------------------
 
 export type JiraTestResult = { ok: boolean; user?: string; error?: string }

--- a/frontend/src/lib/components/Stats.svelte
+++ b/frontend/src/lib/components/Stats.svelte
@@ -65,6 +65,7 @@
       : 0
   )
   const usagePct = $derived(stats?.usage_utilization ?? 0)
+  const sevenDayPct = $derived(stats?.usage_seven_day_utilization ?? 0)
   // When the headless stream reports no numeric utilization, fall back to its
   // categorical status (e.g. "allowed") rather than a misleading 0%.
   const usageStatusLabel = $derived(stats?.usage_status?.replace(/_/g, ' ') ?? 'Unknown')
@@ -160,9 +161,9 @@
       {#if stats.usage_utilization != null}
         {@render gauge(
           usagePct,
-          'Usage limit',
+          stats.usage_seven_day_utilization != null ? '5-hour limit' : 'Usage limit',
           usageColor(usagePct),
-          `Subscription usage limit: ${pctLabel(usagePct)} used${resetsLabel(stats.usage_resets_at)}. This is the whole subscription (all terminals), not just Seraphim.`
+          `Subscription 5-hour usage limit: ${pctLabel(usagePct)} used${resetsLabel(stats.usage_resets_at)}. This is the whole subscription (all terminals), not just Seraphim.`
         )}
       {:else}
         <!-- The headless agent stream reports a status, not a percentage. -->
@@ -177,6 +178,15 @@
           </div>
           <span class="text-xs text-muted-foreground">Usage limit</span>
         </div>
+      {/if}
+
+      {#if stats.usage_seven_day_utilization != null}
+        {@render gauge(
+          sevenDayPct,
+          'Weekly limit',
+          usageColor(sevenDayPct),
+          `Subscription 7-day usage limit: ${pctLabel(sevenDayPct)} used${resetsLabel(stats.usage_seven_day_resets_at)}. This is the whole subscription (all terminals), not just Seraphim.`
+        )}
       {/if}
 
       {@render gauge(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -131,6 +131,9 @@ export type AvailabilityWindow = {
   end_minute: number
 }
 
+// How the agent authenticates to Claude.
+export type ClaudeAuthMode = 'subscription' | 'api_key'
+
 export type Settings = {
   org_name: string
   global_instructions: string
@@ -145,6 +148,10 @@ export type Settings = {
   current_session_id: string | null
   updated_at: string
   claude_token_set: boolean
+  // How the agent authenticates to Claude (subscription token vs API key).
+  claude_auth_mode: ClaudeAuthMode
+  // Whether subscription usage credentials are stored (powers the usage gauge).
+  claude_usage_token_set: boolean
   github_token_set: boolean
   availability_enabled: boolean
   availability_timezone: string
@@ -251,6 +258,10 @@ export type Stats = {
   usage_resets_at: number | null
   // Rate-limit status (e.g. "allowed") shown when the stream reports no number.
   usage_status: string | null
+  // Subscription 7-day usage utilization (0-100) and reset (unix seconds), when a
+  // subscription login is configured.
+  usage_seven_day_utilization: number | null
+  usage_seven_day_resets_at: number | null
   turns: number
 }
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -36,6 +36,9 @@
     runUpdate,
     setEnvVars,
     setTokens,
+    startClaudeOauth,
+    finishClaudeOauth,
+    setClaudeApiKey,
     testJira,
     updateJiraBoard,
     updateSettings,
@@ -98,11 +101,18 @@
   let importMessage = $state<string | null>(null)
 
   // Write-only secret inputs; never populated from the server.
-  let claudeTokenInput = $state('')
   let githubTokenInput = $state('')
   let githubWebhookSecretInput = $state('')
   let jiraWebhookSecretInput = $state('')
   let tokensMessage = $state<string | null>(null)
+
+  // Claude authentication (subscription OAuth vs API key).
+  let claudeAuthBusy = $state(false)
+  let claudeAuthError = $state<string | null>(null)
+  let claudeAuthMessage = $state<string | null>(null)
+  let oauthAuthorizeUrl = $state<string | null>(null)
+  let oauthCodeInput = $state('')
+  let claudeApiKeyInput = $state('')
 
   // Model picker: a dropdown of known ids plus a custom free-text fallback.
   let modelChoice = $state<string>(KNOWN_MODELS[0].value)
@@ -517,7 +527,6 @@
 
   async function saveTokens() {
     if (
-      !claudeTokenInput.trim() &&
       !githubTokenInput.trim() &&
       !githubWebhookSecretInput.trim() &&
       !jiraWebhookSecretInput.trim()
@@ -525,16 +534,78 @@
       return
     }
     settings = await setTokens({
-      claude_oauth_token: claudeTokenInput.trim() || undefined,
       github_token: githubTokenInput.trim() || undefined,
       github_webhook_secret: githubWebhookSecretInput.trim() || undefined,
       jira_webhook_secret: jiraWebhookSecretInput.trim() || undefined
     })
-    claudeTokenInput = ''
     githubTokenInput = ''
     githubWebhookSecretInput = ''
     jiraWebhookSecretInput = ''
     tokensMessage = 'Saved to the database.'
+  }
+
+  // Opens the Claude consent screen in a new tab; the operator pastes the code
+  // back to complete the login.
+  async function connectClaudeSubscription() {
+    claudeAuthError = null
+    claudeAuthMessage = null
+    claudeAuthBusy = true
+    try {
+      const { authorize_url } = await startClaudeOauth()
+      oauthAuthorizeUrl = authorize_url
+      window.open(authorize_url, '_blank', 'noopener,noreferrer')
+    }
+    catch (error) {
+      console.debug('startClaudeOauth failed', error)
+      claudeAuthError = 'Could not start the login. Check the API logs.'
+    }
+    finally {
+      claudeAuthBusy = false
+    }
+  }
+
+  async function completeClaudeLogin() {
+    const code = oauthCodeInput.trim()
+    if (!code) {
+      return
+    }
+    claudeAuthError = null
+    claudeAuthBusy = true
+    try {
+      settings = await finishClaudeOauth(code)
+      oauthAuthorizeUrl = null
+      oauthCodeInput = ''
+      claudeAuthMessage = 'Connected your Claude subscription.'
+    }
+    catch (error) {
+      console.debug('finishClaudeOauth failed', error)
+      claudeAuthError = 'Login failed. Paste the full code from the consent page, then try again.'
+    }
+    finally {
+      claudeAuthBusy = false
+    }
+  }
+
+  async function saveClaudeApiKey() {
+    const key = claudeApiKeyInput.trim()
+    if (!key) {
+      return
+    }
+    claudeAuthError = null
+    claudeAuthMessage = null
+    claudeAuthBusy = true
+    try {
+      settings = await setClaudeApiKey(key)
+      claudeApiKeyInput = ''
+      claudeAuthMessage = 'Saved your Anthropic API key.'
+    }
+    catch (error) {
+      console.debug('setClaudeApiKey failed', error)
+      claudeAuthError = 'Could not save the API key.'
+    }
+    finally {
+      claudeAuthBusy = false
+    }
   }
 
   async function runRestart() {
@@ -810,20 +881,91 @@
         </Card.Description>
       </Card.Header>
       <Card.Content class="space-y-5">
-        <div class="space-y-1.5">
-          <Label for="claude-token" class="flex items-center gap-2">
-            Claude OAuth token
+        <div class="space-y-2">
+          <Label class="flex flex-wrap items-center gap-2">
+            Claude authentication
             <Badge variant="outline" class={settings.claude_token_set ? 'border-success/40 text-success' : 'text-muted-foreground'}>
-              {settings.claude_token_set ? 'configured' : 'not set'}
+              {#if !settings.claude_token_set}
+                not set
+              {:else if settings.claude_auth_mode === 'api_key'}
+                API key
+              {:else}
+                subscription
+              {/if}
             </Badge>
+            {#if settings.claude_auth_mode === 'subscription' && settings.claude_usage_token_set}
+              <Badge variant="outline" class="border-success/40 text-success">usage gauge on</Badge>
+            {/if}
           </Label>
-          <Input
-            id="claude-token"
-            type="password"
-            autocomplete="off"
-            placeholder="from `claude setup-token`"
-            bind:value={claudeTokenInput}
-          />
+          <p class="text-sm text-muted-foreground">
+            Connect a Claude subscription (recommended) to run the agent and light up the live usage
+            gauge, or use an Anthropic API key. The subscription path is the same one-click login the
+            Claude Code CLI uses.
+          </p>
+
+          <!-- Claude subscription OAuth: opens consent, then paste the code back. -->
+          <div class="space-y-2 rounded-md border border-border p-3">
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-sm font-medium">Claude subscription</span>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={claudeAuthBusy}
+                onclick={connectClaudeSubscription}
+              >
+                {settings.claude_token_set && settings.claude_auth_mode === 'subscription'
+                  ? 'Reconnect'
+                  : 'Connect'}
+              </Button>
+            </div>
+            {#if oauthAuthorizeUrl}
+              <p class="text-xs text-muted-foreground">
+                A consent tab opened. Approve it, copy the code it shows, and paste it below.
+                <a href={oauthAuthorizeUrl} target="_blank" rel="noopener noreferrer" class="underline">
+                  Reopen the tab
+                </a>.
+              </p>
+              <div class="flex gap-2">
+                <Input placeholder="paste the code here" autocomplete="off" bind:value={oauthCodeInput} />
+                <Button
+                  size="sm"
+                  disabled={claudeAuthBusy || !oauthCodeInput.trim()}
+                  onclick={completeClaudeLogin}
+                >
+                  Complete
+                </Button>
+              </div>
+            {/if}
+          </div>
+
+          <!-- Anthropic API key (no subscription usage gauge in this mode). -->
+          <div class="space-y-2 rounded-md border border-border p-3">
+            <span class="text-sm font-medium">Anthropic API key</span>
+            <div class="flex gap-2">
+              <Input
+                type="password"
+                autocomplete="off"
+                placeholder="sk-ant-api03-…"
+                bind:value={claudeApiKeyInput}
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={claudeAuthBusy || !claudeApiKeyInput.trim()}
+                onclick={saveClaudeApiKey}
+              >
+                Save
+              </Button>
+            </div>
+            <p class="text-xs text-muted-foreground">No subscription usage gauge applies in this mode.</p>
+          </div>
+
+          {#if claudeAuthError}
+            <p class="text-sm text-destructive">{claudeAuthError}</p>
+          {/if}
+          {#if claudeAuthMessage}
+            <p class="text-sm text-success">{claudeAuthMessage}</p>
+          {/if}
         </div>
         <div class="space-y-1.5">
           <Label for="gh-token" class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Replaces the manual `claude setup-token` paste with a first-class Claude login in Settings, offering two options:

- **Claude account with subscription** (recommended): the same Auth Code + PKCE consent flow the Claude Code CLI uses.
- **Anthropic API key**: paste a key; the agent runs on it directly. No subscription usage gauge applies in this mode.

This supersedes #164 (the usage gauge showing "Allowed" / 0%), which was a symptom of not having a `user:profile`-scoped credential to read `/api/oauth/usage`.

## The credential separation (subscription mode)

A single consent produces two credentials, stored and used independently:

1. A long-lived, rock-solid inference token, minted via `create_api_key` (the same mechanism behind `claude setup-token`). The agent runs every turn on this token, so inference never depends on the refresh loop.
2. The short-lived, refreshing access/refresh pair, used only to poll `/api/oauth/usage` for the live usage gauge (5-hour and 7-day utilization).

Why two: inference must never break because a refresh failed, and Seraphim owns its own dedicated login, so there is no refresh-token rotation conflict with the operator's other terminals.

## Changes

**Backend**
- `api/src/claude/oauth.rs`: native OAuth client (PKCE start, code exchange with CSRF state check, refresh, `create_api_key` inference-token mint, `/api/oauth/usage` fetch + parse). Unit-tested.
- `api/migrations/0031_claude_oauth.sql`: `claude_auth_mode` enum column plus the usage access/refresh/expiry/scopes columns.
- `api/src/orchestrator/subscription.rs`: background poller that refreshes the usage token before expiry and snapshots utilization into shared state.
- `api/src/claude/exec.rs`: auth-mode-aware credential injection (`CLAUDE_CODE_OAUTH_TOKEN` for subscription, `ANTHROPIC_API_KEY` for API key).
- `api/src/http/settings.rs`: `/settings/claude/oauth/start`, `/oauth/finish`, `/api-key` handlers.
- `api/src/http/stats.rs`: prefers the polled subscription utilization over the stream's status-only event; adds the 7-day fields.

**Frontend**
- `settings/+page.svelte`: two login options with status badges, a Connect button that opens the consent tab, a code-paste field to complete the login, and an API-key input.
- `Stats.svelte`: surfaces the real 5-hour percentage plus a 7-day gauge when a subscription login is configured.

## Checks

- `cargo +1.88 fmt` clean, `clippy` clean (only pre-existing `too_many_lines` warnings), `cargo +1.88 test` 73 passed.
- `yarn check` 0 errors, `yarn build` ok.

## Validate at deploy time (live, together)

The OAuth wire shapes are flagged with `WIRE:` comments and need one live confirmation against the deployed Claude Code version:

- the exact field name `create_api_key` returns the minted token under,
- the exact `/api/oauth/usage` response shape,
- acceptance of the requested scope string.

## Out of scope / follow-up

- Writing `~/.claude/.credentials.json` into the volume (optional; the DB is the source of truth).
