### PR TITLE
Run embedded migrations against a throwaway Postgres in CI (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,29 @@ jobs:
     defaults:
       run:
         working-directory: api
+
+    # Disposable Postgres for the migration check below. sqlx uses runtime
+    # queries, so a broken or duplicate migration (a repeated version number, a
+    # typo in an ALTER TABLE) compiles and tests green and only fails at API
+    # boot on a real deploy. Applying the embedded migrations to a real database
+    # here catches that in the PR. Mapped to host port 5433 (not the default
+    # 5432) so it never collides with a dev Postgres on the shared self-hosted
+    # runner. The container is torn down with the job, so every run is clean.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: seraphim
+          POSTGRES_PASSWORD: seraphim
+          POSTGRES_DB: seraphim_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U seraphim -d seraphim_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -49,6 +72,15 @@ jobs:
       - name: Test
         if: ${{ !cancelled() }}
         run: cargo test --all-features
+
+      # Apply the embedded migrations to the throwaway Postgres above. Runs the
+      # same `sqlx::migrate!("./migrations")` set the API runs at boot, so a
+      # broken migration fails here instead of on a real deploy.
+      - name: Migrate (throwaway Postgres)
+        if: ${{ !cancelled() }}
+        env:
+          DATABASE_URL: postgres://seraphim:seraphim@localhost:5433/seraphim_test
+        run: cargo run --bin migrate
 
   frontend:
     name: Frontend (SvelteKit)

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -9,6 +9,13 @@ license = "MIT"
 name = "seraphim-api"
 path = "src/main.rs"
 
+# One-shot helper that applies the embedded migrations to $DATABASE_URL. Used by
+# CI to run them against a throwaway Postgres so a broken migration fails the PR
+# instead of only failing at API boot. Not shipped in the image.
+[[bin]]
+name = "migrate"
+path = "src/bin/migrate.rs"
+
 [dependencies]
 # Async runtime + web framework
 tokio = { version = "1", features = ["full"] }

--- a/api/src/bin/migrate.rs
+++ b/api/src/bin/migrate.rs
@@ -1,0 +1,38 @@
+//! Apply the embedded SQL migrations to `$DATABASE_URL`, then exit.
+//!
+//! The API runs `sqlx::migrate!("./migrations")` at boot (see [`db::connect`]),
+//! but these are *runtime* queries, so a broken or duplicate migration (a
+//! repeated version number, a typo in an `ALTER TABLE`) still compiles and
+//! tests green and only fails when the API first connects to a real database.
+//!
+//! This binary runs that exact same embedded migration set against a disposable
+//! Postgres in CI, so a migration regression fails the pull request instead of
+//! only surfacing on a real deploy. It is not part of the shipped image; the
+//! API applies its own migrations on startup.
+//!
+//! Exits non-zero on any connection or migration failure.
+
+use eyre::{Context, Result};
+use sqlx::postgres::PgPoolOptions;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let database_url = std::env::var("DATABASE_URL")
+        .wrap_err("DATABASE_URL must be set (e.g. postgres://user:pass@localhost:5432/db)")?;
+
+    // One connection is plenty for a one-shot migrate; keeping it at 1 also
+    // makes the failure mode obvious if the throwaway Postgres isn't reachable.
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .wrap_err("failed to connect to Postgres")?;
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .wrap_err("failed to run database migrations")?;
+
+    println!("Applied all embedded migrations successfully.");
+    Ok(())
+}


### PR DESCRIPTION
Closes #174.

CI runs `cargo build`/`clippy`/`test`, but because sqlx uses runtime queries, the SQL migrations are never applied to a real database. A broken or duplicate migration (a repeated version number, a typo in an `ALTER TABLE`) compiles and tests green and only fails at API boot on a real deploy. This adds an end-to-end migration check to the PR.

## What changed
- **New `migrate` bin** (`api/src/bin/migrate.rs`): connects to `$DATABASE_URL` and runs the same `sqlx::migrate!("./migrations")` set the API applies at boot (`db::connect`), exiting non-zero on any connection or migration error. It is not shipped in the image (the Dockerfile still copies only `seraphim-api`; the API migrates itself on startup).
- **CI** (`.github/workflows/ci.yml`): the **API (Rust)** job now provisions a disposable `postgres:17` service and a new **Migrate (throwaway Postgres)** step runs `cargo run --bin migrate` against it. The service is mapped to host port **5433** (not the default 5432) so it never collides with a dev Postgres on the shared self-hosted runner, and it is torn down with the job so every run is clean. The step is `if: ${{ !cancelled() }}`, matching the job's no-fail-fast convention, and reuses the binary already compiled by the Clippy/Test steps.

## Validation
Built and ran end to end against a real Postgres locally:
- All **33** embedded migrations apply cleanly (`Applied all embedded migrations successfully.`).
- Re-running is **idempotent** (sqlx skips already-applied versions, no error).
- `cargo fmt --check` and `cargo clippy --all-targets --all-features` are clean for the new bin.

No new dependencies (reuses the existing `sqlx` + `eyre` + `tokio`), so `Cargo.lock` is unchanged.

Single repo, single PR.