### PR TITLE
Watch page tweaks (#173)

### DIFF
--- a/frontend/src/lib/components/Stats.svelte
+++ b/frontend/src/lib/components/Stats.svelte
@@ -99,6 +99,23 @@
     return `${seconds}s`
   }
 
+  // Like `duration`, but always carries down to whole seconds so the headline
+  // Time stat visibly ticks up second-by-second while the agent works, instead
+  // of freezing at "3h 12m" for a minute at a time (issue #173).
+  function durationPrecise(ms: number): string {
+    const total = Math.max(0, Math.floor(ms / 1000))
+    const days = Math.floor(total / 86400)
+    const hours = Math.floor((total % 86400) / 3600)
+    const minutes = Math.floor((total % 3600) / 60)
+    const seconds = total % 60
+    const parts: string[] = []
+    if (days > 0) parts.push(`${days}d`)
+    if (days > 0 || hours > 0) parts.push(`${hours}h`)
+    if (days > 0 || hours > 0 || minutes > 0) parts.push(`${minutes}m`)
+    parts.push(`${seconds}s`)
+    return parts.join(' ')
+  }
+
   function resetsLabel(unix: number | null): string {
     if (!unix) return ''
     const date = new Date(unix * 1000)
@@ -198,7 +215,7 @@
 
       <!-- Time -->
       <div class="flex flex-col items-center">
-        <span class="text-xl font-semibold tabular-nums">{duration(workedMs)}</span>
+        <span class="text-xl font-semibold tabular-nums">{durationPrecise(workedMs)}</span>
         <span class="text-xs text-muted-foreground">{taskId ? 'Time on task' : 'Lifetime'}</span>
       </div>
 

--- a/frontend/src/lib/rateLimit.ts
+++ b/frontend/src/lib/rateLimit.ts
@@ -1,0 +1,53 @@
+// Human-readable summary of a Claude `rate_limit_event` payload, shared by the
+// task activity log and the watch feed so both describe the subscription usage
+// limit the same way and never dump raw JSON.
+
+// Human labels for the rate-limit window and status codes Claude emits.
+const RATE_LIMIT_WINDOWS: Record<string, string> = {
+  five_hour: '5-hour limit',
+  weekly: 'weekly limit'
+}
+const RATE_LIMIT_STATUSES: Record<string, string> = {
+  allowed: 'allowed',
+  allowed_warning: 'approaching limit',
+  rejected: 'limit reached'
+}
+
+function humanize(value: string): string {
+  return value.replace(/_/g, ' ')
+}
+
+// A reset moment as "3:40 PM (in 2h 14m)", or just the clock time once it's past.
+function formatReset(unixSeconds: number): string {
+  const date = new Date(unixSeconds * 1000)
+  const time = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  const diffMinutes = Math.round((date.getTime() - Date.now()) / 60000)
+  if (diffMinutes <= 0) {
+    return time
+  }
+  const relative =
+    diffMinutes < 60 ? `${diffMinutes}m` : `${Math.floor(diffMinutes / 60)}h ${diffMinutes % 60}m`
+  return `${time} (in ${relative})`
+}
+
+// Turns a rate_limit_event payload into one clean line instead of raw JSON.
+export function describeRateLimit(payload: Record<string, unknown>): string {
+  const info = payload?.rate_limit_info as Record<string, unknown> | undefined
+  if (!info) {
+    return 'Rate limit update'
+  }
+  const window = RATE_LIMIT_WINDOWS[String(info.rateLimitType)] ?? humanize(String(info.rateLimitType ?? 'usage'))
+  const status = RATE_LIMIT_STATUSES[String(info.status)] ?? humanize(String(info.status ?? ''))
+  let line = `Rate limit · ${window}: ${status}`
+  if (typeof info.resetsAt === 'number') {
+    line += `, resets ${formatReset(info.resetsAt)}`
+  }
+  if (info.isUsingOverage) {
+    const overage = RATE_LIMIT_STATUSES[String(info.overageStatus)] ?? humanize(String(info.overageStatus ?? ''))
+    line += ` · overage ${overage}`
+    if (typeof info.overageResetsAt === 'number') {
+      line += `, resets ${formatReset(info.overageResetsAt)}`
+    }
+  }
+  return line
+}

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -53,6 +53,7 @@
   import JsonHighlight from '$lib/components/JsonHighlight.svelte'
   import DiffView from '$lib/components/DiffView.svelte'
   import { editDiff } from '$lib/diff'
+  import { describeRateLimit } from '$lib/rateLimit'
 
   const taskId = $page.params.id ?? ''
 
@@ -374,56 +375,6 @@
         ? 'Marked blocking — the agent starts nothing new while this is in progress'
         : 'No longer blocking'
     )
-  }
-
-  // Human labels for the rate-limit window and status codes Claude emits.
-  const RATE_LIMIT_WINDOWS: Record<string, string> = {
-    five_hour: '5-hour limit',
-    weekly: 'weekly limit'
-  }
-  const RATE_LIMIT_STATUSES: Record<string, string> = {
-    allowed: 'allowed',
-    allowed_warning: 'approaching limit',
-    rejected: 'limit reached'
-  }
-
-  function humanize(value: string): string {
-    return value.replace(/_/g, ' ')
-  }
-
-  // A reset moment as "3:40 PM (in 2h 14m)", or just the clock time once it's past.
-  function formatReset(unixSeconds: number): string {
-    const date = new Date(unixSeconds * 1000)
-    const time = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-    const diffMinutes = Math.round((date.getTime() - Date.now()) / 60000)
-    if (diffMinutes <= 0) {
-      return time
-    }
-    const relative =
-      diffMinutes < 60 ? `${diffMinutes}m` : `${Math.floor(diffMinutes / 60)}h ${diffMinutes % 60}m`
-    return `${time} (in ${relative})`
-  }
-
-  // Turns a rate_limit_event payload into one clean line instead of raw JSON.
-  function describeRateLimit(payload: Record<string, unknown>): string {
-    const info = payload?.rate_limit_info as Record<string, unknown> | undefined
-    if (!info) {
-      return 'Rate limit update'
-    }
-    const window = RATE_LIMIT_WINDOWS[String(info.rateLimitType)] ?? humanize(String(info.rateLimitType ?? 'usage'))
-    const status = RATE_LIMIT_STATUSES[String(info.status)] ?? humanize(String(info.status ?? ''))
-    let line = `Rate limit · ${window}: ${status}`
-    if (typeof info.resetsAt === 'number') {
-      line += `, resets ${formatReset(info.resetsAt)}`
-    }
-    if (info.isUsingOverage) {
-      const overage = RATE_LIMIT_STATUSES[String(info.overageStatus)] ?? humanize(String(info.overageStatus ?? ''))
-      line += ` · overage ${overage}`
-      if (typeof info.overageResetsAt === 'number') {
-        line += `, resets ${formatReset(info.overageResetsAt)}`
-      }
-    }
-    return line
   }
 
   // The most telling argument of a tool call, so `Bash(cargo build)` reads at a

--- a/frontend/src/routes/watch/+page.svelte
+++ b/frontend/src/routes/watch/+page.svelte
@@ -13,6 +13,7 @@
   import { getBoard } from '$lib/api'
   import { STATUS_LABELS } from '$lib/types'
   import { isWithinSchedule } from '$lib/schedule'
+  import { describeRateLimit } from '$lib/rateLimit'
   import Stats from '$lib/components/Stats.svelte'
 
   let board = $state<BoardResponse | null>(null)
@@ -37,11 +38,13 @@
   const tasks = $derived(board?.tasks ?? [])
   const titleById = $derived(new Map(tasks.map((task) => [task.id, task.title])))
 
-  // Remaining = everything still in the pipeline (backlog through review);
-  // completed = the Done lane. Ignored tasks count as neither.
+  // Remaining = work the operator has actually committed to (queued through
+  // review); completed = the Done lane. "Available" tasks are merely suggestions
+  // the operator hasn't picked up yet, so they count toward neither the big
+  // number nor the progress bar. Ignored tasks count as neither too.
   const remainingCount = $derived(
     tasks.filter((task) =>
-      ['available', 'todo', 'in_progress', 'in_review'].includes(task.board_column)
+      ['todo', 'in_progress', 'in_review'].includes(task.board_column)
     ).length
   )
   const completedCount = $derived(tasks.filter((task) => task.board_column === 'done').length)
@@ -68,34 +71,89 @@
     ) ?? null
   )
 
+  // A task is "waiting" when the agent has stopped to ask for input or is blocked
+  // on CI, and "heart attack" when a task has crashed and not yet been
+  // acknowledged. Both pull the whole page into an attention-grabbing state.
+  const hasWaiting = $derived(
+    tasks.some((task) => task.status === 'waiting_for_input' || task.status === 'ci_blocked')
+  )
+  const hasHeartAttack = $derived((board?.heart_attacks?.length ?? 0) > 0)
+
   // Overall agent state, mirroring the navbar's logic, used to theme the page.
-  type StateKey = 'working' | 'paused' | 'halted' | 'cooldown' | 'offhours' | 'idle'
+  type StateKey =
+    | 'working'
+    | 'paused'
+    | 'halted'
+    | 'heart_attack'
+    | 'cooldown'
+    | 'waiting'
+    | 'offhours'
+    | 'idle'
   const agentState = $derived.by<{ key: StateKey; label: string }>(() => {
     const settings = board?.settings
     if (!settings) return { key: 'idle', label: 'Connecting' }
     if (settings.agent_paused) return { key: 'paused', label: 'Paused' }
     if (settings.config_repo_url && settings.config_repo_error)
       return { key: 'halted', label: 'Halted' }
+    if (hasHeartAttack) return { key: 'heart_attack', label: 'Heart attack' }
     if (settings.cooldown_until && new Date(settings.cooldown_until) > new Date(now))
       return { key: 'cooldown', label: 'Cooling down' }
+    if (hasWaiting) return { key: 'waiting', label: 'Waiting for input' }
     if (current) return { key: 'working', label: 'Working' }
     if (settings.availability_enabled && !isWithinSchedule(settings, new Date(now)))
       return { key: 'offhours', label: 'Off hours' }
     return { key: 'idle', label: 'Idle' }
   })
 
-  // Accent color per state: green when working, amber/red when stopped, calm blue
-  // when idle. Drives the ring, the aura, and the status glow.
-  const ACCENTS: Record<StateKey, string> = {
-    working: '#3fb950',
-    paused: '#d29922',
-    halted: '#f85149',
-    cooldown: '#d29922',
-    offhours: '#8b97a6',
-    idle: '#6e8bff'
+  // Each state maps to an accent color and a "liveliness": how fast the ring and
+  // progress bar animate. Working is full-speed green; waiting/cooling is a
+  // half-speed amber warning; paused, halted, or a heart attack is a frozen red
+  // alert; nothing-to-do (idle/off-hours) is a still, grey "halted" look.
+  type Spin = 'full' | 'half' | 'none'
+  const STATE_STYLES: Record<StateKey, { accent: string; spin: Spin }> = {
+    working: { accent: '#3fb950', spin: 'full' },
+    paused: { accent: '#f85149', spin: 'none' },
+    halted: { accent: '#f85149', spin: 'none' },
+    heart_attack: { accent: '#f85149', spin: 'none' },
+    cooldown: { accent: '#d29922', spin: 'half' },
+    waiting: { accent: '#d29922', spin: 'half' },
+    offhours: { accent: '#8b97a6', spin: 'none' },
+    idle: { accent: '#8b97a6', spin: 'none' }
   }
-  const accent = $derived(ACCENTS[agentState.key])
+  const accent = $derived(STATE_STYLES[agentState.key].accent)
+  const spin = $derived(STATE_STYLES[agentState.key].spin)
   const isWorking = $derived(agentState.key === 'working')
+
+  // Animation class for the rotating ring, scaled to the current liveliness.
+  const ringSpinClass = $derived(
+    spin === 'full' ? 'animate-spin-slow' : spin === 'half' ? 'animate-spin-half' : ''
+  )
+  // The progress bar shares the same liveliness via a flowing sheen.
+  const barFlowClass = $derived(
+    spin === 'full' ? 'bar-flow' : spin === 'half' ? 'bar-flow bar-flow-half' : ''
+  )
+
+  // The standby glyph and message shown in the ring when no task is in flight.
+  const STANDBY_GLYPH: Record<StateKey, string> = {
+    working: '✦',
+    paused: '⏸',
+    halted: '✕',
+    heart_attack: '✕',
+    cooldown: '◷',
+    waiting: '?',
+    offhours: '☾',
+    idle: '✦'
+  }
+  const STANDBY_MESSAGE: Record<StateKey, string> = {
+    working: 'Standing by for the next task.',
+    paused: 'The agent is paused.',
+    halted: 'Needs attention to resume.',
+    heart_attack: 'A task crashed and needs attention.',
+    cooldown: 'Cooling down before the next task.',
+    waiting: 'Waiting on your input to continue.',
+    offhours: 'Outside working hours.',
+    idle: 'Standing by for the next task.'
+  }
 
   // --- Activity feed wiring ---------------------------------------------------
 
@@ -141,7 +199,7 @@
       case 'result':
         return 'turn complete'
       case 'rate_limit':
-        return 'rate-limit notice'
+        return describeRateLimit(payload)
       default:
         return null
     }
@@ -235,9 +293,8 @@
         class="status-pill inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-semibold"
         style="border-color: color-mix(in srgb, var(--accent) 45%, transparent); color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent)"
       >
-        <span class="size-2.5 rounded-full {isWorking ? 'animate-ping-slow' : ''}" style="background: var(--accent)"></span>
+        <span class="size-2.5 rounded-full {spin !== 'none' ? 'animate-ping-slow' : ''}" style="background: var(--accent)"></span>
         {agentState.label}
-        <span class="font-normal text-muted-foreground">· {clockLabel(now)}</span>
       </span>
     </header>
 
@@ -265,12 +322,12 @@
         <div class="relative grid size-[clamp(15rem,26vw,24rem)] place-items-center">
           <!-- pulsing aura behind the ring -->
           <div
-            class="absolute inset-0 rounded-full blur-2xl {isWorking ? 'animate-breathe' : 'opacity-20'}"
+            class="absolute inset-0 rounded-full blur-2xl {spin !== 'none' ? 'animate-breathe' : 'opacity-20'}"
             style="background: radial-gradient(circle, color-mix(in srgb, var(--accent) 55%, transparent), transparent 70%)"
           ></div>
           <!-- rotating gradient ring -->
           <div
-            class="absolute inset-0 rounded-full {isWorking ? 'animate-spin-slow' : ''}"
+            class="absolute inset-0 rounded-full {ringSpinClass}"
             style="background: conic-gradient(from 0deg, transparent 0%, var(--accent) 18%, transparent 38%, color-mix(in srgb, var(--accent) 60%, transparent) 60%, transparent 80%, var(--accent) 100%)"
           ></div>
           <!-- a comet dot orbiting the ring while working -->
@@ -306,15 +363,9 @@
               {/key}
             {:else}
               <div class="flex flex-col items-center gap-2 text-muted-foreground">
-                <span class="text-4xl">{agentState.key === 'paused' ? '⏸' : '✦'}</span>
+                <span class="text-4xl">{STANDBY_GLYPH[agentState.key]}</span>
                 <span class="text-sm font-semibold uppercase tracking-[0.3em]">{agentState.label}</span>
-                <span class="max-w-[12rem] text-xs">
-                  {agentState.key === 'paused'
-                    ? 'The agent is paused.'
-                    : agentState.key === 'halted'
-                      ? 'Needs attention to resume.'
-                      : 'Standing by for the next task.'}
-                </span>
+                <span class="max-w-[12rem] text-xs">{STANDBY_MESSAGE[agentState.key]}</span>
               </div>
             {/if}
           </div>
@@ -342,8 +393,8 @@
       </span>
       <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-white/5">
         <div
-          class="h-full rounded-full transition-[width] duration-700 ease-out"
-          style="width: {completionPct}%; background: linear-gradient(90deg, var(--primary), var(--success)); box-shadow: 0 0 12px color-mix(in srgb, var(--success) 55%, transparent)"
+          class="h-full rounded-full transition-[width] duration-700 ease-out {barFlowClass}"
+          style="width: {completionPct}%; background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 40%, transparent), var(--accent), color-mix(in srgb, var(--accent) 40%, transparent)); background-size: 200% 100%; box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 55%, transparent)"
         ></div>
       </div>
       <span class="w-10 shrink-0 text-xs tabular-nums text-muted-foreground">
@@ -420,6 +471,17 @@
   :global(.watch) .animate-spin-slow {
     animation: spin 5s linear infinite;
   }
+  /* Half-speed spin for the amber "waiting"/"cooling down" warning state. */
+  :global(.watch) .animate-spin-half {
+    animation: spin 10s linear infinite;
+  }
+  /* The progress bar's sheen flows at the same cadence as the ring spins. */
+  :global(.watch) .bar-flow {
+    animation: barflow 2.5s linear infinite;
+  }
+  :global(.watch) .bar-flow-half {
+    animation-duration: 5s;
+  }
   :global(.watch) .animate-breathe {
     animation: breathe 3.5s ease-in-out infinite;
   }
@@ -453,6 +515,11 @@
       transform: rotate(360deg);
     }
   }
+  @keyframes barflow {
+    to {
+      background-position: -200% 0;
+    }
+  }
   @keyframes breathe {
     0%,
     100% {
@@ -477,6 +544,8 @@
   @media (prefers-reduced-motion: reduce) {
     .aura,
     :global(.watch) .animate-spin-slow,
+    :global(.watch) .animate-spin-half,
+    :global(.watch) .bar-flow,
     :global(.watch) .animate-breathe,
     :global(.watch) .animate-ping-slow,
     :global(.watch) .animate-orbit {


### PR DESCRIPTION
Closes #173.

Polishes the kiosk watch page so its visuals track the agent's real state.

## Changes
- **Removed the clock** from the top status pill (redundant noise).
- **Remaining number + progress bar count only committed work** (todo / in progress / in review). "Available" tasks are suggestions the operator hasn't picked up yet, so they no longer inflate the totals or the completion bar.
- **Ring and progress bar are themed by agent state** (color + animation speed):
  - working: full-speed green
  - waiting for input / CI blocked / cooling down: half-speed amber warning
  - paused / halted / heart attack: frozen red alert
  - idle / off-hours: still, grey "halted" look

  Adds detection for waiting/blocked tasks and unacknowledged heart attacks, plus per-state standby glyph and message in the ring.
- **Humanized the rate-limit feed line.** Instead of the vague "rate-limit notice" it now reads e.g. `Rate limit, 5-hour limit: approaching limit, resets 3:40 PM (in 2h 14m)`. The formatter moved into a shared `$lib/rateLimit` module now used by both the task view and the watch feed (no duplicated logic).
- **Seconds in the headline time stat.** The Lifetime / Time-on-task value now carries down to whole seconds so it visibly ticks up while the agent works.

## Validation
- `yarn check`: 0 errors, 0 warnings
- `yarn build`: passes

## Note for the reviewer
There is a small overlap with #182 (PR #193), which hides the rate-limit line from the activity log entirely. This branch does not include #182, so it humanizes that line instead. Whichever merges second wins for that one line; resolve by merge order / preference (hide vs humanize).