### PR TITLE
Internal tickets can target multiple repositories (#189)

### DIFF
--- a/api/migrations/0034_task_target_repos.sql
+++ b/api/migrations/0034_task_target_repos.sql
@@ -1,0 +1,15 @@
+-- Internal tickets can target several repositories (issue #189).
+--
+-- `repo_id` stays the primary/focus repo the agent branches in and that gates
+-- auto-pull; `target_repo_ids` is the full ordered set the operator picked. The
+-- agent is told about every target for context but may open a PR in only some of
+-- them. Mirrors the `jira_boards.repo_ids` shape: a JSONB array of repo UUIDs,
+-- first entry == the primary `repo_id`.
+ALTER TABLE tasks
+    ADD COLUMN target_repo_ids JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- Backfill existing tasks that already have a single repo so their target set is
+-- consistent with the new column (one entry: the current primary repo).
+UPDATE tasks
+SET target_repo_ids = jsonb_build_array(repo_id::text)
+WHERE repo_id IS NOT NULL;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -414,6 +414,11 @@ pub struct Task {
     pub source_kind: SourceKind,
     pub external_id: String,
     pub repo_id: Option<Uuid>,
+    /// Every repo an internal ticket targets, in priority order; the first equals
+    /// `repo_id`, the primary/focus repo the agent branches in. The agent is told
+    /// about all of them for context but may open a PR in only some. Empty for
+    /// tracking-only tickets and for GitHub/Jira tasks. See issue #189.
+    pub target_repo_ids: Json<Vec<Uuid>>,
     /// For a Jira task, the followed board it came from, so a column move can map
     /// back to a Jira status and transition the ticket. `None` for GitHub tasks.
     pub jira_board_id: Option<Uuid>,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1317,24 +1317,26 @@ pub async fn set_task_notes(pool: &PgPool, id: Uuid, notes: &str) -> sqlx::Resul
 // --- Internal tickets --------------------------------------------------------
 
 /// Creates an internal ticket (no external tracker). It lands in `Available` at
-/// the given position with a sequential, human-friendly external id. An optional
-/// `repo_id` targets the repo the agent will branch in when the ticket is worked;
-/// leave it `None` to triage the repo later.
+/// the given position with a sequential, human-friendly external id. `repo_ids`
+/// are the repos the ticket targets, in priority order; the first becomes the
+/// primary `repo_id` the agent branches in. Pass an empty slice to triage the
+/// repos later (a tracking-only ticket that is not auto-pulled).
 pub async fn create_internal_task(
     pool: &PgPool,
     title: &str,
     body: &str,
     state: &str,
-    repo_id: Option<Uuid>,
+    repo_ids: &[Uuid],
     initial_position: f64,
 ) -> sqlx::Result<Task> {
     sqlx::query_as::<_, Task>(
         "INSERT INTO tasks \
-           (source_kind, external_id, repo_id, title, body_snapshot, url, external_state, board_column, position) \
-         VALUES ('internal', nextval('internal_ticket_seq')::text, $1, $2, $3, '', $4, 'available', $5) \
+           (source_kind, external_id, repo_id, target_repo_ids, title, body_snapshot, url, external_state, board_column, position) \
+         VALUES ('internal', nextval('internal_ticket_seq')::text, $1, $2, $3, $4, '', $5, 'available', $6) \
          RETURNING *",
     )
-    .bind(repo_id)
+    .bind(repo_ids.first().copied())
+    .bind(Json(repo_ids.to_vec()))
     .bind(title)
     .bind(body)
     .bind(state)
@@ -1343,21 +1345,22 @@ pub async fn create_internal_task(
     .await
 }
 
-/// Points an internal ticket at the repo the agent should branch in, or clears it
-/// with `None`. Restricted to internal tasks: a GitHub task's repo is its issue's
-/// and must not be reassigned. Returns the updated task, or `None` if the id is
-/// not an internal task.
-pub async fn set_internal_task_repo(
+/// Sets the repos an internal ticket targets (priority order; the first becomes
+/// the primary `repo_id`), or clears them with an empty slice. Restricted to
+/// internal tasks: a GitHub task's repo is its issue's and must not be
+/// reassigned. Returns the updated task, or `None` if the id is not internal.
+pub async fn set_internal_task_repos(
     pool: &PgPool,
     id: Uuid,
-    repo_id: Option<Uuid>,
+    repo_ids: &[Uuid],
 ) -> sqlx::Result<Option<Task>> {
     sqlx::query_as::<_, Task>(
-        "UPDATE tasks SET repo_id = $2, updated_at = now() \
+        "UPDATE tasks SET repo_id = $2, target_repo_ids = $3, updated_at = now() \
          WHERE id = $1 AND source_kind = 'internal' RETURNING *",
     )
     .bind(id)
-    .bind(repo_id)
+    .bind(repo_ids.first().copied())
+    .bind(Json(repo_ids.to_vec()))
     .fetch_optional(pool)
     .await
 }

--- a/api/src/http/suggestions.rs
+++ b/api/src/http/suggestions.rs
@@ -132,7 +132,7 @@ pub async fn create_issue(
                 + 1.0;
             // No target repo: a recommendation is tracking-only until the operator
             // assigns a repo (on the task page), keeping its prior behavior.
-            queries::create_internal_task(&state.db, &title, &detail, "open", None, position)
+            queries::create_internal_task(&state.db, &title, &detail, "open", &[], position)
                 .await?;
             None
         }

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -169,9 +169,14 @@ pub struct CreateTaskRequest {
     /// `"open"` (default) or `"closed"`.
     #[serde(default)]
     pub state: Option<String>,
-    /// Optional target repo the agent branches in when the ticket is worked. With
-    /// it set, the ticket is auto-pulled like a GitHub issue; without it the ticket
-    /// is tracking-only until a repo is assigned.
+    /// Target repos the ticket affects, in priority order; the first is the
+    /// primary one the agent branches in (and that makes it auto-pullable). The
+    /// agent is told about all of them but may open a PR in only some. Empty (or
+    /// omitted) leaves the ticket tracking-only until repos are assigned.
+    #[serde(default)]
+    pub repo_ids: Option<Vec<Uuid>>,
+    /// Legacy single-repo field, still accepted: treated as a one-entry
+    /// `repo_ids` when that newer field is absent.
     #[serde(default)]
     pub repo_id: Option<Uuid>,
 }
@@ -199,12 +204,17 @@ pub async fn create(
         .await?
         .unwrap_or(0.0)
         + 1.0;
+    // Prefer the multi-repo field; fall back to the legacy single `repo_id`.
+    let repo_ids = body
+        .repo_ids
+        .clone()
+        .unwrap_or_else(|| body.repo_id.into_iter().collect());
     let task = queries::create_internal_task(
         &state.db,
         title,
         body.body.trim(),
         ticket_state,
-        body.repo_id,
+        &repo_ids,
         position,
     )
     .await?;
@@ -214,19 +224,29 @@ pub async fn create(
 
 #[derive(Debug, Deserialize)]
 pub struct SetTaskRepoRequest {
-    /// The target repo, or `null` to clear it (back to tracking-only).
+    /// The target repos in priority order, or an empty list to clear them (back
+    /// to tracking-only). The first becomes the primary repo the agent branches in.
+    #[serde(default)]
+    pub repo_ids: Option<Vec<Uuid>>,
+    /// Legacy single-repo field, still accepted when `repo_ids` is absent.
+    #[serde(default)]
     pub repo_id: Option<Uuid>,
 }
 
-/// `POST /api/v1/tasks/:id/repo` - point an internal ticket at the repo the agent
-/// should branch in (or clear it). Only valid for internal tickets; a GitHub
-/// task's repo is its issue's and is never reassigned.
+/// `POST /api/v1/tasks/:id/repo` - set the repos an internal ticket targets (or
+/// clear them). Only valid for internal tickets; a GitHub task's repo is its
+/// issue's and is never reassigned.
 pub async fn set_repo(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
     Json(payload): Json<SetTaskRepoRequest>,
 ) -> ApiResult<Response> {
-    match queries::set_internal_task_repo(&state.db, id, payload.repo_id).await? {
+    // Prefer the multi-repo field; fall back to the legacy single `repo_id`.
+    let repo_ids = payload
+        .repo_ids
+        .clone()
+        .unwrap_or_else(|| payload.repo_id.into_iter().collect());
+    match queries::set_internal_task_repos(&state.db, id, &repo_ids).await? {
         Some(task) => {
             state.notify_board();
             Ok(Json(task).into_response())

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -803,6 +803,24 @@ async fn work_task(state: &AppState, task: Task, mode: WorkMode) -> Result<()> {
     }
 }
 
+/// Resolves a ticket's target repos (priority order, the first being the primary)
+/// into `Repository` rows for the prompt, skipping any that have since been
+/// deleted. Best-effort: a lookup error is logged and dropped rather than failing
+/// the turn, since the focus repo is always passed to the prompt separately.
+async fn load_target_repos(state: &AppState, task: &Task) -> Vec<Repository> {
+    let mut repos = Vec::new();
+    for repo_id in &task.target_repo_ids.0 {
+        match queries::get_repository(&state.db, *repo_id).await {
+            Ok(Some(repo)) => repos.push(repo),
+            Ok(None) => {}
+            Err(error) => {
+                warn!(error = %error, repo_id = %repo_id, "failed to load a target repo for the prompt");
+            }
+        }
+    }
+    repos
+}
+
 /// Runs a fresh issue end to end: prepare repo, drive Claude, detect PR.
 async fn work_fresh(state: &AppState, task: Task, resume: bool) -> Result<()> {
     info!(task_id = %task.id, title = %task.title, resume, "working task");
@@ -860,7 +878,8 @@ async fn work_fresh(state: &AppState, task: Task, resume: bool) -> Result<()> {
         prompt
     } else {
         let comments = fetch_issue_comments(state, &repo, &task).await;
-        prompt::build(&settings, &repo, &task, &branch, &comments)
+        let target_repos = load_target_repos(state, &task).await;
+        prompt::build(&settings, &repo, &task, &branch, &comments, &target_repos)
     };
     let outcome = run_agent_turn(state, &settings, &task, prompt).await?;
     persist_session(state, &settings, &outcome).await?;
@@ -2230,6 +2249,7 @@ mod tests {
             source_kind: crate::db::models::SourceKind::Github,
             external_id: String::new(),
             repo_id: None,
+            target_repo_ids: sqlx::types::Json(Vec::new()),
             jira_board_id: None,
             title: String::new(),
             body_snapshot: String::new(),

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -15,12 +15,17 @@ use super::provision::repo_dir_name;
 /// `comments` is the issue's discussion thread (empty when there is none or it
 /// could not be fetched); it is rendered into the brief so the agent works from
 /// the full conversation, not just the title and description.
+/// `target_repos` is the full set of repos the ticket targets (priority order,
+/// the first being `repo`, the focus repo). For a multi-repo ticket they are all
+/// named in the working agreement so the agent has the full context up front,
+/// even though it may end up opening a PR in only some of them.
 pub fn build(
     settings: &Settings,
     repo: &Repository,
     task: &Task,
     branch: &str,
     comments: &[IssueComment],
+    target_repos: &[Repository],
 ) -> String {
     let repo_path = format!("/workspace/{}", repo_dir_name(&repo.full_name));
     let mut prompt = context_header(settings, repo, task, comments);
@@ -55,6 +60,28 @@ pub fn build(
         default = repo.default_branch,
         issue_reference = issue_reference,
     ));
+
+    // When the ticket targets several repos, name them so the agent knows the full
+    // blast radius up front. It branches in the focus repo above; it should change
+    // and open a PR in each repo that actually needs it. Some targets may need no
+    // change, and that is fine: do not force an empty PR.
+    if target_repos.len() > 1 {
+        let names = target_repos
+            .iter()
+            .map(|repo| repo.full_name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        prompt.push_str(&format!(
+            "- This ticket targets multiple repositories: {names}. They are all cloned as \
+             siblings under `/workspace`, and `{focus}` (above) is the primary one. Make the \
+             changes each affected repo needs and open a pull request (same branch name \
+             `{branch}`) in every repo you actually change. A target that needs no change \
+             needs no PR.\n",
+            names = names,
+            focus = repo.full_name,
+            branch = branch,
+        ));
+    }
 
     prompt.push_str(ASKING_FOR_HELP);
     prompt
@@ -521,6 +548,7 @@ mod tests {
             source_kind: SourceKind::Github,
             external_id: "57".to_string(),
             repo_id: None,
+            target_repo_ids: Json(Vec::new()),
             jira_board_id: None,
             title: "Ask the user for help".to_string(),
             body_snapshot: String::new(),
@@ -562,6 +590,7 @@ mod tests {
             &task,
             "seraphim/task-3",
             &[],
+            &[],
         );
 
         // An internal ticket has no upstream issue, so the brief and the PR step
@@ -582,9 +611,48 @@ mod tests {
             &sample_task(),
             "seraphim/issue-57",
             &[],
+            &[],
         );
         assert!(prompt.contains("Work issue #57"));
         assert!(prompt.contains("referencing issue #57"));
+    }
+
+    #[test]
+    fn multi_repo_ticket_names_every_target_repo() {
+        let mut task = sample_task();
+        task.source_kind = SourceKind::Internal;
+
+        let focus = sample_repo();
+        let mut other = sample_repo();
+        other.id = uuid::Uuid::from_u128(1);
+        other.full_name = "navarrotech/yearloom".to_string();
+        let targets = [focus.clone(), other];
+
+        let prompt = build(
+            &sample_settings(),
+            &focus,
+            &task,
+            "seraphim/task-57",
+            &[],
+            &targets,
+        );
+
+        assert!(prompt.contains("This ticket targets multiple repositories"));
+        assert!(prompt.contains("navarrotech/seraphim"));
+        assert!(prompt.contains("navarrotech/yearloom"));
+    }
+
+    #[test]
+    fn single_repo_ticket_omits_the_multi_repo_line() {
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+        );
+        assert!(!prompt.contains("targets multiple repositories"));
     }
 
     #[test]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,22 +59,23 @@ export function getTask(taskId: string) {
   return apiClient.get(`tasks/${taskId}`).json<TaskDetail>()
 }
 
-// Create an internal ticket (no GitHub/Jira backing). Returns the new task. An
-// optional repo_id targets the repo the agent branches in; without it the ticket
-// is tracking-only until a repo is assigned.
+// Create an internal ticket (no GitHub/Jira backing). Returns the new task.
+// `repo_ids` are the repos the ticket targets, in priority order; the first is
+// the primary one the agent branches in. An empty list leaves it tracking-only.
 export function createInternalTask(body: {
   title: string
   body: string
   state: 'open' | 'closed'
-  repo_id?: string | null
+  repo_ids?: string[]
 }) {
   return apiClient.post('tasks', { json: body }).json<Task>()
 }
 
-// Point an internal ticket at the repo the agent should branch in (or clear it
-// with null). Only valid for internal tickets. Returns the updated task.
-export function setTaskRepo(taskId: string, repoId: string | null) {
-  return apiClient.post(`tasks/${taskId}/repo`, { json: { repo_id: repoId } }).json<Task>()
+// Set the repos an internal ticket targets (priority order; the first is the
+// primary one the agent branches in), or clear them with an empty list. Only
+// valid for internal tickets. Returns the updated task.
+export function setTaskRepos(taskId: string, repoIds: string[]) {
+  return apiClient.post(`tasks/${taskId}/repo`, { json: { repo_ids: repoIds } }).json<Task>()
 }
 
 // --- Live statistics ---------------------------------------------------------

--- a/frontend/src/lib/components/RepoMultiSelect.svelte
+++ b/frontend/src/lib/components/RepoMultiSelect.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import type { Repository } from '$lib/types'
+
+  import { Check } from '@lucide/svelte'
+
+  // `selected` is bindable so a parent can two-way bind the chosen repo ids.
+  // Order is preserved in selection order: the first picked is the primary repo
+  // the agent branches in. Clicking a row toggles its membership.
+  let {
+    repos,
+    selected = $bindable([]),
+    id
+  }: {
+    repos: Repository[]
+    selected?: string[]
+    id?: string
+  } = $props()
+
+  function toggle(repoId: string) {
+    if (selected.includes(repoId)) {
+      selected = selected.filter((entry) => entry !== repoId)
+    } else {
+      selected = [...selected, repoId]
+    }
+  }
+</script>
+
+<div {id} class="max-h-56 overflow-y-auto rounded-md border border-border">
+  {#if repos.length === 0}
+    <p class="px-3 py-2 text-xs text-muted-foreground">No repositories are configured yet.</p>
+  {/if}
+  {#each repos as repo (repo.id)}
+    {@const isSelected = selected.includes(repo.id)}
+    {@const primary = selected[0] === repo.id}
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={isSelected}
+      onclick={() => toggle(repo.id)}
+      class="flex w-full items-center gap-2 border-b border-border px-3 py-2 text-left text-sm last:border-b-0 hover:bg-secondary/50"
+    >
+      <span
+        class="flex size-4 shrink-0 items-center justify-center rounded border {isSelected
+          ? 'border-primary bg-primary text-primary-foreground'
+          : 'border-border'}"
+      >
+        {#if isSelected}
+          <Check class="size-3" />
+        {/if}
+      </span>
+      <span class="min-w-0 flex-1 truncate">{repo.full_name}</span>
+      {#if primary && selected.length > 1}
+        <span class="shrink-0 rounded bg-primary/15 px-1.5 py-0.5 text-xs text-primary">Primary</span>
+      {/if}
+    </button>
+  {/each}
+</div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -93,6 +93,10 @@ export type Task = {
   source_kind: SourceKind
   external_id: string
   repo_id: string | null
+  // Every repo an internal ticket targets, in priority order; the first equals
+  // `repo_id` (the primary repo the agent branches in). Empty for tracking-only
+  // tickets and for GitHub/Jira tasks.
+  target_repo_ids: string[]
   title: string
   body_snapshot: string
   url: string

--- a/frontend/src/routes/issues/new/+page.svelte
+++ b/frontend/src/routes/issues/new/+page.svelte
@@ -7,31 +7,46 @@
 
   import { createInternalTask, listRepos } from '$lib/api'
   import * as Card from '$lib/components/ui/card'
-  import * as Select from '$lib/components/ui/select'
   import { Button, buttonVariants } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
   import { Textarea } from '$lib/components/ui/textarea'
   import { Switch } from '$lib/components/ui/switch'
+  import RepoMultiSelect from '$lib/components/RepoMultiSelect.svelte'
 
-  // The sentinel value for "no repo": Select needs a non-empty string value.
-  const NO_REPO = '__none__'
+  // Remember the last repo selection so creating many tickets back to back does
+  // not mean re-picking the same repos every time (issue #189). Restored on mount.
+  const REPO_SELECTION_STORAGE_KEY = 'seraphim:new-issue:repo-ids'
 
   let title = $state('')
   let description = $state('')
   let open = $state(true)
   let saving = $state(false)
   let repos = $state<Repository[]>([])
-  let repoId = $state(NO_REPO)
-
-  const repoLabel = $derived(
-    repoId === NO_REPO
-      ? 'No repo (tracking only)'
-      : (repos.find((repo) => repo.id === repoId)?.full_name ?? 'Select a repo')
-  )
+  let selectedRepoIds = $state<string[]>([])
 
   onMount(async () => {
     repos = await listRepos()
+    // Restore the saved selection, dropping any repos that no longer exist.
+    try {
+      const saved = localStorage.getItem(REPO_SELECTION_STORAGE_KEY)
+      if (saved) {
+        const savedIds = JSON.parse(saved) as string[]
+        const known = new Set(repos.map((repo) => repo.id))
+        selectedRepoIds = savedIds.filter((id) => known.has(id))
+      }
+    } catch (error) {
+      console.debug('failed to restore saved repo selection', error)
+    }
+  })
+
+  // Persist the selection on every change so it survives navigation and reloads.
+  $effect(() => {
+    try {
+      localStorage.setItem(REPO_SELECTION_STORAGE_KEY, JSON.stringify(selectedRepoIds))
+    } catch (error) {
+      console.debug('failed to save repo selection', error)
+    }
   })
 
   async function submit() {
@@ -45,7 +60,7 @@
         title: title.trim(),
         body: description.trim(),
         state: open ? 'open' : 'closed',
-        repo_id: repoId === NO_REPO ? null : repoId
+        repo_ids: selectedRepoIds
       })
       toast.success('Issue created')
       goto(`/task/${task.id}`)
@@ -85,21 +100,24 @@
       </div>
 
       <div class="grid gap-2">
-        <Label for="repo">Target repository</Label>
-        <Select.Root type="single" value={repoId} onValueChange={(value) => (repoId = value)}>
-          <Select.Trigger id="repo" class="w-full">{repoLabel}</Select.Trigger>
-          <Select.Content>
-            <Select.Item value={NO_REPO} label="No repo (tracking only)">
-              No repo (tracking only)
-            </Select.Item>
-            {#each repos as repo (repo.id)}
-              <Select.Item value={repo.id} label={repo.full_name}>{repo.full_name}</Select.Item>
-            {/each}
-          </Select.Content>
-        </Select.Root>
+        <div class="flex items-center justify-between">
+          <Label for="repo">Target repositories</Label>
+          {#if selectedRepoIds.length}
+            <button
+              type="button"
+              class="text-xs text-muted-foreground hover:text-foreground"
+              onclick={() => (selectedRepoIds = [])}
+            >
+              Clear ({selectedRepoIds.length})
+            </button>
+          {/if}
+        </div>
+        <RepoMultiSelect id="repo" {repos} bind:selected={selectedRepoIds} />
         <span class="text-xs text-muted-foreground">
-          Pick a repo and the agent will branch and open a PR there when the ticket reaches To Do.
-          Leave as tracking-only to assign a repo later.
+          Pick one or more repos this ticket affects. The first is the primary one the agent
+          branches in; it gets the full list as context and opens a PR in each repo it changes.
+          Leave empty to keep the ticket tracking-only and assign repos later. Your selection is
+          remembered for the next ticket.
         </span>
       </div>
 

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -33,13 +33,12 @@
     setTaskBlocking,
     setTaskHold,
     setTaskNotes,
-    setTaskRepo
+    setTaskRepos
   } from '$lib/api'
   import { STATUS_BADGE, STATUS_LABELS } from '$lib/types'
   import { PaneGroup, type PaneGroupAPI } from 'paneforge'
 
   import { Badge } from '$lib/components/ui/badge'
-  import * as Select from '$lib/components/ui/select'
   import { Switch } from '$lib/components/ui/switch'
   import { Textarea } from '$lib/components/ui/textarea'
   import * as Alert from '$lib/components/ui/alert'
@@ -47,6 +46,7 @@
   import * as Resizable from '$lib/components/ui/resizable'
   import { buttonVariants } from '$lib/components/ui/button'
   import IssueView from '$lib/components/IssueView.svelte'
+  import RepoMultiSelect from '$lib/components/RepoMultiSelect.svelte'
   import SuggestionCreateButton from '$lib/components/SuggestionCreateButton.svelte'
   import Stats from '$lib/components/Stats.svelte'
   import Markdown from '$lib/components/Markdown.svelte'
@@ -66,23 +66,26 @@
   let eventSource: EventSource | null = null
 
   // Target-repo picker, shown only for internal tickets (a GitHub task's repo is
-  // its issue's and never reassigned). The sentinel stands in for "no repo".
-  const NO_REPO = '__none__'
+  // its issue's and never reassigned). Internal tickets can target several repos
+  // in priority order; the first is the primary one the agent branches in.
   let repos = $state<Repository[]>([])
-  const taskRepoValue = $derived(task?.repo_id ?? NO_REPO)
-  const taskRepoLabel = $derived(
-    !task?.repo_id
-      ? 'No repo (tracking only)'
-      : (repos.find((repo) => repo.id === task?.repo_id)?.full_name ?? 'Unknown repo')
+  // The edited selection, seeded once from the task and saved on demand so an SSE
+  // reload never clobbers an in-progress edit (mirrors the notepad below).
+  let targetRepoIds = $state<string[]>([])
+  let targetReposInitialized = false
+  const targetReposDirty = $derived(
+    !!task &&
+      (targetRepoIds.length !== (task.target_repo_ids?.length ?? 0) ||
+        targetRepoIds.some((id, index) => id !== task?.target_repo_ids?.[index]))
   )
 
-  async function changeRepo(value: string) {
+  async function saveRepos() {
     if (!task) {
       return
     }
-    const repoId = value === NO_REPO ? null : value
-    task = await setTaskRepo(task.id, repoId)
-    toast.success(repoId ? 'Target repo set' : 'Target repo cleared')
+    task = await setTaskRepos(task.id, targetRepoIds)
+    targetRepoIds = [...task.target_repo_ids]
+    toast.success(targetRepoIds.length ? 'Target repos saved' : 'Target repos cleared')
   }
 
   // A one-word status for a PR row, combining its lifecycle and (while open) its
@@ -321,6 +324,11 @@
       notesOpen = notes.trim().length > 0
       notesInitialized = true
     }
+    // Seed the target-repo selection once, so SSE reloads don't drop an edit.
+    if (!targetReposInitialized) {
+      targetRepoIds = [...detail.task.target_repo_ids]
+      targetReposInitialized = true
+    }
   }
 
   // Hold toggle, behind a confirmation so it's a deliberate action.
@@ -522,24 +530,24 @@
            agent works. Until a repo is set the ticket is tracking-only and is not
            auto-pulled from To Do. -->
       <section class="rounded-lg border border-border bg-card p-3">
-        <h2 class="text-sm font-semibold">Target repository</h2>
+        <h2 class="text-sm font-semibold">Target repositories</h2>
         <p class="mt-0.5 text-xs text-muted-foreground">
-          The repo the agent branches in and opens a PR against. Required before this ticket can be
-          worked from To Do.
+          The repos this ticket affects. The first (primary) is the one the agent branches in and
+          that makes the ticket auto-pullable; the agent gets the whole list as context and opens a
+          PR in each repo it changes. Leave empty to keep the ticket tracking-only.
         </p>
         <div class="mt-2">
-          <Select.Root type="single" value={taskRepoValue} onValueChange={changeRepo}>
-            <Select.Trigger class="w-full">{taskRepoLabel}</Select.Trigger>
-            <Select.Content>
-              <Select.Item value={NO_REPO} label="No repo (tracking only)">
-                No repo (tracking only)
-              </Select.Item>
-              {#each repos as repo (repo.id)}
-                <Select.Item value={repo.id} label={repo.full_name}>{repo.full_name}</Select.Item>
-              {/each}
-            </Select.Content>
-          </Select.Root>
+          <RepoMultiSelect {repos} bind:selected={targetRepoIds} />
         </div>
+        {#if targetReposDirty}
+          <button
+            type="button"
+            onclick={saveRepos}
+            class={buttonVariants({ variant: 'default', size: 'sm' }) + ' mt-2 w-full'}
+          >
+            Save target repos
+          </button>
+        {/if}
       </section>
     {/if}
 


### PR DESCRIPTION
Closes #189.

Internal Seraphim tickets could only point at a single repo. They can now target several. The agent is told about every target repo for context ("this affects repos X, Y, Z"), while keeping a single primary repo it branches in; the real PR(s) may land in only some of the targets, which the review loop already handles.

Per the issue's clarification, this is **full multi-repo execution**, not just a UI tweak.

## Backend
- **Migration 0034** adds `tasks.target_repo_ids` (JSONB array, mirroring the existing `jira_boards.repo_ids` shape), backfilled from each task's current `repo_id`. `repo_id` remains the **primary/focus** repo (the first of the set) that drives branch cutting, auto-pull eligibility, and PR detection, so every existing single-repo code path is unchanged.
- `create_internal_task` / `set_internal_task_repos` take the ordered repo set and keep `repo_id` synced to its first entry. `POST /tasks` and `POST /tasks/:id/repo` accept `repo_ids` (and still accept the legacy single `repo_id` for safety).
- The fresh-work **prompt** names every target repo when there is more than one, instructing the agent to open a PR only in the repos it actually changes ("a target that needs no change needs no PR"). PR detection already scans all enabled repos for the task branch, so multi-repo PRs are tracked and Done-gated with **no change to the review loop**.
- Two new pure unit tests for the prompt (multi-repo line present with >1 target, absent with 1).

## Frontend
- **New issue page**: a multi-select repo checklist (new `RepoMultiSelect` component) replaces the single dropdown, with a Clear button. The selection is **saved to localStorage and restored on `/issues/new`**, so creating tickets back to back reuses the same repos (the second ask in the issue).
- **Task view**: the target-repo picker becomes the same multi-select, seeded once from the task and saved on demand (so an SSE reload never clobbers an in-progress edit). The PR list already shows every repo's PR.

## Validation
- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (96 pass, 2 new) all green.
- `yarn check` (0 errors) and `yarn build` both pass.
- No new dependencies. Migration 0034 is linear after 0033.

Note: CI's "Docker images" job has been intermittently failing on a transient Microsoft base-image registry flake (401/429 pulling `devcontainers/universal`); if it trips here it is unrelated to this diff (no Docker/build files changed).