### PR TITLE
Keep rate-limit usage notices out of the activity log (#182)

### DIFF
--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1859,9 +1859,12 @@ pub async fn list_events_for_task(
     pool: &PgPool,
     task_id: Uuid,
 ) -> sqlx::Result<Vec<super::models::Event>> {
+    // `rate_limit` events are persisted only to feed the usage gauge's fallback
+    // (`latest_rate_limit`); they are not activity, so they are omitted from the
+    // activity log the task view renders (issue #182).
     sqlx::query_as::<_, super::models::Event>(
         "SELECT e.* FROM events e JOIN turns t ON e.turn_id = t.id \
-         WHERE t.task_id = $1 ORDER BY t.idx, e.seq",
+         WHERE t.task_id = $1 AND e.type <> 'rate_limit' ORDER BY t.idx, e.seq",
     )
     .bind(task_id)
     .fetch_all(pool)

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1409,10 +1409,17 @@ async fn stream_turn(
         let mut payload = event.raw.clone();
         scrubber.scrub_value(&mut payload);
         queries::append_event(&state.db, turn.id, seq, label, payload.clone()).await?;
-        state.notify_task(
-            task.id,
-            serde_json::json!({ "type": label, "payload": payload, "created_at": Utc::now() }),
-        );
+        // Rate-limit notices are a stats-only signal: they feed the usage gauge's
+        // fallback via `latest_rate_limit`, but they carry no actionable detail, so
+        // they are deliberately kept out of the live activity stream (and out of
+        // `list_events_for_task`) rather than cluttering the activity log and the
+        // watch feed (issue #182). They are still persisted for the gauge.
+        if label != "rate_limit" {
+            state.notify_task(
+                task.id,
+                serde_json::json!({ "type": label, "payload": payload, "created_at": Utc::now() }),
+            );
+        }
         queries::set_task_status(&state.db, task.id, TaskStatus::Working)
             .await
             .ok();


### PR DESCRIPTION
Closes #182.

The periodic `Rate limit · 5-hour limit: allowed, resets 7:20 PM (in 4h 2m)` notices carry no actionable detail (no remaining amount), and the user asked to just silently drop them from the activity log.

These come from Claude's `rate_limit_event` stream lines, classified as a `rate_limit` activity event. They have one genuinely useful job: feeding the usage gauge's fallback (`latest_rate_limit`) when no subscription-usage poll is configured. So rather than delete them, this treats `rate_limit` as a **stats-only signal** instead of activity:

- **`stream_turn`** still `append_event`s the `rate_limit` row (so `latest_rate_limit` / the gauge fallback keep working) but no longer calls `notify_task` for it, so it never appears live in the task view or the global watch feed.
- **`list_events_for_task`** now omits `rate_limit` rows, so they don't render in the task's activity history on load either.

The subscription usage-pause logic and the stats gauge are untouched: both read the event independently of the activity-log path (the pause logic earlier in `stream_turn`, the gauge via `latest_rate_limit`, which queries the `events` table directly).

Backend-only; no schema changes, no migrations, no new dependencies. The frontend's `rate_limit` rendering is left in place as a harmless fallback (it is simply never delivered anymore).

### Validation
`cargo fmt --check`, `cargo clippy --all-targets --all-features`, and `cargo test` (94 pass) all green.

Single repo, single PR.