### PR TITLE
Make Postgres 17 and Docker usable in the agent workspace (#186)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,12 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   `current_session_id`; Claude auto-compacts.
 - **Auth:** `CLAUDE_CODE_OAUTH_TOKEN` (subscription) for Claude; mounted host
   `~/.ssh` for `git@` clones; `GH_TOKEN` for HTTPS + octocrab.
+- **Local DB validation:** PostgreSQL 17 (client + server) is baked into the
+  workspace image, and `pg-ephemeral` boots a throwaway PG17 on `127.0.0.1` and
+  prints a `DATABASE_URL` (`export DATABASE_URL="$(pg-ephemeral)"`), so the agent
+  can verify migrations / integration tests against the same major as CI and
+  prod without a daemon. The entrypoint also aligns the agent to the mounted host
+  Docker socket's group, so `docker` / `earthly` work without `sudo` too.
 
 ### The orchestrator loops (`api/src/orchestrator/mod.rs`)
 1. **sync** — polls every repo with `sync_issues` for open issues and upserts

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -19,6 +19,21 @@ RUN apt-get update \
         ca-certificates curl gnupg git jq sudo less ripgrep openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
+# --- PostgreSQL 17 (client + server) for local DB validation -----------------
+# The base image's distro ships an older Postgres than the PG17 the API, CI, and
+# production all run, so a hand-installed cluster would drift onto PG16. Install
+# the matching major from the official PostgreSQL APT repository (PGDG) so the
+# agent can stand up a throwaway PG17 (see the `pg-ephemeral` helper below) and
+# verify migrations and integration tests locally before pushing.
+RUN install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        -o /etc/apt/keyrings/pgdg.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-17 postgresql-client-17 \
+    && rm -rf /var/lib/apt/lists/*
+
 # --- GitHub CLI (release tarball; no dependency on an apt source) ------------
 RUN tag="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/cli/cli/releases/latest | sed -E 's#.*/tag/##')" \
     && ver="${tag#v}" \
@@ -91,6 +106,10 @@ COPY seraphim-comment /usr/local/bin/seraphim-comment
 COPY seraphim-state /usr/local/bin/seraphim-state
 RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
     /usr/local/bin/seraphim-comment /usr/local/bin/seraphim-state
+
+# --- Throwaway PostgreSQL 17 helper (boots a local cluster for DB validation) -
+COPY pg-ephemeral /usr/local/bin/pg-ephemeral
+RUN chmod +x /usr/local/bin/pg-ephemeral
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -33,5 +33,25 @@ if [ -n "${GH_TOKEN:-}" ]; then
   runuser -u "${AGENT_USER}" -- gh auth setup-git >/dev/null 2>&1 || true
 fi
 
+# --- Docker: let the non-root agent use the mounted host socket --------------
+# docker-compose bind-mounts the host's /var/run/docker.sock so the agent can run
+# docker (and Earthly) for the repos it works on, e.g. `docker run postgres:17`.
+# That socket is owned by a group whose GID comes from the host and rarely lines
+# up with a group in this image, so the codespace user otherwise gets "permission
+# denied". Align a group to the socket's GID and add the agent to it; a later
+# `docker exec -u codespace` resolves this membership from /etc/group. We talk to
+# the mounted daemon directly and never start dockerd in here, which cannot bind
+# the bind-mounted socket anyway ("device or resource busy").
+DOCKER_SOCK=/var/run/docker.sock
+if [ -S "${DOCKER_SOCK}" ]; then
+  sock_gid="$(stat -c '%g' "${DOCKER_SOCK}")"
+  group_name="$(getent group "${sock_gid}" | cut -d: -f1 || true)"
+  if [ -z "${group_name}" ]; then
+    group_name=docker-host
+    groupadd -g "${sock_gid}" "${group_name}"
+  fi
+  usermod -aG "${group_name}" "${AGENT_USER}"
+fi
+
 # Hand off to the idle command (tail -f /dev/null).
 exec "$@"

--- a/workspace/pg-ephemeral
+++ b/workspace/pg-ephemeral
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Boot a throwaway local PostgreSQL 17 for DB validation in the workspace (#186).
+#
+# Creates (once) and starts a fresh PG17 cluster under a temp data dir, listening
+# on 127.0.0.1, then prints a ready-to-use connection URL on stdout. It matches
+# the Postgres 17 the API, CI, and production use, so migrations and integration
+# tests can be verified locally before pushing, with no Docker daemon and no
+# sibling-container networking to wrangle.
+#
+# Usage:
+#   pg-ephemeral [start]   start it if needed and print the DATABASE_URL (default)
+#   pg-ephemeral url       print the DATABASE_URL without touching the cluster
+#   pg-ephemeral stop      stop the cluster (keeps the data dir)
+#   pg-ephemeral reset     stop and delete the data dir for a clean slate
+#
+# Typical use:
+#   export DATABASE_URL="$(pg-ephemeral)"
+#   psql "$DATABASE_URL" -f migration.sql
+#
+# PostgreSQL refuses to run as root, so run this as the non-root workspace agent
+# user (codespace); everything lives under a writable temp dir it owns.
+set -euo pipefail
+
+# PGDG installs the server binaries (initdb, pg_ctl, ...) here rather than on the
+# default PATH, so address them explicitly.
+PG_BIN=/usr/lib/postgresql/17/bin
+
+PGDATA="${PG_EPHEMERAL_DATA:-/tmp/seraphim-pg17}"
+PGPORT="${PG_EPHEMERAL_PORT:-5432}"
+PGSUPERUSER=postgres
+PGSUPERPASS=postgres
+PGDATABASE="${PG_EPHEMERAL_DB:-app}"
+LOGFILE="${PGDATA}/postgres.log"
+URL="postgresql://${PGSUPERUSER}:${PGSUPERPASS}@127.0.0.1:${PGPORT}/${PGDATABASE}"
+
+die() {
+  echo "pg-ephemeral: $*" >&2
+  exit 1
+}
+
+[ "$(id -u)" -ne 0 ] || die "refusing to run as root; PostgreSQL must run as a non-root user (e.g. codespace)"
+[ -x "${PG_BIN}/pg_ctl" ] || die "PostgreSQL 17 is not installed at ${PG_BIN}"
+
+is_running() {
+  "${PG_BIN}/pg_ctl" -D "${PGDATA}" status >/dev/null 2>&1
+}
+
+start() {
+  if is_running; then
+    echo "${URL}"
+    return 0
+  fi
+
+  # First run: lay down a fresh cluster owned by the superuser with a known
+  # password (this is a disposable instance, so the password is not a secret).
+  if [ ! -s "${PGDATA}/PG_VERSION" ]; then
+    mkdir -p "${PGDATA}"
+    local pwfile
+    pwfile="$(mktemp)"
+    printf '%s' "${PGSUPERPASS}" > "${pwfile}"
+    "${PG_BIN}/initdb" -D "${PGDATA}" -U "${PGSUPERUSER}" \
+      -A scram-sha-256 --pwfile="${pwfile}" >/dev/null
+    rm -f "${pwfile}"
+  fi
+
+  # Listen only on loopback, and keep the unix socket in a writable temp dir
+  # rather than the default /var/run/postgresql, which the agent user cannot use.
+  "${PG_BIN}/pg_ctl" -D "${PGDATA}" -l "${LOGFILE}" -w \
+    -o "-p ${PGPORT} -c listen_addresses=127.0.0.1 -c unix_socket_directories=/tmp" \
+    start >/dev/null \
+    || { [ -f "${LOGFILE}" ] && cat "${LOGFILE}" >&2; die "failed to start PostgreSQL"; }
+
+  # Create the application database once; ignore the error if it already exists.
+  PGPASSWORD="${PGSUPERPASS}" "${PG_BIN}/createdb" \
+    -h 127.0.0.1 -p "${PGPORT}" -U "${PGSUPERUSER}" "${PGDATABASE}" 2>/dev/null || true
+
+  echo "pg-ephemeral: PostgreSQL 17 ready at ${URL}" >&2
+  echo "${URL}"
+}
+
+case "${1:-start}" in
+  start | "")
+    start
+    ;;
+  url)
+    echo "${URL}"
+    ;;
+  stop)
+    "${PG_BIN}/pg_ctl" -D "${PGDATA}" -m fast stop >/dev/null 2>&1 || true
+    ;;
+  reset)
+    "${PG_BIN}/pg_ctl" -D "${PGDATA}" -m immediate stop >/dev/null 2>&1 || true
+    rm -rf "${PGDATA}"
+    ;;
+  *)
+    die "usage: pg-ephemeral [start|url|stop|reset]"
+    ;;
+esac


### PR DESCRIPTION
Closes #186.

## Problem
DB-touching tasks (migrations, integration tests) could not be verified inside the agent workspace:
- The mounted host Docker socket gave the `codespace` agent **permission denied**, and trying to start a daemon inside failed with `dockerd could not bind /var/run/docker.sock: device or resource busy`, so `docker run postgres:17` was unusable.
- The fallback (`apt-get install postgresql`) landed on **PG16**, not the **PG17** the API, CI, and production use.

## Fix
Two small, complementary changes to the workspace image, each closing a distinct gap the issue describes:

1. **Preinstall PostgreSQL 17 (client + server)** from the official PostgreSQL APT repository (PGDG) in `workspace/Dockerfile`, plus a **`pg-ephemeral`** helper that boots a throwaway PG17 cluster on `127.0.0.1` and prints a connection URL:
   ```bash
   export DATABASE_URL="$(pg-ephemeral)"
   psql "$DATABASE_URL" -f migration.sql
   pg-ephemeral stop   # or: reset
   ```
   This is daemon-free, version-exact with CI/prod, and avoids sibling-container networking. PostgreSQL refuses to run as root, so the helper runs as the non-root agent and keeps everything under a writable temp dir.

2. **Fix the Docker socket permissions** in `workspace/entrypoint.sh`: align a group to the mounted socket's host GID and add `codespace` to it, so `docker` and `earthly` work without `sudo`. A later `docker exec -u codespace` (how the API drives turns) resolves the membership from `/etc/group`. We use the mounted daemon directly and never start `dockerd`, which cannot bind the bind-mounted socket.

Also documented both in `CLAUDE.md` so future agents discover the tooling.

## Validation
- `bash -n` and `shellcheck` are clean on `entrypoint.sh` and `pg-ephemeral`.
- The workspace image build is exercised by the existing "Docker images" CI job (I cannot build the image from inside the current workspace, which is exactly the gap this PR closes).

No backend/frontend code, schema, or API-shape changes.