### PR TITLE
Show PR CI activity (per-step) in the activity logs (#185)

### DIFF
--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1586,6 +1586,51 @@ pub async fn list_task_prs(pool: &PgPool, task_id: Uuid) -> sqlx::Result<Vec<Tas
     .await
 }
 
+/// Every open pull request across all tasks, for the CI-step watcher. Merged /
+/// closed PRs are settled, so the watcher ignores them.
+pub async fn list_open_task_prs(pool: &PgPool) -> sqlx::Result<Vec<TaskPullRequest>> {
+    sqlx::query_as::<_, TaskPullRequest>(
+        "SELECT * FROM task_pull_requests WHERE pr_state = 'open' ORDER BY task_id, created_at",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Prompt sentinel marking a synthetic turn that holds CI-step activity rather
+/// than a real Claude invocation. The watcher appends its events here so they
+/// flow through the same activity-log query as agent events, without a schema
+/// change. No `prompt` event is recorded for it, so it shows nothing of itself.
+const CI_TURN_PROMPT: &str = "[CI activity]";
+
+/// Finds the turn the CI watcher should append to, or creates one. Reuses the
+/// latest turn only when it is already a CI turn, so CI events that arrive after
+/// a fresh agent turn (e.g. a CI-fix turn) open a new CI turn and stay in
+/// chronological order in the activity log.
+pub async fn get_or_create_ci_turn(pool: &PgPool, task_id: Uuid) -> sqlx::Result<Turn> {
+    let latest = sqlx::query_as::<_, Turn>(
+        "SELECT * FROM turns WHERE task_id = $1 ORDER BY idx DESC LIMIT 1",
+    )
+    .bind(task_id)
+    .fetch_optional(pool)
+    .await?;
+    if let Some(turn) = latest {
+        if turn.prompt == CI_TURN_PROMPT {
+            return Ok(turn);
+        }
+    }
+    let idx = next_turn_idx(pool, task_id).await?;
+    create_turn(pool, task_id, idx, CI_TURN_PROMPT, None).await
+}
+
+/// The next event sequence number within a turn (max + 1, or 0 for the first).
+pub async fn next_event_seq(pool: &PgPool, turn_id: Uuid) -> sqlx::Result<i32> {
+    let max: Option<i32> = sqlx::query_scalar("SELECT MAX(seq) FROM events WHERE turn_id = $1")
+        .bind(turn_id)
+        .fetch_one(pool)
+        .await?;
+    Ok(max.map_or(0, |value| value + 1))
+}
+
 /// Records (or refreshes) a task's pull request, keyed by `(task, repo, number)`.
 #[allow(clippy::too_many_arguments)]
 pub async fn upsert_task_pr(

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -310,14 +310,162 @@ struct WorkflowRunsPage {
     workflow_runs: Vec<WorkflowRun>,
 }
 
-#[derive(Debug, Deserialize)]
-struct WorkflowRun {
-    id: u64,
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkflowRun {
+    pub id: u64,
     /// The workflow's display name, reported as the failing check when it fails.
-    name: String,
-    status: String,
-    conclusion: Option<String>,
-    run_attempt: u32,
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub run_attempt: u32,
+}
+
+/// Lists the workflow runs at a commit, for step-level CI watching. Same source
+/// as [`ci_status`] (the Actions API), but returns the raw runs so a caller can
+/// drill into each run's jobs and steps rather than just the aggregate verdict.
+///
+/// # Errors
+/// If listing the commit's workflow runs fails.
+pub async fn list_runs_for_sha(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    sha: &str,
+) -> Result<Vec<WorkflowRun>> {
+    let runs: WorkflowRunsPage = octo
+        .get(
+            format!("/repos/{owner}/{repo}/actions/runs?head_sha={sha}&per_page={PER_PAGE}"),
+            None::<&()>,
+        )
+        .await
+        .wrap_err("failed to list workflow runs")?;
+    Ok(runs.workflow_runs)
+}
+
+/// A single job within a workflow run, with its ordered steps. A job is one
+/// runner's worth of work (e.g. "API (Rust)"); its steps are the named actions
+/// inside it (e.g. "Format", "Clippy", "Test").
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkflowJob {
+    pub id: u64,
+    pub name: String,
+    /// `queued` | `in_progress` | `completed`.
+    pub status: String,
+    /// `success` | `failure` | `skipped` | `cancelled` | ... (only once completed).
+    pub conclusion: Option<String>,
+    #[serde(default)]
+    pub steps: Vec<WorkflowStep>,
+}
+
+/// One step inside a [`WorkflowJob`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkflowStep {
+    pub name: String,
+    /// `queued` | `in_progress` | `completed`.
+    pub status: String,
+    /// `success` | `failure` | `skipped` | ... (only once completed).
+    pub conclusion: Option<String>,
+    /// 1-based position of the step within its job.
+    pub number: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct JobsPage {
+    jobs: Vec<WorkflowJob>,
+}
+
+/// Lists a workflow run's jobs (each with its steps), for the latest attempt.
+///
+/// # Errors
+/// If the jobs request fails.
+pub async fn list_run_jobs(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    run_id: u64,
+) -> Result<Vec<WorkflowJob>> {
+    let page: JobsPage = octo
+        .get(
+            format!("/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?per_page=100"),
+            None::<&()>,
+        )
+        .await
+        .wrap_err("failed to list workflow run jobs")?;
+    Ok(page.jobs)
+}
+
+/// Fetches a failed job's log and returns its last `max_lines` lines, with the
+/// per-line ISO timestamp GitHub prepends stripped so the snippet reads like a
+/// raw terminal. Any ANSI color the log carries is left intact for the UI to
+/// honor. Returns `None` when the log can't be fetched (e.g. not yet available).
+///
+/// Uses `reqwest` directly rather than octocrab because the logs endpoint 302s
+/// to a pre-signed blob URL and serves plain text, not JSON.
+///
+/// # Errors
+/// Never returns `Err` for an unavailable log (logs as a warning and yields
+/// `None`); only a malformed client build would error, which can't happen here.
+pub async fn fetch_job_log_tail(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    job_id: u64,
+    max_lines: usize,
+) -> Option<String> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/actions/jobs/{job_id}/logs");
+    let request = reqwest::Client::new()
+        .get(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "seraphim");
+    let response = match request.send().await {
+        Ok(response) if response.status().is_success() => response,
+        Ok(response) => {
+            tracing::debug!(status = %response.status(), job_id, "job log not available yet");
+            return None;
+        }
+        Err(error) => {
+            tracing::debug!(%error, job_id, "failed to fetch job log");
+            return None;
+        }
+    };
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            tracing::debug!(%error, job_id, "failed to read job log body");
+            return None;
+        }
+    };
+
+    let lines: Vec<&str> = body.lines().collect();
+    let tail = lines
+        .iter()
+        .rev()
+        .take(max_lines)
+        .rev()
+        .map(|line| strip_log_timestamp(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if tail.trim().is_empty() {
+        None
+    } else {
+        Some(tail)
+    }
+}
+
+/// Strips the leading `2026-06-15T21:00:00.1234567Z ` timestamp GitHub prepends
+/// to each raw log line. Leaves a line without that prefix untouched.
+fn strip_log_timestamp(line: &str) -> &str {
+    // The prefix is an RFC3339 timestamp followed by a single space. Detect it
+    // cheaply: a 'T' at index 10 and a 'Z' before the first space.
+    if let Some(space) = line.find(' ') {
+        let stamp = &line[..space];
+        if stamp.len() >= 20 && stamp.as_bytes().get(10) == Some(&b'T') && stamp.ends_with('Z') {
+            return &line[space + 1..];
+        }
+    }
+    line
 }
 
 /// Re-runs the failed jobs of any first-attempt workflow run at `head_sha`.
@@ -633,4 +781,38 @@ pub async fn add_issue_comment(
         .await
         .wrap_err("failed to post issue comment")?;
     Ok(comment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_log_timestamp;
+
+    #[test]
+    fn strips_the_leading_iso_timestamp() {
+        assert_eq!(
+            strip_log_timestamp("2026-06-15T21:00:00.1234567Z Running typecheck"),
+            "Running typecheck"
+        );
+    }
+
+    #[test]
+    fn leaves_a_line_without_a_timestamp_untouched() {
+        assert_eq!(
+            strip_log_timestamp("Reading package lists..."),
+            "Reading package lists..."
+        );
+        // A leading word with a space but no timestamp shape is left alone.
+        assert_eq!(
+            strip_log_timestamp("error: build failed"),
+            "error: build failed"
+        );
+    }
+
+    #[test]
+    fn keeps_the_rest_of_the_line_intact_including_extra_spaces() {
+        assert_eq!(
+            strip_log_timestamp("2026-06-15T21:00:00Z Fetched 31.1 MB in 3s (12.3 MB/s)"),
+            "Fetched 31.1 MB in 3s (12.3 MB/s)"
+        );
+    }
 }

--- a/api/src/orchestrator/ci_watch.rs
+++ b/api/src/orchestrator/ci_watch.rs
@@ -1,0 +1,268 @@
+//! Mirrors a watched pull request's GitHub Actions progress into the task's
+//! activity log, so the operator sees CI's per-step progress alongside the
+//! agent's own events (issue #185).
+//!
+//! For every open PR a task tracks, the loop polls the commit's workflow runs,
+//! then each run's jobs and steps, and emits one activity event per transition:
+//!
+//! - `step_running`: a step started (live only, never persisted, so the history isn't cluttered).
+//! - `step_passed`: a step succeeded (persisted: "CI: <step> complete").
+//! - `step_failed`: a step failed (persisted, with the tail of the job log so the error is visible inline).
+//! - `job_passed`: a whole job succeeded (persisted: "CI: All <job> passed").
+//!
+//! These flow through the same `events` table + task SSE stream as agent events,
+//! so both the per-task view and the global watch view render them with no
+//! special transport. Persisted events carry a stable `key` so a process restart
+//! reseeds from the database and never re-writes a line it already recorded.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use chrono::Utc;
+use eyre::Result;
+use serde_json::json;
+use tokio::time::sleep;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::db::models::TaskPullRequest;
+use crate::db::queries;
+use crate::git;
+use crate::state::AppState;
+
+/// How often the watcher polls GitHub Actions for the open PRs it tracks. Faster
+/// than the 30s review loop so a step reads as live, but coarse enough that a
+/// handful of open PRs stay well within the API budget.
+const CI_POLL: Duration = Duration::from_secs(12);
+
+/// Lines of a failed step's job log to surface inline in the activity log.
+const FAIL_LOG_LINES: usize = 25;
+
+/// The phase we last emitted for a step (or job), so each transition is emitted
+/// exactly once. `Running` is live-only; `Done` is persisted to history.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    Running,
+    Done,
+}
+
+/// This process's watch memory for one task: the phase last emitted per step/job
+/// key, and whether the already-persisted keys have been seeded from the DB yet
+/// (so a restart never re-writes history that is already there).
+#[derive(Default)]
+struct TaskWatch {
+    seeded: bool,
+    phases: HashMap<String, Phase>,
+}
+
+/// Background loop: poll the open PRs' CI and emit step activity. Never exits.
+pub async fn ci_watch_loop(state: AppState) {
+    let mut watch: HashMap<Uuid, TaskWatch> = HashMap::new();
+    loop {
+        if let Err(error) = watch_once(&state, &mut watch).await {
+            warn!(error = %error, "CI activity watch failed");
+        }
+        sleep(CI_POLL).await;
+    }
+}
+
+async fn watch_once(state: &AppState, watch: &mut HashMap<Uuid, TaskWatch>) -> Result<()> {
+    // No GitHub auth configured means nothing to watch (and unauthenticated
+    // Actions calls would just 401); skip quietly.
+    let token = queries::get_github_token(&state.db).await?;
+    if token.is_empty() {
+        return Ok(());
+    }
+
+    let prs = queries::list_open_task_prs(&state.db).await?;
+    // Forget watch memory for tasks whose PRs have all settled, so it can't grow
+    // without bound over the process's lifetime.
+    let open_task_ids: HashSet<Uuid> = prs.iter().map(|pr| pr.task_id).collect();
+    watch.retain(|task_id, _| open_task_ids.contains(task_id));
+    if prs.is_empty() {
+        return Ok(());
+    }
+
+    let github = state.github().await?;
+    for pr in prs {
+        let Some((owner, name)) = pr.repo_full_name.split_once('/') else {
+            continue;
+        };
+        if pr.head_sha.is_empty() {
+            continue;
+        }
+
+        let entry = watch.entry(pr.task_id).or_default();
+        if !entry.seeded {
+            if let Err(error) = seed_seen(state, pr.task_id, entry).await {
+                debug!(error = %error, task_id = %pr.task_id, "failed to seed CI watch state");
+            } else {
+                entry.seeded = true;
+            }
+        }
+
+        if let Err(error) = watch_pr(state, &github, &token, &pr, owner, name, entry).await {
+            debug!(error = %error, task_id = %pr.task_id, repo = %pr.repo_full_name, "CI watch for PR failed");
+        }
+    }
+    Ok(())
+}
+
+/// Seeds a task's already-recorded CI keys from the database so a restart resumes
+/// where it left off instead of re-writing the same lines.
+async fn seed_seen(state: &AppState, task_id: Uuid, watch: &mut TaskWatch) -> Result<()> {
+    for event in queries::list_events_for_task(&state.db, task_id).await? {
+        if event.event_type != "ci" {
+            continue;
+        }
+        if let Some(key) = event.payload.0.get("key").and_then(|value| value.as_str()) {
+            watch.phases.insert(key.to_string(), Phase::Done);
+        }
+    }
+    Ok(())
+}
+
+async fn watch_pr(
+    state: &AppState,
+    github: &octocrab::Octocrab,
+    token: &str,
+    pr: &TaskPullRequest,
+    owner: &str,
+    name: &str,
+    watch: &mut TaskWatch,
+) -> Result<()> {
+    for run in git::list_runs_for_sha(github, owner, name, &pr.head_sha).await? {
+        for job in git::list_run_jobs(github, owner, name, run.id).await? {
+            for step in &job.steps {
+                let key = format!(
+                    "{}#{}#{}#{}",
+                    pr.repo_full_name, run.id, job.id, step.number
+                );
+                process_step(state, token, pr, owner, name, &job, step, &key, watch).await?;
+            }
+
+            // A whole job finishing green gets a summary line, mirroring the
+            // issue's "All <job> has passed".
+            if job.status == "completed" && job.conclusion.as_deref() == Some("success") {
+                let key = format!("{}#{}#{}#job", pr.repo_full_name, run.id, job.id);
+                if watch.phases.get(&key) != Some(&Phase::Done) {
+                    emit_persisted(
+                        state,
+                        pr.task_id,
+                        "job_passed",
+                        format!("CI: All {} passed", job.name),
+                        None,
+                        &key,
+                    )
+                    .await?;
+                    watch.phases.insert(key, Phase::Done);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_step(
+    state: &AppState,
+    token: &str,
+    pr: &TaskPullRequest,
+    owner: &str,
+    name: &str,
+    job: &git::WorkflowJob,
+    step: &git::WorkflowStep,
+    key: &str,
+    watch: &mut TaskWatch,
+) -> Result<()> {
+    match step.status.as_str() {
+        // First time we see a step running, announce it live (not persisted).
+        "in_progress" => {
+            if !watch.phases.contains_key(key) {
+                emit_live(
+                    state,
+                    pr.task_id,
+                    "step_running",
+                    &format!("CI: Running {}...", step.name),
+                    key,
+                );
+                watch.phases.insert(key.to_string(), Phase::Running);
+            }
+        }
+        "completed" => {
+            if watch.phases.get(key) == Some(&Phase::Done) {
+                return Ok(());
+            }
+            match step.conclusion.as_deref() {
+                Some("success") => {
+                    emit_persisted(
+                        state,
+                        pr.task_id,
+                        "step_passed",
+                        format!("CI: {} complete", step.name),
+                        None,
+                        key,
+                    )
+                    .await?;
+                }
+                // Skipped steps (and the odd null conclusion) aren't worth a line.
+                Some("skipped") | None => {}
+                Some(_failed) => {
+                    let log =
+                        git::fetch_job_log_tail(token, owner, name, job.id, FAIL_LOG_LINES).await;
+                    emit_persisted(
+                        state,
+                        pr.task_id,
+                        "step_failed",
+                        format!("CI: {} failed", step.name),
+                        log,
+                        key,
+                    )
+                    .await?;
+                }
+            }
+            watch.phases.insert(key.to_string(), Phase::Done);
+        }
+        // queued / unknown: nothing to show yet.
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Pushes a live CI event onto the task's stream without persisting it, so an
+/// in-progress step shows immediately but doesn't clutter the saved history.
+fn emit_live(state: &AppState, task_id: Uuid, status: &str, text: &str, key: &str) {
+    let payload = json!({ "status": status, "text": text, "key": key });
+    state.notify_task(
+        task_id,
+        json!({ "type": "ci", "payload": payload, "created_at": Utc::now() }),
+    );
+}
+
+/// Persists a CI event to the task's activity history and streams it live. An
+/// optional `log` (a failed step's log tail) rides along, with `has_ansi` set so
+/// the UI knows whether to honor embedded ANSI color.
+async fn emit_persisted(
+    state: &AppState,
+    task_id: Uuid,
+    status: &str,
+    text: String,
+    log: Option<String>,
+    key: &str,
+) -> Result<()> {
+    let turn = queries::get_or_create_ci_turn(&state.db, task_id).await?;
+    let seq = queries::next_event_seq(&state.db, turn.id).await?;
+
+    let mut payload = json!({ "status": status, "text": text, "key": key });
+    if let Some(log) = log {
+        payload["has_ansi"] = json!(log.contains('\u{1b}'));
+        payload["log"] = json!(log);
+    }
+
+    queries::append_event(&state.db, turn.id, seq, "ci", payload.clone()).await?;
+    state.notify_task(
+        task_id,
+        json!({ "type": "ci", "payload": payload, "created_at": Utc::now() }),
+    );
+    Ok(())
+}

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -10,6 +10,7 @@
 //! completion before the next is considered, so turns never overlap.
 
 mod availability;
+mod ci_watch;
 mod network;
 mod prompt;
 mod provision;
@@ -129,6 +130,7 @@ pub fn spawn(state: AppState) {
     tokio::spawn(provision_on_startup(state.clone()));
     tokio::spawn(sync_loop(state.clone()));
     tokio::spawn(review_loop(state.clone()));
+    tokio::spawn(ci_watch::ci_watch_loop(state.clone()));
     tokio::spawn(defibrillator_loop(state.clone()));
     tokio::spawn(subscription::token_loop(state.clone()));
     tokio::spawn(agent_loop(state));

--- a/frontend/src/lib/ansi.ts
+++ b/frontend/src/lib/ansi.ts
@@ -1,0 +1,90 @@
+// A minimal SGR (Select Graphic Rendition) parser: turns a string carrying ANSI
+// color escapes into styled segments for rendering. CI logs only ever use the
+// 8/16-color foreground codes plus bold, so that is all we honor; any other
+// escape sequence is dropped so the text stays clean. Dependency-free, in the
+// same hand-rolled spirit as `json-highlight.ts`.
+
+export type AnsiSegment = {
+  text: string
+  classes: string
+}
+
+// The escape byte (ESC, 0x1b). Kept as a constant so the regex is built via the
+// `RegExp` constructor rather than a literal with a control character in it
+// (which the linter flags as `no-control-regex`).
+const ESC = '\u001b'
+const SGR = new RegExp(`${ESC}\\[([0-9;]*)m`, 'g')
+
+// Foreground color codes mapped to Tailwind text classes. Bright variants
+// (90-97) map to slightly lighter shades. White maps to the theme foreground so
+// it reads correctly on the dark background rather than as literal white.
+const FG_CLASS: Record<number, string> = {
+  30: 'text-neutral-500',
+  31: 'text-red-400',
+  32: 'text-green-400',
+  33: 'text-yellow-300',
+  34: 'text-blue-400',
+  35: 'text-fuchsia-400',
+  36: 'text-cyan-300',
+  37: 'text-foreground',
+  90: 'text-neutral-400',
+  91: 'text-red-300',
+  92: 'text-green-300',
+  93: 'text-yellow-200',
+  94: 'text-blue-300',
+  95: 'text-fuchsia-300',
+  96: 'text-cyan-200',
+  97: 'text-foreground'
+}
+
+/** Whether the text carries any ANSI escape sequence at all. */
+export function hasAnsi(text: string): boolean {
+  return text.includes(`${ESC}[`)
+}
+
+/**
+ * Split `text` into styled segments, applying SGR foreground + bold state as it
+ * goes. Text with no escapes returns a single, class-less segment.
+ */
+export function parseAnsi(text: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = []
+  let foreground = ''
+  let bold = false
+  let lastIndex = 0
+
+  function push(chunk: string) {
+    if (!chunk) {
+      return
+    }
+    const classes = [foreground, bold ? 'font-bold' : ''].filter(Boolean).join(' ')
+    segments.push({ text: chunk, classes })
+  }
+
+  SGR.lastIndex = 0
+  let match = SGR.exec(text)
+  while (match !== null) {
+    push(text.slice(lastIndex, match.index))
+    lastIndex = SGR.lastIndex
+
+    const codes = match[1] === '' ? [0] : match[1].split(';').map((code) => Number(code))
+    for (const code of codes) {
+      if (code === 0) {
+        foreground = ''
+        bold = false
+      } else if (code === 1) {
+        bold = true
+      } else if (code === 22) {
+        bold = false
+      } else if (code === 39) {
+        foreground = ''
+      } else if (FG_CLASS[code]) {
+        foreground = FG_CLASS[code]
+      }
+    }
+
+    match = SGR.exec(text)
+  }
+  push(text.slice(lastIndex))
+
+  return segments
+}

--- a/frontend/src/lib/components/AnsiLog.svelte
+++ b/frontend/src/lib/components/AnsiLog.svelte
@@ -1,0 +1,26 @@
+<!--
+  Renders a snippet of log text, honoring any ANSI color it carries. When the
+  text has no ANSI color of its own and it represents an error, the whole block
+  falls back to red so a failure still reads as a failure (issue #185).
+-->
+<script lang="ts">
+  import { hasAnsi, parseAnsi } from '$lib/ansi'
+
+  type Props = {
+    text: string
+    /** Tint the whole block red when the log carries no color of its own. */
+    isError?: boolean
+  }
+
+  let { text, isError = false }: Props = $props()
+
+  const colored = $derived(hasAnsi(text))
+  const segments = $derived(parseAnsi(text))
+  // Plain (color-less) error logs get a red base; everything else stays muted
+  // and lets per-segment ANSI colors show through.
+  const baseColor = $derived(!colored && isError ? 'text-destructive' : 'text-muted-foreground')
+</script>
+
+<pre
+  class="mt-1 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/60 px-2 py-1.5 font-mono text-xs leading-snug {baseColor}"
+>{#each segments as segment}<span class={segment.classes}>{segment.text}</span>{/each}</pre>

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -52,6 +52,7 @@
   import Markdown from '$lib/components/Markdown.svelte'
   import JsonHighlight from '$lib/components/JsonHighlight.svelte'
   import DiffView from '$lib/components/DiffView.svelte'
+  import AnsiLog from '$lib/components/AnsiLog.svelte'
   import { editDiff } from '$lib/diff'
 
   const taskId = $page.params.id ?? ''
@@ -484,7 +485,24 @@
     if (event.type === 'rate_limit') {
       return describeRateLimit(payload)
     }
+    if (event.type === 'ci') {
+      return String(payload?.text ?? '')
+    }
     return JSON.stringify(event.payload)
+  }
+
+  // CI events carry their own pass/fail/running status, so their dot color is
+  // driven by that rather than the generic per-type table.
+  function ciColor(payload: Record<string, unknown>): string {
+    switch (payload?.status) {
+      case 'step_failed':
+        return 'text-destructive'
+      case 'step_passed':
+      case 'job_passed':
+        return 'text-success'
+      default:
+        return 'text-info'
+    }
   }
 
   onMount(() => {
@@ -827,6 +845,25 @@
                       >{describe(event)}</span>
                     </span>
                   </button>
+                {:else if event.type === 'ci'}
+                  <!-- A GitHub Actions step: a colored dot (green pass / red
+                       fail / info running) + the step line, with a failed
+                       step's log tail rendered below honoring ANSI color. -->
+                  {@const ciPayload = event.payload as Record<string, unknown>}
+                  <div class="py-0.5">
+                    <div class="flex items-start gap-2">
+                      <span class="w-[1ch] flex-none {ciColor(ciPayload)}">●</span>
+                      <span class="min-w-0 flex-1 whitespace-pre-wrap break-words {ciColor(ciPayload)}"
+                        >{describe(event)}</span
+                      >
+                    </div>
+                    {#if typeof ciPayload.log === 'string' && ciPayload.log}
+                      <div class="flex gap-2 pl-[1ch]">
+                        <span class="w-[1ch] flex-none text-muted-foreground">⎿</span>
+                        <div class="min-w-0 flex-1"><AnsiLog text={ciPayload.log} isError /></div>
+                      </div>
+                    {/if}
+                  </div>
                 {:else if collapsible}
                   <button
                     type="button"

--- a/frontend/src/routes/watch/+page.svelte
+++ b/frontend/src/routes/watch/+page.svelte
@@ -28,6 +28,9 @@
     type: string
     text: string
     at: number
+    // For CI events, the step status ('step_passed' | 'step_failed' | ...) so the
+    // glyph can be colored green/red rather than the type's single color.
+    status?: string
   }
   let feed = $state<FeedEntry[]>([])
   let feedSeq = 0
@@ -107,7 +110,20 @@
     assistant_text: { glyph: '▸', color: 'text-foreground' },
     tool_use: { glyph: '⚙', color: 'text-primary' },
     result: { glyph: '✓', color: 'text-success' },
-    rate_limit: { glyph: '◷', color: 'text-info' }
+    rate_limit: { glyph: '◷', color: 'text-info' },
+    ci: { glyph: '●', color: 'text-info' }
+  }
+
+  // CI glyph color follows the step status (green pass / red fail / info running),
+  // since one CI type covers all three outcomes.
+  function ciGlyphColor(status: string | undefined): string {
+    if (status === 'step_failed') {
+      return 'text-destructive'
+    }
+    if (status === 'step_passed' || status === 'job_passed') {
+      return 'text-success'
+    }
+    return 'text-info'
   }
 
   function firstLine(text: unknown, max = 120): string {
@@ -142,6 +158,8 @@
         return 'turn complete'
       case 'rate_limit':
         return 'rate-limit notice'
+      case 'ci':
+        return firstLine(payload?.text)
       default:
         return null
     }
@@ -150,7 +168,8 @@
   async function pushFeed(taskId: string, type: string, payload: Record<string, unknown>, at: number) {
     const text = summarize(type, payload)
     if (!text) return
-    const entry: FeedEntry = { id: feedSeq++, taskId, type, text, at }
+    const status = type === 'ci' ? String(payload?.status ?? '') : undefined
+    const entry: FeedEntry = { id: feedSeq++, taskId, type, text, at, status }
     feed = [...feed, entry].slice(-MAX_FEED)
     // Keep the newest line in view (terminal-style autoscroll).
     await tick()
@@ -363,6 +382,7 @@
         {/if}
         {#each feed as entry (entry.id)}
           {@const meta = GLYPHS[entry.type] ?? { glyph: '·', color: 'text-muted-foreground' }}
+          {@const glyphColor = entry.type === 'ci' ? ciGlyphColor(entry.status) : meta.color}
           {@const hue = taskHue(entry.taskId)}
           <div class="flex items-center gap-3 py-0.5" in:fly={{ y: 8, duration: 250, easing: cubicOut }}>
             <span class="w-[4.5rem] shrink-0 text-xs tabular-nums text-muted-foreground/60">
@@ -375,7 +395,7 @@
             >
               {taskLabel(entry.taskId)}
             </span>
-            <span class="w-[1ch] shrink-0 text-center {meta.color}">{meta.glyph}</span>
+            <span class="w-[1ch] shrink-0 text-center {glyphColor}">{meta.glyph}</span>
             <span class="min-w-0 flex-1 truncate text-foreground/90">{entry.text}</span>
           </div>
         {/each}


### PR DESCRIPTION
Closes #185.

A background CI watcher mirrors each watched PR's GitHub Actions progress into the task's activity log, so the operator sees CI's per-step progress alongside the agent's own events. It shows up in **both** the per-task view and the global watch view, and (per the issue) the watcher only follows the PRs the board is actually tracking, not all of GitHub Actions.

### Behavior (matches the issue)
- A step **starts** -> a live `CI: Running <step>...` line (streamed only, **not** persisted, so the saved history isn't cluttered with transient running lines).
- A step **succeeds** -> persisted, green: `CI: <step> complete`.
- A step **fails** -> persisted, red: `CI: <step> failed`, with the **tail of the job log** rendered beneath it.
- A whole job **succeeds** -> persisted, green: `CI: All <job> passed`.
- **Colors:** the log snippet honors any ANSI color the CI log carries; when the log has no color of its own and the step failed, the whole snippet falls back to red.

### Backend
- `git/mod.rs`: `list_runs_for_sha` + `list_run_jobs` (a run's jobs and their steps) and `fetch_job_log_tail` (via `reqwest`, since the logs endpoint 302s to a plain-text blob; strips GitHub's per-line ISO timestamp and leaves ANSI intact). Unit-tested timestamp stripper.
- `orchestrator/ci_watch.rs`: a new 12s loop over open PRs that diffs each step against what it has already emitted and fires the events above. Step keys are deduped in memory and **seeded from the database** on first sight per task, so a process restart never re-writes a line it already recorded.
- `queries`: `list_open_task_prs`, `get_or_create_ci_turn` (a synthetic turn that carries CI events so they flow through the existing activity-log query and SSE stream with no schema change), `next_event_seq`.

### Frontend
- Task view (`task/[id]`): renders the new `ci` event with a status-colored dot (green pass / red fail / info running); a failed step shows the job log tail below via a new `AnsiLog`.
- Watch view (`watch`): a `ci` glyph + one-line summary, colored by step status.
- `lib/ansi.ts` + `lib/components/AnsiLog.svelte`: a small, dependency-free SGR parser (in the same hand-rolled spirit as `json-highlight.ts`) that turns ANSI color into styled spans.

### Notes / scope
- No new dependencies (reuses the existing `reqwest`); `yarn.lock` unchanged.
- The CI events are persisted under a synthetic `[CI activity]` turn so they survive reload without a migration; a fresh CI turn opens after any later agent turn so events stay chronological.
- Validated locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test` (97 pass), and `yarn check` + `yarn build` all green.

Single repo, single PR.