### PR TITLE
Fix Switch on/off state not rendering (#165)

### DIFF
--- a/frontend/src/lib/components/ui/switch/switch.svelte
+++ b/frontend/src/lib/components/ui/switch/switch.svelte
@@ -19,13 +19,13 @@
 	data-slot="switch"
 	data-size={size}
 	class={cn(
-		"data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+		"data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-[state=unchecked]:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
 		className
 	)}
 	{...restProps}
 >
 	<SwitchPrimitive.Thumb
 		data-slot="switch-thumb"
-		class="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform rtl:data-[state=checked]:translate-x-[calc(-100%)]"
+		class="bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-[state=checked]:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-[state=unchecked]:translate-x-0 group-data-[size=sm]/switch:data-[state=unchecked]:translate-x-0 pointer-events-none block ring-0 transition-transform rtl:data-[state=checked]:translate-x-[calc(-100%)]"
 	/>
 </SwitchPrimitive.Root>


### PR DESCRIPTION
Closes #165. Reopened because the earlier fix (#168, checkbox → toggle switch) made no visible difference — this PR fixes the actual root cause.

## Root cause

The shared `Switch` component (`frontend/src/lib/components/ui/switch/switch.svelte`) styled its on/off state with `data-checked:` / `data-unchecked:` Tailwind variants. But **bits-ui v2.18.1 emits `data-state="checked"` / `data-state="unchecked"`** on both the Root and the Thumb — never a bare `data-checked` attribute. With no `@custom-variant` alias defined in `app.css`, those variants matched nothing, so:

- the track never turned `bg-primary` (`data-checked:bg-primary` was dead), and
- the thumb never slid (`data-checked:translate-x-…` was dead),

leaving the "on" state **pixel-identical to "off"** — exactly the reported symptom. It also explains why #168 (which converted the form checkboxes to this same `Switch`) changed nothing: the Switch component itself was broken. (Tell-tale: the file's own RTL rule already used the correct `data-[state=checked]:` form.)

## Fix

Replace every `data-checked:` → `data-[state=checked]:` and `data-unchecked:` → `data-[state=unchecked]:` on the Root and Thumb. `data-disabled:` and `data-[size=…]:` are left as-is — those attributes really are emitted (the latter is set by the component itself).

Two class strings in one file. Because develop already routes every toggle through this component (no raw checkboxes remain — the conversions landed earlier), this single change makes on/off visually distinct **everywhere** (settings, search filters, repo form, automation, task page, etc.).

## Verification

Inspected the production build's CSS — the on-state rules are now generated and keyed to the attribute bits-ui actually sets:
- `…[data-state=checked]{background-color:var(--primary)}` (track turns primary)
- thumb `…[data-state=checked]{--tw-translate-x: calc(100% - 2px)}` (thumb slides)
- zero leftover bare `[data-checked]` / `[data-unchecked]` selectors.

`yarn check` (0 errors/warnings) and `yarn build` both pass. No backend changes.