### PR TITLE
Collapse all-additions Write diffs in the activity log by default (#183)

### DIFF
--- a/frontend/src/lib/components/DiffView.svelte
+++ b/frontend/src/lib/components/DiffView.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import type { DiffLine, DiffLineKind } from '$lib/diff'
 
-  let { lines, added, removed }: { lines: DiffLine[]; added: number; removed: number } = $props()
+  // `collapsed` hides the patch rows but keeps the one-line summary, so a caller
+  // can offer an expand/collapse affordance for big, all-additions writes.
+  let {
+    lines,
+    added,
+    removed,
+    collapsed = false
+  }: { lines: DiffLine[]; added: number; removed: number; collapsed?: boolean } = $props()
 
   // A long Write would otherwise flood the log; show a generous window and note
   // the remainder rather than rendering hundreds of rows.
@@ -34,7 +41,7 @@
     Added {plural(added, 'line')}, removed {plural(removed, 'line')}
   </div>
 
-  {#if shown.length}
+  {#if shown.length && !collapsed}
     <div class="mt-1 overflow-hidden rounded-md border border-border text-xs">
       {#each shown as line}
         <div class="flex {ROW_CLASS[line.kind]}">

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -800,12 +800,35 @@
                     ? editDiff(event.payload as Record<string, unknown>)
                     : null}
                 {#if diff}
-                  <!-- Write/Edit calls render as a red/green patch, not a bare summary line. -->
+                  <!-- Write/Edit calls render as a red/green patch. An all-additions
+                       write (no removals) is collapsed by default so a big new file
+                       doesn't flood the log; click the header to expand it. Edits that
+                       remove lines stay expanded so the change is always visible. -->
+                  {@const writeOnly = diff.removed === 0}
                   <div class="flex items-start gap-2 py-0.5">
                     <span class="w-[1ch] flex-none text-primary">●</span>
                     <div class="min-w-0 flex-1">
-                      <div class="truncate text-primary">{diff.verb}({diff.path})</div>
-                      <DiffView lines={diff.lines} added={diff.added} removed={diff.removed} />
+                      {#if writeOnly}
+                        <button
+                          type="button"
+                          onclick={() => toggle(index)}
+                          title={open ? 'Click to collapse' : 'Click to expand'}
+                          class="flex w-full items-center gap-1 text-left text-primary hover:opacity-80"
+                        >
+                          <ChevronDown
+                            class="size-3.5 flex-none transition-transform {open ? '' : '-rotate-90'}"
+                          />
+                          <span class="truncate">{diff.verb}({diff.path})</span>
+                        </button>
+                      {:else}
+                        <div class="truncate text-primary">{diff.verb}({diff.path})</div>
+                      {/if}
+                      <DiffView
+                        lines={diff.lines}
+                        added={diff.added}
+                        removed={diff.removed}
+                        collapsed={writeOnly && !open}
+                      />
                     </div>
                   </div>
                 {:else if event.type === 'prompt'}


### PR DESCRIPTION
Closes #183.

When the agent writes a file with only additions (no removals), the activity log dumps the entire new file. This makes that case expand/collapse, **collapsed by default**.

### Changes (frontend-only)
- **`DiffView.svelte`**: adds a `collapsed` prop. When set, it still shows the one-line `Added N lines, removed M lines` summary but hides the patch rows.
- **Task activity log** (`routes/task/[id]/+page.svelte`): an all-additions diff (`removed === 0`) now renders its `verb(path)` header as a clickable toggle (a chevron that rotates) and is collapsed by default, reusing the existing per-event `expanded[index]` / `toggle(index)` machinery. Clicking expands the rows.

Edits that **remove** lines are left expanded (always visible), since the issue only asked to collapse the all-write case.

### Validation
`yarn check` (0 errors) and `yarn build` both green. No API/schema changes, no new dependencies.

Single repo, single PR.