### PR TITLE
Watch page: live activity forest via runewood (#180)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "node build",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@iconify/json": "^2.2.484",
@@ -28,7 +29,8 @@
     "tailwindcss": "^4.3.0",
     "typescript": "^5.6.0",
     "unplugin-icons": "^23.0.1",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^2"
   },
   "dependencies": {
     "bits-ui": "^2.18.1",
@@ -38,6 +40,7 @@
     "ky": "^1.7.0",
     "marked": "^18.0.5",
     "paneforge": "^1.0.2",
+    "runewood": "^0.0.2",
     "svelte-dnd-action": "^0.9.50",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/frontend/src/lib/runewood/mapEvent.test.ts
+++ b/frontend/src/lib/runewood/mapEvent.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+
+import { mapActivityEvent, normalizePath, type ActivityEvent } from './mapEvent'
+
+// Builds a `tool_use` activity frame for a given tool + input.
+function toolUse(name: string, input: Record<string, unknown>, taskId = 'task-1'): ActivityEvent {
+  return {
+    task_id: taskId,
+    event: {
+      type: 'tool_use',
+      payload: { name, input },
+      created_at: '2026-06-16T01:00:00.000Z'
+    }
+  }
+}
+
+const AT = Date.parse('2026-06-16T01:00:00.000Z')
+
+describe('normalizePath', () => {
+  it('strips the /workspace/ prefix so the first segment is the repo', () => {
+    expect(normalizePath('/workspace/seraphim/api/src/main.rs')).toBe('seraphim/api/src/main.rs')
+  })
+
+  it('keeps an already-relative path as-is', () => {
+    expect(normalizePath('seraphim/frontend/src/app.css')).toBe('seraphim/frontend/src/app.css')
+  })
+
+  it('drops an absolute path outside the workspace', () => {
+    expect(normalizePath('/etc/passwd')).toBeNull()
+    expect(normalizePath('/workspace')).toBeNull()
+  })
+
+  it('drops paths that escape via ..', () => {
+    expect(normalizePath('/workspace/../secret')).toBeNull()
+    expect(normalizePath('a/../../b')).toBeNull()
+  })
+
+  it('drops empty/blank input', () => {
+    expect(normalizePath('')).toBeNull()
+    expect(normalizePath('   ')).toBeNull()
+    expect(normalizePath(null)).toBeNull()
+    expect(normalizePath(undefined)).toBeNull()
+  })
+})
+
+describe('mapActivityEvent', () => {
+  it('maps Write to create off file_path', () => {
+    const result = mapActivityEvent(toolUse('Write', { file_path: '/workspace/repo/a.ts' }), 'My task')
+    expect(result).toEqual({
+      at: AT,
+      actor: 'task-1',
+      action: 'create',
+      path: 'repo/a.ts',
+      label: 'My task'
+    })
+  })
+
+  it('maps Edit and NotebookEdit to modify', () => {
+    expect(mapActivityEvent(toolUse('Edit', { file_path: '/workspace/repo/a.ts' }))?.action).toBe(
+      'modify'
+    )
+    expect(
+      mapActivityEvent(toolUse('NotebookEdit', { notebook_path: '/workspace/repo/n.ipynb' }))?.action
+    ).toBe('modify')
+  })
+
+  it('maps Read to scan off file_path, and Grep/Glob to scan off path', () => {
+    expect(mapActivityEvent(toolUse('Read', { file_path: '/workspace/repo/a.ts' }))?.action).toBe(
+      'scan'
+    )
+    const grep = mapActivityEvent(toolUse('Grep', { pattern: 'foo', path: '/workspace/repo/src' }))
+    expect(grep).toMatchObject({ action: 'scan', path: 'repo/src' })
+  })
+
+  it('maps Bash to a pathless pulse labeled with the command', () => {
+    const result = mapActivityEvent(toolUse('Bash', { command: 'cargo test' }), 'My task')
+    expect(result).toEqual({ at: AT, actor: 'task-1', action: 'pulse', label: 'cargo test' })
+    expect(result).not.toHaveProperty('path')
+  })
+
+  it('drops non-tool_use events', () => {
+    const assistant: ActivityEvent = {
+      task_id: 'task-1',
+      event: { type: 'assistant_text', payload: { text: 'hi' }, created_at: '2026-06-16T01:00:00Z' }
+    }
+    expect(mapActivityEvent(assistant)).toBeNull()
+  })
+
+  it('drops unknown tools and tools with no usable path', () => {
+    expect(mapActivityEvent(toolUse('TodoWrite', { todos: [] }))).toBeNull()
+    expect(mapActivityEvent(toolUse('Write', {}))).toBeNull()
+    expect(mapActivityEvent(toolUse('Read', { file_path: '/etc/hosts' }))).toBeNull()
+  })
+
+  it('drops malformed frames without throwing', () => {
+    expect(mapActivityEvent(null)).toBeNull()
+    expect(mapActivityEvent({})).toBeNull()
+    expect(mapActivityEvent({ task_id: 'task-1', event: { type: 'tool_use' } })).toBeNull()
+    // Missing actor (task_id) is unusable for a stable color.
+    expect(mapActivityEvent(toolUse('Write', { file_path: '/workspace/repo/a.ts' }, ''))).toBeNull()
+  })
+
+  it('falls back to a numeric timestamp when created_at is missing/invalid', () => {
+    const frame: ActivityEvent = {
+      task_id: 'task-1',
+      event: { type: 'tool_use', payload: { name: 'Write', input: { file_path: 'repo/a.ts' } } }
+    }
+    const result = mapActivityEvent(frame)
+    expect(result?.path).toBe('repo/a.ts')
+    expect(typeof result?.at).toBe('number')
+    expect(Number.isNaN(result?.at)).toBe(false)
+  })
+})

--- a/frontend/src/lib/runewood/mapEvent.ts
+++ b/frontend/src/lib/runewood/mapEvent.ts
@@ -1,0 +1,130 @@
+// Maps Seraphim's live agent activity stream into runewood events for the watch
+// page's activity forest (issue #180). This is the only place Seraphim specifics
+// touch runewood; the library stays a generic event renderer.
+//
+// Pure and defensive by design: the stream-json schema drifts across Claude Code
+// versions, so every unrecognized or malformed shape is dropped, never thrown
+// (mirroring the Rust parser's `Other` handling). It is unit-tested in
+// `mapEvent.test.ts`.
+
+import type { RunewoodEvent } from 'runewood'
+
+// Repo ignore globs so the forest stays clean (build output, deps, lockfiles).
+// Passed to runewood's `exclude` option.
+export const DEFAULT_EXCLUDES = [
+  '**/node_modules/**',
+  '**/target/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.git/**',
+  '**/.svelte-kit/**',
+  '**/__pycache__/**',
+  '**/.venv/**',
+  '**/*.lock'
+]
+
+// The shape of one `activity` SSE frame's data (loose: read defensively).
+export type ActivityEvent = {
+  task_id?: string
+  event?: {
+    type?: string
+    payload?: unknown
+    created_at?: string
+  }
+}
+
+// How each Claude tool maps to a runewood action and where its path comes from.
+// A `pulse` tool (Bash) has no path and renders on the actor, not the tree.
+type ToolRule =
+  | { action: 'create' | 'modify' | 'scan'; pathKeys: readonly string[] }
+  | { action: 'pulse' }
+
+const TOOL_RULES: Record<string, ToolRule> = {
+  Write: { action: 'create', pathKeys: ['file_path', 'path'] },
+  Edit: { action: 'modify', pathKeys: ['file_path', 'path'] },
+  MultiEdit: { action: 'modify', pathKeys: ['file_path', 'path'] },
+  NotebookEdit: { action: 'modify', pathKeys: ['notebook_path', 'file_path', 'path'] },
+  Read: { action: 'scan', pathKeys: ['file_path', 'path'] },
+  Grep: { action: 'scan', pathKeys: ['path'] },
+  Glob: { action: 'scan', pathKeys: ['path'] },
+  Bash: { action: 'pulse' }
+}
+
+// Reads a string property off a loose record, or null when absent/not a string.
+function readString(record: Record<string, unknown> | undefined, key: string): string | null {
+  const value = record?.[key]
+  return typeof value === 'string' ? value : null
+}
+
+// Normalizes a tool path to a forest path whose first segment is the repo: strips
+// a leading `/workspace/` (the agent's cwd, where repos are cloned flat), keeps
+// already-relative paths as-is, and drops anything that escapes the workspace (an
+// absolute path elsewhere, or a `..` segment). Returns null to drop the event.
+export function normalizePath(raw: string | null | undefined): string | null {
+  if (!raw) {
+    return null
+  }
+  let path = raw.trim()
+  if (!path) {
+    return null
+  }
+
+  const WORKSPACE_PREFIX = '/workspace/'
+  if (path.startsWith(WORKSPACE_PREFIX)) {
+    path = path.slice(WORKSPACE_PREFIX.length)
+  } else if (path.startsWith('/')) {
+    // Absolute path outside the workspace (or `/workspace` itself): escapes, drop.
+    return null
+  }
+
+  path = path.replace(/^\/+/, '')
+  if (!path || path.split('/').some((segment) => segment === '..')) {
+    return null
+  }
+  return path
+}
+
+// Maps one activity frame to a single runewood event, or null to drop it. Only
+// `tool_use` frames produce events (see `TOOL_RULES`); `taskTitle` is used as the
+// actor's display label (Bash pulses prefer the command).
+export function mapActivityEvent(
+  input: ActivityEvent | null | undefined,
+  taskTitle?: string
+): RunewoodEvent | null {
+  const event = input?.event
+  if (!event || event.type !== 'tool_use') {
+    return null
+  }
+  const actor = input?.task_id
+  if (!actor) {
+    return null
+  }
+
+  const payload = (event.payload ?? {}) as Record<string, unknown>
+  const name = readString(payload, 'name')
+  if (!name) {
+    return null
+  }
+  const rule = TOOL_RULES[name]
+  if (!rule) {
+    return null
+  }
+
+  const parsed = event.created_at ? Date.parse(event.created_at) : Number.NaN
+  const at = Number.isNaN(parsed) ? Date.now() : parsed
+
+  const toolInput = (payload.input ?? {}) as Record<string, unknown>
+
+  if (rule.action === 'pulse') {
+    // A shell command: a contributor pulse with no file target.
+    const command = readString(toolInput, 'command')
+    return { at, actor, action: 'pulse', label: command ?? taskTitle }
+  }
+
+  const rawPath = rule.pathKeys.map((key) => readString(toolInput, key)).find((value) => value)
+  const path = normalizePath(rawPath)
+  if (!path) {
+    return null
+  }
+  return { at, actor, action: rule.action, path, label: taskTitle }
+}

--- a/frontend/src/routes/watch/+page.svelte
+++ b/frontend/src/routes/watch/+page.svelte
@@ -4,8 +4,10 @@
   // worked, and a big completed count in the middle; and a combined live activity
   // feed across every task along the bottom. Built to be left running on a TV.
   import type { BoardResponse, Task, TaskStatus } from '$lib/types'
+  import type { RunewoodController, RunewoodHighlight, Hsl } from 'runewood'
 
   import { onMount, onDestroy, tick } from 'svelte'
+  import { browser } from '$app/environment'
   import { Tween } from 'svelte/motion'
   import { cubicOut } from 'svelte/easing'
   import { fly } from 'svelte/transition'
@@ -14,6 +16,7 @@
   import { STATUS_LABELS } from '$lib/types'
   import { isWithinSchedule } from '$lib/schedule'
   import { describeRateLimit } from '$lib/rateLimit'
+  import { mapActivityEvent, DEFAULT_EXCLUDES } from '$lib/runewood/mapEvent'
   import Stats from '$lib/components/Stats.svelte'
 
   let board = $state<BoardResponse | null>(null)
@@ -253,6 +256,90 @@
     return new Date(at).toLocaleTimeString([], { hour12: false })
   }
 
+  // --- Activity forest (runewood, issue #180) ---------------------------------
+
+  // The Gource-style live forest. Created on mount (WebGL is browser-only) and
+  // fed the same `activity` stream through the pure mapper. `runewood` is imported
+  // dynamically so the WebGL bundle never loads during SSR/build.
+  let forestEl = $state<HTMLDivElement>()
+  let forest: RunewoodController | null = null
+  let forestReady = $state(false)
+  // Tooltip for the hovered node (driven by runewood's nodeHover event).
+  let hoverTip = $state<{ path: string; x: number; y: number } | null>(null)
+
+  // CI highlight, driven off the board's per-task status (issue #180): light up
+  // the files a PR touched while its CI runs, and clear them when it settles.
+  // Touched files accumulate per task from the live stream; the color tracks the
+  // task's status (amber under review/CI, green about to merge, red failing).
+  const touchedFiles = new Map<string, Set<string>>()
+  const highlightHandles = new Map<string, { handle: RunewoodHighlight; colorKey: string }>()
+  const CI_COLORS = {
+    running: { h: 38, s: 0.9, l: 0.55 }, // amber
+    passing: { h: 140, s: 0.6, l: 0.5 }, // green
+    failing: { h: 0, s: 0.75, l: 0.55 } // red
+  } as const satisfies Record<string, Hsl>
+
+  // The highlight color for a task's PR, or null when it should not be lit. Only
+  // In Review tasks (which have an open PR) are highlighted.
+  function ciColor(task: Task): Hsl | null {
+    if (task.board_column !== 'in_review') {
+      return null
+    }
+    if (task.status === 'ci_failing' || task.status === 'ci_blocked') {
+      return CI_COLORS.failing
+    }
+    if (task.status === 'merging') {
+      return CI_COLORS.passing
+    }
+    return CI_COLORS.running
+  }
+
+  // Reconcile the live highlights with the current board: create/grow/recolor a
+  // group per highlightable task, and clear groups whose task has settled.
+  function reconcileHighlights() {
+    if (!forest) {
+      return
+    }
+    const active = new Set<string>()
+    for (const task of tasks) {
+      const color = ciColor(task)
+      if (!color) {
+        continue
+      }
+      const files = [...(touchedFiles.get(task.id) ?? [])]
+      if (files.length === 0) {
+        continue
+      }
+      active.add(task.id)
+      const colorKey = `${color.h},${color.s},${color.l}`
+      const existing = highlightHandles.get(task.id)
+      if (!existing) {
+        const handle = forest.highlight(files, { id: task.id, color })
+        highlightHandles.set(task.id, { handle, colorKey })
+      } else {
+        existing.handle.update(files)
+        // Re-highlighting the same id replaces the group, which is how a color
+        // change (e.g. amber -> red) is encoded.
+        if (existing.colorKey !== colorKey) {
+          const handle = forest.highlight(files, { id: task.id, color })
+          highlightHandles.set(task.id, { handle, colorKey })
+        }
+      }
+    }
+    for (const [taskId, entry] of highlightHandles) {
+      if (!active.has(taskId)) {
+        entry.handle.clear()
+        highlightHandles.delete(taskId)
+      }
+    }
+  }
+
+  // Re-reconcile whenever the board changes (status transitions, settled PRs).
+  $effect(() => {
+    tasks
+    reconcileHighlights()
+  })
+
   async function loadBoard() {
     try {
       board = await getBoard()
@@ -277,16 +364,58 @@
         }
         const at = data.event.created_at ? new Date(data.event.created_at).getTime() : Date.now()
         void pushFeed(data.task_id, data.event.type, data.event.payload ?? {}, at)
+
+        // Feed the forest through the pure mapper. A file-touch event also grows
+        // its task's CI highlight set.
+        const mapped = mapActivityEvent(data, titleById.get(data.task_id))
+        if (mapped) {
+          forest?.ingest(mapped)
+          if (mapped.path) {
+            const files = touchedFiles.get(data.task_id) ?? new Set<string>()
+            files.add(mapped.path)
+            touchedFiles.set(data.task_id, files)
+            reconcileHighlights()
+          }
+        }
       } catch {
         // Ignore malformed frames.
       }
     })
+
+    // Create the forest once the DOM node exists. Browser-only; the dynamic import
+    // keeps the WebGL bundle out of SSR/build evaluation.
+    if (browser && forestEl) {
+      import('runewood')
+        .then(({ createRunewood }) => {
+          if (!forestEl) {
+            return
+          }
+          forest = createRunewood(forestEl, {
+            theme: 'void',
+            bloom: 'off',
+            cameraMode: 'follow',
+            rootLabel: 'workspace',
+            exclude: DEFAULT_EXCLUDES,
+            // Keep a contributor lingering on its last file across edit gaps so a
+            // live agent feed reads as continuous activity, not flicker.
+            actorLingerMs: 60 * 60 * 1000
+          })
+          forest.on('nodeHover', (hit) => {
+            hoverTip = hit ? { path: hit.path, x: hit.screen.x, y: hit.screen.y } : null
+          })
+          forestReady = true
+          // Any PRs already In Review get lit as soon as their files stream in.
+          reconcileHighlights()
+        })
+        .catch((error) => console.debug('runewood failed to load', error))
+    }
   })
 
   onDestroy(() => {
     if (clock) clearInterval(clock)
     boardStream?.close()
     activityStream?.close()
+    forest?.destroy()
   })
 </script>
 
@@ -421,35 +550,60 @@
       </span>
     </div>
 
-    <!-- Live activity across every task -->
-    <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/60 bg-black/30 backdrop-blur">
-      <div class="flex items-center gap-2 border-b border-border/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-        <span class="size-2 rounded-full bg-primary {feed.length ? 'animate-pulse' : ''}"></span>
-        Live activity
+    <!-- Bottom: live activity log (1/3) beside the live activity forest (2/3). -->
+    <section class="flex min-h-0 flex-1 gap-5">
+      <!-- Live activity log -->
+      <div class="flex w-1/3 min-w-0 flex-col overflow-hidden rounded-xl border border-border/60 bg-black/30 backdrop-blur">
+        <div class="flex items-center gap-2 border-b border-border/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          <span class="size-2 rounded-full bg-primary {feed.length ? 'animate-pulse' : ''}"></span>
+          Live activity
+        </div>
+        <div bind:this={feedEl} class="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-3 py-3 font-mono text-xs">
+          {#if feed.length === 0}
+            <p class="text-muted-foreground">Waiting for the agent to act…</p>
+          {/if}
+          {#each feed as entry (entry.id)}
+            {@const meta = GLYPHS[entry.type] ?? { glyph: '·', color: 'text-muted-foreground' }}
+            {@const glyphColor = entry.type === 'ci' ? ciGlyphColor(entry.status) : meta.color}
+            {@const hue = taskHue(entry.taskId)}
+            <div class="flex items-center gap-2 py-0.5" in:fly={{ y: 8, duration: 250, easing: cubicOut }}>
+              <span class="w-[3.5rem] shrink-0 tabular-nums text-muted-foreground/60">
+                {clockLabel(entry.at)}
+              </span>
+              <span
+                class="w-28 shrink-0 truncate rounded px-1.5 py-0.5 font-medium"
+                style="color: hsl({hue} 75% 72%); background: hsl({hue} 75% 55% / 0.12)"
+                title={titleById.get(entry.taskId) ?? entry.taskId}
+              >
+                {taskLabel(entry.taskId)}
+              </span>
+              <span class="w-[1ch] shrink-0 text-center {glyphColor}">{meta.glyph}</span>
+              <span class="min-w-0 flex-1 truncate text-foreground/90">{entry.text}</span>
+            </div>
+          {/each}
+        </div>
       </div>
-      <div bind:this={feedEl} class="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-4 py-3 font-mono text-sm">
-        {#if feed.length === 0}
-          <p class="text-muted-foreground">Waiting for the agent to act…</p>
-        {/if}
-        {#each feed as entry (entry.id)}
-          {@const meta = GLYPHS[entry.type] ?? { glyph: '·', color: 'text-muted-foreground' }}
-          {@const glyphColor = entry.type === 'ci' ? ciGlyphColor(entry.status) : meta.color}
-          {@const hue = taskHue(entry.taskId)}
-          <div class="flex items-center gap-3 py-0.5" in:fly={{ y: 8, duration: 250, easing: cubicOut }}>
-            <span class="w-[4.5rem] shrink-0 text-xs tabular-nums text-muted-foreground/60">
-              {clockLabel(entry.at)}
-            </span>
-            <span
-              class="w-44 shrink-0 truncate rounded px-1.5 py-0.5 text-xs font-medium"
-              style="color: hsl({hue} 75% 72%); background: hsl({hue} 75% 55% / 0.12)"
-              title={titleById.get(entry.taskId) ?? entry.taskId}
-            >
-              {taskLabel(entry.taskId)}
-            </span>
-            <span class="w-[1ch] shrink-0 text-center {glyphColor}">{meta.glyph}</span>
-            <span class="min-w-0 flex-1 truncate text-foreground/90">{entry.text}</span>
+
+      <!-- Live activity forest (runewood): a Gource-style view of every file the
+           agents touch, lit up per PR while its CI runs. -->
+      <div class="relative w-2/3 min-w-0 overflow-hidden rounded-xl border border-border/60 bg-black/30 backdrop-blur">
+        <div bind:this={forestEl} class="absolute inset-0"></div>
+        <div class="pointer-events-none absolute left-4 top-2 z-10 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground/80">
+          Activity forest
+        </div>
+        {#if !forestReady}
+          <div class="pointer-events-none absolute inset-0 grid place-items-center text-xs text-muted-foreground">
+            Spinning up the activity forest…
           </div>
-        {/each}
+        {/if}
+        {#if hoverTip}
+          <div
+            class="pointer-events-none absolute z-20 max-w-xs -translate-y-full truncate rounded bg-black/80 px-2 py-1 font-mono text-xs text-foreground shadow"
+            style="left: {hoverTip.x}px; top: {hoverTip.y}px"
+          >
+            {hoverTip.path}
+          </div>
+        {/if}
       </div>
     </section>
   </div>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+// Unit tests run as plain TypeScript in a node environment, deliberately without
+// the SvelteKit/Tailwind plugins: the only tested code is pure logic (e.g. the
+// runewood event mapper), so the lighter config keeps `yarn test` fast and free
+// of browser/SvelteKit setup.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts']
+  }
+})

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -341,6 +341,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pixi/colord@npm:^2.9.6":
+  version: 2.9.6
+  resolution: "@pixi/colord@npm:2.9.6"
+  checksum: 10c0/513636a67140b8bb3292eb4a7a3a5303a394525410fe972ebfe1e5db3749f27f7c0f176e4c84fcb9ab0fa22ee1d8ce2a15b3e32db7021e65ac0561941d2933a3
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
@@ -891,10 +898,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/earcut@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/earcut@npm:3.0.0"
+  checksum: 10c0/3c03e66bebb9b2408934f3ba4c3e9de37847166047fd64c23efd1bb9e127ed9330a9c61b03f3dc6cee060cb3b7e0a19689ee983d08defc93ca387a17b96e9499
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:*, @types/estree@npm:1.0.9, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6":
   version: 1.0.9
   resolution: "@types/estree@npm:1.0.9"
   checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
+  languageName: node
+  linkType: hard
+
+"@types/gradient-parser@npm:^0.1.2":
+  version: 0.1.5
+  resolution: "@types/gradient-parser@npm:0.1.5"
+  checksum: 10c0/8347fb24885aeb133421baec58d0eab4e8ec43d17f337bc4f1d23bde99ca5e87b82b44834eb00d71fd820503c530d4c75e4d9a98652e09b2f04b08fbc1057762
   languageName: node
   linkType: hard
 
@@ -921,6 +942,101 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/expect@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/98d1cf02917316bebef9e4720723e38298a1c12b3c8f3a81f259bb822de4288edf594e69ff64f0b88afbda6d04d7a4f0c2f720f3fec16b4c45f5e2669f09fdbb
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/mocker@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.12"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/f734490d8d1206a7f44dfdfca459282f5921d73efa72935bb1dc45307578defd38a4131b14853316373ec364cbe910dbc74594ed4137e0da35aa4d9bb716f190
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:2.1.9, @vitest/pretty-format@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/pretty-format@npm:2.1.9"
+  dependencies:
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/155f9ede5090eabed2a73361094bb35ed4ec6769ae3546d2a2af139166569aec41bb80e031c25ff2da22b71dd4ed51e5468e66a05e6aeda5f14b32e30bc18f00
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/runner@npm:2.1.9"
+  dependencies:
+    "@vitest/utils": "npm:2.1.9"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/e81f176badb12a815cbbd9bd97e19f7437a0b64e8934d680024b0f768d8670d59cad698ef0e3dada5241b6731d77a7bb3cd2c7cb29f751fd4dd35eb11c42963a
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/snapshot@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/394974b3a1fe96186a3c87f933b2f7f1f7b7cc42f9c781d80271dbb4c987809bf035fecd7398b8a3a2d54169e3ecb49655e38a0131d0e7fea5ce88960613b526
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/spy@npm:2.1.9"
+  dependencies:
+    tinyspy: "npm:^3.0.2"
+  checksum: 10c0/12a59b5095e20188b819a1d797e0a513d991b4e6a57db679927c43b362a3eff52d823b34e855a6dd9e73c9fa138dcc5ef52210841a93db5cbf047957a60ca83c
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/utils@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    loupe: "npm:^3.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/81a346cd72b47941f55411f5df4cc230e5f740d1e97e0d3f771b27f007266fc1f28d0438582f6409ea571bc0030ed37f684c64c58d1947d6298d770c21026fdf
+  languageName: node
+  linkType: hard
+
+"@webgpu/types@npm:^0.1.69":
+  version: 0.1.70
+  resolution: "@webgpu/types@npm:0.1.70"
+  checksum: 10c0/6d70ee5c316e7d9e3c3b0a855df1b91221f4137b4de5223f2658c57780894c155070be7c24686ab4b436e0ffae6517e392219b2eb65315dd380d8f7d9d2cd160
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.8.13":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -941,6 +1057,13 @@ __metadata:
   version: 5.3.1
   resolution: "aria-query@npm:5.3.1"
   checksum: 10c0/2e9aca7d92d20b8539ee58fa1d29ba07e2269a68da8d27e9830d3cb816d49bb01648610ac3f2e365a8dedbf00168ac18c017ea49c512fbe2537a0b17184a458b
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -965,6 +1088,33 @@ __metadata:
     "@internationalized/date": ^3.8.1
     svelte: ^5.33.0
   checksum: 10c0/1ed513a994d66449ab00c091f70111de30182856a167110ec3a413317014e7b949c50a8501aaa8a7603829394e5499bcb5a2b7c4a38a541b3820aad03e01f3cf
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
+  languageName: node
+  linkType: hard
+
+"chai@npm:^5.1.2":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/b360fd4d38861622e5010c2f709736988b05c7f31042305fa3f4e9911f6adb80ccfb4e302068bf8ed10e835c2e2520cba0f5edc13d878b886987e5aa62483f53
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
   languageName: node
   linkType: hard
 
@@ -1040,6 +1190,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
+  languageName: node
+  linkType: hard
+
 "deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.1":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
@@ -1080,6 +1237,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"earcut@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "earcut@npm:3.0.2"
+  checksum: 10c0/3d76da3d8a935244d59713edc70de71cdb5326a80b31c5c5cb96bc5b61f56b86ed35f032fffb66be7a4558e06efe1e94934f43ba6ca1b6c2af1420e87dd7ad71
+  languageName: node
+  linkType: hard
+
 "enhanced-resolve@npm:^5.21.0":
   version: 5.23.0
   resolution: "enhanced-resolve@npm:5.23.0"
@@ -1101,6 +1265,13 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^1.5.4":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
   languageName: node
   linkType: hard
 
@@ -1212,6 +1383,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "eventemitter3@npm:5.0.4"
+  checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
+  languageName: node
+  linkType: hard
+
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
@@ -1268,6 +1462,15 @@ __metadata:
   version: 7.4.2
   resolution: "fuse.js@npm:7.4.2"
   checksum: 10c0/b83e50e0cdbeca995ea373e19569c7d89a8a9af64e5752cc23d06e823332a699a5f14f0c6e4036f7e2b4cbd9ed960761cec6b20ea8a3bf3905b1af0cfa296447
+  languageName: node
+  linkType: hard
+
+"gifuct-js@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "gifuct-js@npm:2.1.2"
+  dependencies:
+    js-binary-schema-parser: "npm:^2.0.3"
+  checksum: 10c0/39521aabcb87b50c3e44b98c564bf229f33f9667809b643c719674a7bcc6b42eb9faa521be6575707ea5964ecf1613991b09295a7a389aa502b109d1ca303fcf
   languageName: node
   linkType: hard
 
@@ -1342,12 +1545,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ismobilejs@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "ismobilejs@npm:1.1.1"
+  checksum: 10c0/3f15f3bd8fe2290bc2f7398c95ceee7525db7d8cf76b8def201c19c49b3a37be33d9ecedc4e316aadcc67a70859ae491981e07cf998db1ec3e5ad0df905bc16a
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^2.6.1":
   version: 2.7.0
   resolution: "jiti@npm:2.7.0"
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10c0/1b1e2310a490dce1aeea3da5f5dfe18273516c20ce48be2e98eb8ea452d5f3dcc8fd0cfd6d28b4052a24c5dbab6e3089b2d7e79f0bce7915b10d750929563c42
+  languageName: node
+  linkType: hard
+
+"js-binary-schema-parser@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "js-binary-schema-parser@npm:2.0.3"
+  checksum: 10c0/0acf895918974d95f5c8c432486d23b6257c555c8a3efff1e4f6a72818877b40c2467bcb2fbd79e519b9c34612526b3595f805eb294e19f48f68f6aa9ee8469e
   languageName: node
   linkType: hard
 
@@ -1500,6 +1717,13 @@ __metadata:
   version: 3.0.0
   resolution: "locate-character@npm:3.0.0"
   checksum: 10c0/9da917622395002eb1336fca8cbef1c19904e3dc0b3b8078abe8ff390106d947a86feccecd0346f0e0e19fa017623fb4ccb65263d72a76dfa36e20cc18766b6c
+  languageName: node
+  linkType: hard
+
+"loupe@npm:^3.1.0, loupe@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10c0/910c872cba291309664c2d094368d31a68907b6f5913e989d301b5c25f30e97d76d77f23ab3bf3b46d0f601ff0b6af8810c10c31b91d2c6b2f132809ca2cc705
   languageName: node
   linkType: hard
 
@@ -1657,6 +1881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-svg-path@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "parse-svg-path@npm:0.2.0"
+  checksum: 10c0/a6089505fd63ce43c873c616e6eb7fa85f88644bb38fadd5c2b66a1e30c77275d391049e5c6cd4be09520f191e1e2d37d173b6470f9aa6f548a2fff6f649894a
+  languageName: node
+  linkType: hard
+
 "path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
@@ -1664,10 +1895,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+  languageName: node
+  linkType: hard
+
 "pathe@npm:^2.0.1, pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10c0/460f4709479fbf2c45903a65655fc8f0a5f6d808f989173aeef5fdea4ff4f303dc13f7870303999add60ec49d4c14733895c0a869392e9866f1091fa64fd7581
   languageName: node
   linkType: hard
 
@@ -1682,6 +1927,35 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
+"pixi-filters@npm:^6.1.5":
+  version: 6.1.5
+  resolution: "pixi-filters@npm:6.1.5"
+  dependencies:
+    "@types/gradient-parser": "npm:^0.1.2"
+  peerDependencies:
+    pixi.js: ">=8.0.0-0"
+  checksum: 10c0/e0cf1586454532b4438d72acced2da8558ee2292b61474395aa60c8c6d92c1337f9a4370d5c0b441fc6010aecbe2065e88a7415bc7c5dbc10d34f0372bae08cd
+  languageName: node
+  linkType: hard
+
+"pixi.js@npm:^8.19.0":
+  version: 8.19.0
+  resolution: "pixi.js@npm:8.19.0"
+  dependencies:
+    "@pixi/colord": "npm:^2.9.6"
+    "@types/earcut": "npm:^3.0.0"
+    "@webgpu/types": "npm:^0.1.69"
+    "@xmldom/xmldom": "npm:^0.8.13"
+    earcut: "npm:^3.0.2"
+    eventemitter3: "npm:^5.0.1"
+    gifuct-js: "npm:^2.1.2"
+    ismobilejs: "npm:^1.1.1"
+    parse-svg-path: "npm:^0.2.0"
+    tiny-lru: "npm:^11.4.7"
+  checksum: 10c0/ba0e688bc7bef70ffd205e67ccdcc915fbb96aba6a41eb14d10e03e6ac1dd9055135e34d09256750d88702bb034b968f17a77d5ac68848518b8b6db0012f1f1c
   languageName: node
   linkType: hard
 
@@ -1928,6 +2202,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"runewood@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "runewood@npm:0.0.2"
+  dependencies:
+    pixi-filters: "npm:^6.1.5"
+    pixi.js: "npm:^8.19.0"
+  checksum: 10c0/abd626796fb3d37d383b6130333a317a3acd33d72968bb748752f7f3f1c9f46eb4935b67b6bfb9703e1fd02fc9d401f4d6984b908028ccce82c5b3f6a1ea6659
+  languageName: node
+  linkType: hard
+
 "sade@npm:^1.7.4":
   version: 1.8.1
   resolution: "sade@npm:1.8.1"
@@ -1967,6 +2251,7 @@ __metadata:
     marked: "npm:^18.0.5"
     mode-watcher: "npm:^1.1.0"
     paneforge: "npm:^1.0.2"
+    runewood: "npm:^0.0.2"
     svelte: "npm:^5.1.0"
     svelte-check: "npm:^4.0.0"
     svelte-dnd-action: "npm:^0.9.50"
@@ -1978,6 +2263,7 @@ __metadata:
     typescript: "npm:^5.6.0"
     unplugin-icons: "npm:^23.0.1"
     vite: "npm:^5.4.0"
+    vitest: "npm:^2"
   languageName: unknown
   linkType: soft
 
@@ -1985,6 +2271,13 @@ __metadata:
   version: 3.1.0
   resolution: "set-cookie-parser@npm:3.1.0"
   checksum: 10c0/7465e389ff9fb7ff243fd55f0f48b5648d53a560903db170a7f766c2b82f22f4242c4d366fcdf12afdd376496f84058025d889e718459256ecbfc9a5fe7755f5
+  languageName: node
+  linkType: hard
+
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
   languageName: node
   linkType: hard
 
@@ -2003,6 +2296,20 @@ __metadata:
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.8.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
   languageName: node
   linkType: hard
 
@@ -2178,6 +2485,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-lru@npm:^11.4.7":
+  version: 11.4.7
+  resolution: "tiny-lru@npm:11.4.7"
+  checksum: 10c0/2cd65b987396e331ddcef57133b3f0cb30c832641a215a2e627af04941c839ca6772f216b238e96500b4747f39b434d129cec4c0a25db3beb08c8f3d448a2705
+  languageName: node
+  linkType: hard
+
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.0.1":
   version: 1.2.4
   resolution: "tinyexec@npm:1.2.4"
@@ -2192,6 +2520,27 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tinyrainbow@npm:1.2.0"
+  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "tinyspy@npm:3.0.2"
+  checksum: 10c0/55ffad24e346622b59292e097c2ee30a63919d5acb7ceca87fc0d1c223090089890587b426e20054733f97a58f20af2c349fb7cc193697203868ab7ba00bcea0
   languageName: node
   linkType: hard
 
@@ -2303,7 +2652,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.4.0":
+"vite-node@npm:2.1.9":
+  version: 2.1.9
+  resolution: "vite-node@npm:2.1.9"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.3.7"
+    es-module-lexer: "npm:^1.5.4"
+    pathe: "npm:^1.1.2"
+    vite: "npm:^5.0.0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/0d3589f9f4e9cff696b5b49681fdb75d1638c75053728be52b4013f70792f38cb0120a9c15e3a4b22bdd6b795ad7c2da13bcaf47242d439f0906049e73bdd756
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0, vite@npm:^5.4.0":
   version: 5.4.21
   resolution: "vite@npm:5.4.21"
   dependencies:
@@ -2358,6 +2722,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:^2":
+  version: 2.1.9
+  resolution: "vitest@npm:2.1.9"
+  dependencies:
+    "@vitest/expect": "npm:2.1.9"
+    "@vitest/mocker": "npm:2.1.9"
+    "@vitest/pretty-format": "npm:^2.1.9"
+    "@vitest/runner": "npm:2.1.9"
+    "@vitest/snapshot": "npm:2.1.9"
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    debug: "npm:^4.3.7"
+    expect-type: "npm:^1.1.0"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+    std-env: "npm:^3.8.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.1"
+    tinypool: "npm:^1.0.1"
+    tinyrainbow: "npm:^1.2.0"
+    vite: "npm:^5.0.0"
+    vite-node: "npm:2.1.9"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/node": ^18.0.0 || >=20.0.0
+    "@vitest/browser": 2.1.9
+    "@vitest/ui": 2.1.9
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/e339e16dccacf4589ff43cb1f38c7b4d14427956ae8ef48702af6820a9842347c2b6c77356aeddb040329759ca508a3cb2b104ddf78103ea5bc98ab8f2c3a54e
+  languageName: node
+  linkType: hard
+
 "webpack-virtual-modules@npm:^0.6.2":
   version: 0.6.2
   resolution: "webpack-virtual-modules@npm:0.6.2"
@@ -2373,6 +2787,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #180.

Replaces the watch page's center with a live, Gource-style **activity forest** rendered by [`runewood`](https://github.com/JalapenoLabs/runewood), driven by the agent activity stream Seraphim already emits. First consumer of runewood.

## What's here
- **Pure, unit-tested mapper** (`frontend/src/lib/runewood/mapEvent.ts`): maps each `activity` SSE frame to zero or one `RunewoodEvent` per the issue's table:
  | tool | action | path |
  |---|---|---|
  | Write | create | `file_path` |
  | Edit / NotebookEdit / MultiEdit | modify | `file_path` / `notebook_path` |
  | Read | scan | `file_path` |
  | Grep / Glob | scan | `path` |
  | Bash | pulse | (none; `command` as label) |

  Path normalization strips the leading `/workspace/` so the first segment is the repo, keeps relative paths, and drops anything that escapes the workspace. Actor = task id (stable color); label = task title (Bash prefers the command). Unknown/malformed shapes are dropped, never thrown (the stream-json schema drifts, like the Rust parser's `Other`). **13 Vitest tests.**
- **Forest on the watch page**: created in `onMount` with `theme: 'void'`, `bloom: 'off'`, `cameraMode: 'follow'`, `rootLabel`, the default repo excludes, and a long `actorLingerMs` so a contributor lingers across edit gaps. `runewood` is imported **dynamically** so its WebGL bundle never loads during SSR/build; destroyed on unmount. A `nodeHover` tooltip shows the hovered path.
- **CI highlighting**: while a PR's task is In Review, the files it touched (accumulated from the live stream) are lit via the highlight API, one group per task id, recolored by status (amber under review/CI, green about to merge, red failing) and cleared when the task settles.
- **Layout** (issue comment 2): stats bar + big circle/counters stay up top; below, the live activity log moves to a **1/3-width** left column and the forest fills the **2/3-width** right column.
- **Vitest** added (the frontend had no test runner): a `test` script + a node-environment config for pure-logic tests.

## Validation
- `yarn check` (0 errors), `yarn build`, and `yarn test` (13 pass) all green.
- Frontend-only: no Rust or schema changes.

## Notes for the reviewer
- `runewood@0.0.2` (latest on npm) was confirmed to export every hook this needs (`createRunewood`, `highlight`, `cameraMode`, `nodeHover`, `rootLabel`, `actorLingerMs`, `seed`, `ingest`, `destroy`).
- The optional `GET /activity/history` seed endpoint is **not** included (the issue marks it nice-to-have); the live view populates as events stream, and a future PR can add seeding to also pre-fill a PR's touched files on load.
- CI highlight is driven off the board's per-task `status` (no extra backend), so the color is a faithful-but-coarse proxy for true per-PR CI state; wiring it to `task_pull_requests.ci_state` is a possible refinement.
- The unrelated, recurring self-hosted-runner glitch (API (Rust) job: `cargo: command not found`) may fail this PR's API check despite no Rust changes; that's an operator-side CI fix already flagged.