### PR TITLE
Make native <select> dropdowns readable in dark mode (#175)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -5,6 +5,13 @@
 /* shadcn-svelte design tokens, themed to Seraphim's dark palette. The app is
    dark-only, so the values live directly on :root (no light/dark switch). */
 :root {
+  /* Tell the browser this is a dark UI so it paints native controls (the
+     <select> option popup, scrollbars, date pickers, etc.) with dark chrome.
+     Without this, a native <select>'s dropdown renders on the OS default
+     white background while our CSS forces the option text light — white text
+     on a white list, unreadable (issue #175). */
+  color-scheme: dark;
+
   --radius: 0.625rem;
 
   --background: #0d1117;


### PR DESCRIPTION
Closes #175.

## Problem

Native `<select>` controls open an OS-rendered option popup. The app forces option text light (dark theme), but the native popup defaults to a **white** background, so the open dropdown was light text on a white list — unreadable (screenshot in the issue). This affected every native select: the automation-rule builder, the bulk-edit "keep / true / false" dropdowns, and the settings selects.

## Fix

The app is **dark-only** (per `app.css`), so declare `color-scheme: dark` on `:root`. This is the standard signal that tells the browser to paint native form controls — the `<select>` option popup, scrollbars, date/number spinners, etc. — with dark chrome, so the option list automatically gets a dark background with light text. Tailwind/CSS can't style a native `<option>` popup directly, so `color-scheme` is the correct lever.

One line; fixes every native select at once, plus incidentally gives native scrollbars/spinners dark chrome consistent with the theme.

## Verification

- `color-scheme:dark` confirmed present in the production build's CSS (`:root` rule).
- `yarn check` (0 errors/warnings) and `yarn build` pass. No backend changes.