### PR TITLE
Stop the agent when its worked card is moved out of In Progress (#172)

### DIFF
--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -10,12 +10,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
-use tracing::warn;
+use tracing::{info, warn};
 
 use super::ApiResult;
-use crate::db::models::{HeartAttack, Settings, SourceKind, Task, TaskColumn};
+use crate::db::models::{HeartAttack, Settings, SourceKind, Task, TaskColumn, TaskStatus};
 use crate::db::queries;
 use crate::git;
+use crate::orchestrator;
 use crate::state::AppState;
 
 #[derive(Debug, Serialize)]
@@ -58,13 +59,44 @@ pub struct MoveRequest {
     pub position: f64,
 }
 
+/// Whether moving a card to `new_column` should stop the agent's in-flight turn.
+///
+/// True only when the card was the live turn (see [`orchestrator::is_active_turn`])
+/// and the operator is moving it to a different lane, e.g. dragging the worked
+/// card back to To Do to re-order the queue (issue #172). A reorder *within* In
+/// Progress leaves the agent alone. Pure, so the rule is unit-tested below.
+fn move_stops_turn(
+    prev_column: TaskColumn,
+    prev_status: TaskStatus,
+    new_column: TaskColumn,
+) -> bool {
+    orchestrator::is_active_turn(prev_column, prev_status) && new_column != prev_column
+}
+
 /// `POST /api/v1/tasks/:id/move` - place a card in a column at a position.
 pub async fn move_task(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
     Json(body): Json<MoveRequest>,
 ) -> ApiResult<Json<Task>> {
+    // Capture the card's state *before* the move: the move itself re-queues it
+    // (resetting status to `queued`), which would erase the signal that it was
+    // the turn the agent is actively running.
+    let was_active_turn = queries::get_task(&state.db, id)
+        .await?
+        .is_some_and(|prev| move_stops_turn(prev.board_column, prev.status, body.column));
+
     let task = queries::move_task(&state.db, id, body.column, body.position).await?;
+
+    // The operator pulled the card the agent was working out from under it (most
+    // often back to To Do to re-order the queue). Stop the current turn at once so
+    // the agent abandons the now-misordered work and re-picks from the board on its
+    // next tick, instead of grinding the stale turn to completion first (issue #172).
+    if was_active_turn {
+        orchestrator::stop_active_turn(&state).await?;
+        info!(task = %task.id, column = ?body.column, "stopped the agent's turn: its card was moved out of In Progress");
+    }
+
     state.notify_board();
 
     // Two-way sync: reflect the move onto a Jira ticket by transitioning its
@@ -210,7 +242,15 @@ pub async fn bulk_status(
 
     for task in &tasks {
         position += 1.0;
+        // `task` still holds the pre-move state, so check before re-queuing it.
+        let interrupt = move_stops_turn(task.board_column, task.status, body.column);
         let moved = queries::move_task(&state.db, task.id, body.column, position).await?;
+        // If the selection swept up the card the agent is actively working, stop
+        // that turn so it pivots instead of finishing misordered work (issue #172).
+        if interrupt {
+            orchestrator::stop_active_turn(&state).await?;
+            info!(task = %moved.id, column = ?body.column, "stopped the agent's turn: its card was bulk-moved out of In Progress");
+        }
         // Reflect the move onto the source ticket (close on Done, reopen
         // otherwise). Best-effort: a service hiccup must not fail the whole move.
         if let Err(error) = sync_ticket_to_column(&state, &moved, body.column).await {
@@ -270,5 +310,64 @@ async fn sync_ticket_to_column(
             queries::set_task_external_state(&state.db, task.id, desired).await?;
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn moving_the_worked_card_to_a_different_lane_stops_the_turn() {
+        // The case from issue #172: the agent is mid-turn (In Progress + working)
+        // and the operator drags the card back to To Do.
+        assert!(move_stops_turn(
+            TaskColumn::InProgress,
+            TaskStatus::Working,
+            TaskColumn::Todo,
+        ));
+        // Preparing counts as a live turn too, and any destination lane qualifies.
+        assert!(move_stops_turn(
+            TaskColumn::InProgress,
+            TaskStatus::Preparing,
+            TaskColumn::Available,
+        ));
+        assert!(move_stops_turn(
+            TaskColumn::InProgress,
+            TaskStatus::Working,
+            TaskColumn::InReview,
+        ));
+    }
+
+    #[test]
+    fn reordering_within_in_progress_leaves_the_turn_running() {
+        // A drop back into the same lane is a no-op reorder, not an interruption.
+        assert!(!move_stops_turn(
+            TaskColumn::InProgress,
+            TaskStatus::Working,
+            TaskColumn::InProgress,
+        ));
+    }
+
+    #[test]
+    fn moving_a_card_that_is_not_the_live_turn_never_stops_the_agent() {
+        // An In Progress card that is only parked awaiting input is not the live
+        // turn, so moving it must not kill whatever the agent is actually doing.
+        assert!(!move_stops_turn(
+            TaskColumn::InProgress,
+            TaskStatus::WaitingForInput,
+            TaskColumn::Todo,
+        ));
+        // A queued To Do card, or one sitting in review, is likewise never the turn.
+        assert!(!move_stops_turn(
+            TaskColumn::Todo,
+            TaskStatus::Queued,
+            TaskColumn::Available,
+        ));
+        assert!(!move_stops_turn(
+            TaskColumn::InReview,
+            TaskStatus::AwaitingReview,
+            TaskColumn::Done,
+        ));
     }
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -552,6 +552,35 @@ pub struct ResetSummary {
     pub issue_reopened: bool,
 }
 
+/// Whether a card is the one the agent is *actively* running a turn on right now.
+///
+/// The agent loop is single-threaded, so at most one task is ever in `InProgress`
+/// with a live (`working`/`preparing`) status, and that task is necessarily the
+/// turn currently streaming. A task parked awaiting input, sitting in review, or
+/// queued is therefore never matched. Pure, so callers deciding whether to
+/// interrupt the agent can be unit-tested.
+pub fn is_active_turn(column: TaskColumn, status: TaskStatus) -> bool {
+    column == TaskColumn::InProgress
+        && matches!(status, TaskStatus::Working | TaskStatus::Preparing)
+}
+
+/// Stops the agent's in-flight turn immediately, abandoning whatever it was doing.
+///
+/// Used both by a per-task reset and when the operator pulls the worked card out
+/// from under the agent (issue #172). It bumps the reset epoch so the dying turn
+/// yields its post-turn handling (it won't move the card or persist its session),
+/// kills the orphaned `claude -p` process, and clears the shared session and live
+/// usage, since a turn killed mid-stream can leave the resumable conversation
+/// inconsistent for the next task. The caller decides *when* to interrupt; the
+/// single-threaded loop guarantees the live turn is unique (see [`is_active_turn`]).
+pub async fn stop_active_turn(state: &AppState) -> Result<()> {
+    state.bump_reset_epoch();
+    kill_agent_process(state).await;
+    queries::set_current_session_id(&state.db, None).await?;
+    state.set_live_usage(None);
+    Ok(())
+}
+
 /// Hard-resets a single stuck task to a clean slate (issue #72): if the agent is
 /// mid-turn on it, that turn is stopped; its pull request is closed, its branch
 /// deleted from the remote and the workspace, a closed source issue is reopened,
@@ -571,17 +600,8 @@ pub async fn reset_task(state: &AppState, task_id: uuid::Uuid) -> Result<ResetSu
     // Stop the agent only if it is *actively* running a turn on THIS task. The
     // loop is single-threaded, so the live turn is unique; a task merely parked
     // awaiting input, or sitting in review, is not it and must not be disturbed.
-    // Interrupting the live turn bumps the reset epoch (so the turn abandons its
-    // post-turn handling rather than re-moving the card), kills the Claude
-    // process, and clears the shared session, since a turn killed mid-stream can
-    // leave the resumable conversation inconsistent for the next task.
-    let actively_working = task.board_column == TaskColumn::InProgress
-        && matches!(task.status, TaskStatus::Working | TaskStatus::Preparing);
-    if actively_working {
-        state.bump_reset_epoch();
-        kill_agent_process(state).await;
-        queries::set_current_session_id(&state.db, None).await?;
-        state.set_live_usage(None);
+    if is_active_turn(task.board_column, task.status) {
+        stop_active_turn(state).await?;
         summary.interrupted_agent = true;
         info!(task_id = %task.id, "stopped the agent's in-flight turn for the reset");
     }


### PR DESCRIPTION
Closes #172.

## Problem
When the agent had already picked up a card and started a turn, dragging that card back to To Do (to re-order the queue) did nothing to the running turn. The agent kept grinding the now-misordered turn to completion (often around 10 minutes, asking confused out-of-order questions) before it re-evaluated the board. The operator expected it to full-stop and pivot.

## Fix
A board move that pulls the actively-worked card into a different lane now stops that turn immediately, so the agent abandons the stale work and re-picks from the re-ordered board on its next idle tick.

The interrupt reuses the exact, already-proven mechanism behind the per-task hard reset (issue #72): bump the reset epoch so the dying turn yields its post-turn handling (it will not move the card or persist its session), kill the orphaned `claude -p` process, and clear the shared session and live usage.

## Changes
- Extracted that interrupt into a reusable `orchestrator::stop_active_turn`, plus a pure `is_active_turn` predicate. `reset_task` now uses both (no behavior change there).
- `POST /tasks/:id/move` and the bulk `POST /tasks/bulk/status` detect the live turn from the card's pre-move state and call `stop_active_turn` when it leaves In Progress.
- Guardrails: a reorder *within* In Progress does not interrupt, and a card that is not the live turn (parked awaiting input, queued, or in review) is never touched. The loop is single-threaded, so the live turn is uniquely the one task in In Progress with a working/preparing status.
- Added unit tests for the pure `move_stops_turn` rule.

## Validation
- `cargo +1.88 fmt`, `cargo +1.88 clippy --all-targets` (no new warnings), `cargo +1.88 test` (97 passed, including 3 new).
- No schema or API-shape changes; the frontend is untouched.