### PR TITLE
Always re-up the target branch before starting a task (#187)

### DIFF
--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -44,7 +44,9 @@ pub fn build(
          - If this issue needs changes in more than one repo, make them in each affected sibling \
          repo on a branch with the SAME name `{branch}`, and open a pull request in each. Seraphim \
          tracks every PR you open on `{branch}`: the task is not done until all of them pass CI and \
-         merge, so do not leave a needed repo without its PR.\n\
+         merge, so do not leave a needed repo without its PR. In each such repo, branch from the \
+         up-to-date target first (`git fetch origin`, then cut `{branch}` from the latest default \
+         branch) so your PR opens on top of the current target and avoids needless merge conflicts.\n\
          - After the PR(s) are open, stop. Do not poll, watch, or wait for CI to finish: Seraphim \
          watches every PR's checks for you and automatically brings you back to fix anything that \
          fails, so a long `gh pr checks` wait only blocks the queue behind you.\n\

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -229,16 +229,27 @@ pub async fn prepare_branch(
     script.push_str(&repo_block(repo, false));
     script.push_str(&format!("cd \"{dir}\"\n", dir = dir));
     script.push_str(reset_tree_snippet());
-    script.push_str(&format!(
-        "git checkout \"{default}\"\n\
-         git pull --ff-only origin \"{default}\" || true\n\
-         git checkout -B \"{branch}\" \"origin/{default}\"\n\
-         git submodule update --init --recursive || true\n",
-        default = repo.default_branch,
-        branch = branch,
-    ));
+    script.push_str(&branch_prep_snippet(&repo.default_branch, branch));
 
     run(state, &script).await
+}
+
+/// Bash that re-ups the target branch, then cuts a fresh work branch from it.
+///
+/// Always fetches `default` from origin so the work branch starts from the
+/// latest target rather than whatever the clone last saw, then branches from
+/// the freshly-fetched `origin/{default}`. The fetch runs under the caller's
+/// `set -e`: an unreachable origin fails preparation loudly instead of silently
+/// building on a stale base, which would otherwise leave this PR (and every one
+/// cut after it) with avoidable merge conflicts once another PR lands on the
+/// target in parallel (issue #187). Mirrors the hard fetch in
+/// [`prepare_existing_branch`].
+fn branch_prep_snippet(default: &str, branch: &str) -> String {
+    format!(
+        "git fetch origin \"{default}\"\n\
+         git checkout -B \"{branch}\" \"origin/{default}\"\n\
+         git submodule update --init --recursive || true\n"
+    )
 }
 
 /// Per-task prep for a CI fix: ensure the repo and AGENTS.md, then check out the
@@ -339,4 +350,30 @@ async fn run(state: &AppState, script: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::branch_prep_snippet;
+
+    #[test]
+    fn branch_prep_fetches_the_target_then_cuts_from_its_fresh_tip() {
+        let script = branch_prep_snippet("develop", "seraphim/issue-187-foo");
+
+        // Re-up the target branch before any work begins (issue #187).
+        assert!(script.contains("git fetch origin \"develop\""));
+        // Cut the work branch from the freshly-fetched remote tip, not a local
+        // branch that may be behind.
+        assert!(script.contains("git checkout -B \"seraphim/issue-187-foo\" \"origin/develop\""));
+    }
+
+    #[test]
+    fn branch_prep_does_not_swallow_a_failed_fetch() {
+        // The old `git pull --ff-only ... || true` masked an unreachable origin
+        // and let a stale base through. The fetch must run bare so prep fails
+        // loudly instead.
+        let script = branch_prep_snippet("main", "branch");
+        assert!(!script.contains("pull"));
+        assert!(!script.contains("git fetch origin \"main\" || true"));
+    }
 }


### PR DESCRIPTION
Closes #187.

When tasks run back to back and other PRs merge in parallel, a fresh task must branch from the **latest** target, or its PR opens behind the base and conflicts. As the issue notes, once that happens the conflicts cascade to nearly every later PR.

### The gap
The fresh-task prep (`provision::prepare_branch`) did branch from `origin/<default>`, but it got there via:

```
git checkout "<default>"
git pull --ff-only origin "<default>" || true
git checkout -B "<branch>" "origin/<default>"
```

The `|| true` silently swallows a failed fetch, so a transient network/auth blip would leave the work branch cut from a **stale** `origin/<default>` with no signal, exactly the "starts behind the base" situation that produces the cascading conflicts.

### The fix
- **`prepare_branch` now re-ups the target deterministically:** a bare `git fetch origin "<default>"` (run under the script's `set -e`, so an unreachable origin fails preparation **loudly** instead of building on a stale base), then `git checkout -B "<branch>" "origin/<default>"`. This is the API mechanism the issue asked for. Extracted into the pure, unit-tested `branch_prep_snippet`, and consistent with the hard `git fetch` already used by `prepare_existing_branch`.
- **Prompt guardrail for multi-repo tasks:** the focus repo is prepared deterministically, but additional repos are the agent's to branch. The working agreement now tells the agent to `git fetch origin` and cut the branch from the up-to-date default in each such repo, so multi-repo PRs also start on top of the current target.

### Notes
- Resumed tasks (a parked question that was answered) intentionally keep their existing branch and are not re-cut, so the agent's earlier work isn't discarded; a base that has moved under a long-lived PR is handled by the existing merge-conflict flow.
- Tests: new `branch_prep_snippet` unit tests assert it fetches the target and cuts from the fresh remote tip, and never falls back to the stale-base-masking `pull --ff-only ... || true`. `cargo fmt --check`, `cargo clippy`, and `cargo test` (96 pass) all green. Backend-only change; no migrations, no new deps.

Single repo, single PR.