### PR TITLE
CI: put Cargo on PATH for the self-hosted API (Rust) job (#200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The self-hosted runner has rustup installed under $HOME, but its job
+      # shells don't source ~/.cargo/env, so `cargo` is missing from PATH and the
+      # steps below otherwise fail with "cargo: command not found" (exit 127)
+      # across fmt/clippy/test (issue #200). Prepend Cargo's bin dir to PATH via
+      # $GITHUB_PATH, which applies to every subsequent step.
+      - name: Put Cargo on PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       # The runner is self-hosted, so $HOME survives between jobs while the
       # checked-out tree does not: actions/checkout runs `git clean -ffdx`, which
       # deletes the gitignored api/target every run. Point Cargo's build output at


### PR DESCRIPTION
Closes #200.

## Problem
The **API (Rust)** CI job intermittently failed with `cargo: command not found` (exit 127) across every step (fmt / clippy / test), forcing manual re-runs on otherwise-green PRs (seen on #195 and #199, on both `runner` and `runner2`). The self-hosted runner has rustup installed under `$HOME`, but its job shells don't source `~/.cargo/env`, so `cargo` isn't on PATH.

## Fix
Add an early step to the `api` job that prepends `$HOME/.cargo/bin` to `$GITHUB_PATH`:

```yaml
- name: Put Cargo on PATH
  run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
```

`$GITHUB_PATH` additions apply to every **subsequent** step in the job, so `cargo` is resolvable for fmt, clippy, test, and the migration check regardless of how the runner's interactive shell is configured. It runs right after checkout, before the cargo steps.

This is the in-repo, reviewable form of the fix the issue suggests ("put `$HOME/.cargo/bin` on PATH in a CI step before the cargo commands"). Only the `api` job needs it; the `frontend` job uses Node, and the `images` job compiles Rust inside the `rust:1.88` container (not on the host).

## Validation
- The workflow YAML parses; the new step is correctly ordered before fmt/clippy/test.
- CI-config only: no source, schema, or dependency changes.

Note: this PR's own API (Rust) check will be the first real-world test of the fix.