### PR TITLE
Seed the watch-page activity forest on load (#216)

### DIFF
--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -772,6 +772,17 @@ pub async fn list_repositories_to_sync(pool: &PgPool) -> sqlx::Result<Vec<Reposi
     .await
 }
 
+/// Enabled repos, for seeding the activity forest with their tracked files (#216).
+/// Every enabled repo is cloned flat under `/workspace`, so this is the set whose
+/// `git ls-files` makes up the seeded tree.
+pub async fn list_enabled_repositories(pool: &PgPool) -> sqlx::Result<Vec<Repository>> {
+    sqlx::query_as::<_, Repository>(
+        "SELECT * FROM repositories WHERE enabled = TRUE ORDER BY full_name",
+    )
+    .fetch_all(pool)
+    .await
+}
+
 /// Repos assigned to one railway, for provisioning that railway's container
 /// (issue #203). A repo belongs to exactly one railway, so this is the exact set
 /// to clone into its container. With only `main`, this is every repo.

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -67,6 +67,7 @@ pub fn router(state: AppState) -> Router {
         .route("/board", get(board::get_board))
         .route("/board/stream", get(sse::board_stream))
         .route("/activity/stream", get(sse::activity_stream))
+        .route("/activity/tree", get(repos::tree))
         .route("/tasks", post(tasks::create))
         .route("/tasks/:id", get(tasks::get_task))
         .route("/tasks/:id/issue", get(tasks::get_issue))

--- a/api/src/http/repos.rs
+++ b/api/src/http/repos.rs
@@ -2,7 +2,7 @@
 
 use axum::extract::{Path, State};
 use axum::Json;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -10,11 +10,82 @@ use super::ApiResult;
 use crate::db::models::{RepoDeletionImpact, Repository, ReviewPolicy};
 use crate::db::queries;
 use crate::git;
+use crate::orchestrator::provision::repo_dir_name;
 use crate::state::AppState;
 
 /// `GET /api/v1/repos`
 pub async fn list(State(state): State<AppState>) -> ApiResult<Json<Vec<Repository>>> {
     Ok(Json(queries::list_repositories(&state.db).await?))
+}
+
+/// Soft cap on seeded paths so a huge monorepo cannot return an unbounded payload.
+/// runewood's `exclude` globs and `git ls-files` (which skips gitignored trees like
+/// `node_modules` / `target`) already trim most noise (#216).
+const MAX_TREE_PATHS: usize = 20_000;
+
+/// The tracked-file list used to seed the watch page's activity forest (#216).
+#[derive(Debug, Serialize)]
+pub struct RepoTreeResponse {
+    pub paths: Vec<String>,
+}
+
+/// `GET /api/v1/activity/tree`
+///
+/// Runs `git ls-files` in the workspace for every enabled repo and returns the
+/// tracked paths, each prefixed with the repo's flat clone dir so the first path
+/// segment is the repo, matching the live activity mapper (which strips
+/// `/workspace/`). A repo that is not cloned, or whose exec fails, is skipped
+/// rather than failing the whole request, so the forest still seeds from the rest.
+pub async fn tree(State(state): State<AppState>) -> ApiResult<Json<RepoTreeResponse>> {
+    let repos = queries::list_enabled_repositories(&state.db).await?;
+
+    let mut paths = Vec::new();
+    'repos: for repo in repos {
+        let dir_name = repo_dir_name(&repo.full_name);
+        let dir = format!("/workspace/{dir_name}");
+        // `core.quotePath=false` keeps non-ascii paths literal instead of octal-escaped,
+        // so they match the live event paths exactly.
+        let command = vec![
+            "git".to_string(),
+            "-c".to_string(),
+            "core.quotePath=false".to_string(),
+            "ls-files".to_string(),
+        ];
+
+        let output = match state
+            .workspace
+            .exec_capture(&dir, command, Vec::new())
+            .await
+        {
+            Ok(output) if output.succeeded() => output,
+            Ok(output) => {
+                tracing::debug!(
+                    repo = %repo.full_name,
+                    exit = output.exit_code,
+                    "skipping repo tree: git ls-files failed (repo not cloned?)"
+                );
+                continue;
+            }
+            Err(error) => {
+                tracing::debug!(repo = %repo.full_name, %error, "skipping repo tree: exec failed");
+                continue;
+            }
+        };
+
+        for line in output.output.lines() {
+            let file = line.trim();
+            if file.is_empty() {
+                continue;
+            }
+            if paths.len() >= MAX_TREE_PATHS {
+                tracing::debug!(cap = MAX_TREE_PATHS, "repo tree truncated at the path cap");
+                break 'repos;
+            }
+            paths.push(format!("{dir_name}/{file}"));
+        }
+    }
+
+    Ok(Json(RepoTreeResponse { paths }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -15,7 +15,9 @@ pub mod compose;
 mod network;
 mod placement;
 mod prompt;
-mod provision;
+// `repo_dir_name` (the flat clone-dir convention) is reused by the activity-forest
+// seed endpoint (#216), so this module is crate-visible rather than orchestrator-private.
+pub(crate) mod provision;
 mod railway;
 mod review;
 mod subscription;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -64,6 +64,12 @@ export function getBoard() {
   return apiClient.get('board').json<BoardResponse>()
 }
 
+// The tracked-file list across enabled repos, used to seed the watch page's
+// activity forest so a refresh shows the full repo structure immediately (#216).
+export function getRepoTree() {
+  return apiClient.get('activity/tree').json<{ paths: string[] }>()
+}
+
 // The global scratchpad shown beside the board. Read/saved on its own so the
 // text never rides along with every board poll.
 export function getNotepad() {

--- a/frontend/src/routes/watch/+page.svelte
+++ b/frontend/src/routes/watch/+page.svelte
@@ -12,7 +12,7 @@
   import { cubicOut } from 'svelte/easing'
   import { fly } from 'svelte/transition'
 
-  import { getBoard, getGlobalStats } from '$lib/api'
+  import { getBoard, getGlobalStats, getRepoTree } from '$lib/api'
   import { STATUS_LABELS } from '$lib/types'
   import { isWithinSchedule } from '$lib/schedule'
   import { describeRateLimit } from '$lib/rateLimit'
@@ -533,6 +533,13 @@
             hoverTip = hit ? { path: hit.path, x: hit.screen.x, y: hit.screen.y } : null
           })
           forestReady = true
+          // Seed the full repo structure so a load/refresh shows the whole forest
+          // immediately as dim nodes, instead of building from empty as live events
+          // arrive (issue #216). runewood queues the seed until its renderer is ready,
+          // and applies the same `exclude` path filter to seeded paths.
+          getRepoTree()
+            .then(({ paths }) => forest?.seed(paths))
+            .catch((error) => console.debug('failed to seed activity forest', error))
           // Any PRs already In Review get lit as soon as their files stream in.
           reconcileHighlights()
         })


### PR DESCRIPTION
Closes #216.

The runewood activity forest started empty on every load and only grew as live events arrived, so a browser refresh wiped the tree and the operator never saw the full repo structure. runewood is a stateless renderer (events are its only input); hydration is the host's job, and it already exposes `controller.seed(paths)`. We just were not calling it.

## Backend: a file-list endpoint

`GET /api/v1/activity/tree` returns `{ "paths": [...] }`:

- Runs `git ls-files` (with `core.quotePath=false`) in the workspace for every **enabled** repo via the existing bollard `Workspace` exec, at `/workspace/{repo-dir}`.
- Prefixes each path with the repo's flat clone dir (`repo_dir_name`) so the first path segment is the repo, exactly matching the live activity mapper (which strips `/workspace/`). `git ls-files` only lists tracked files, so `node_modules` / `target` / anything gitignored is skipped for free.
- A repo that is not cloned (or whose exec fails) is skipped rather than failing the whole request, and the result is capped (`MAX_TREE_PATHS = 20000`) to stay bounded.
- Reuses `orchestrator::provision::repo_dir_name` (made crate-visible) so the seed and live paths share one convention.
- New query `list_enabled_repositories` (all enabled repos, the set cloned flat under `/workspace`).

## Frontend: seed on mount

`frontend/src/routes/watch/+page.svelte` fetches the list and calls `forest.seed(paths)` right after the controller is created. runewood queues the seed until its renderer is ready and applies the same `exclude` path filter to seeded paths, so the structure shows immediately as dim nodes and live events light it up as before. Added `getRepoTree()` to `lib/api.ts`.

## Notes

- Optional recent-activity backfill (#180 `/activity/history` replay) is left out as the nice-to-have it is; the structure shows without it.
- Scoped to all enabled repos (what is actually cloned flat in the workspace), so the forest matches what is on disk. The endpoint execs in the default/`main` workspace container; with per-railway containers (#203) a repo on another railway's container would be absent there and is simply skipped. Re-seeding every load is by design (runewood holds no persistence); the endpoint makes it cheap.

## Checks

- `cd api && cargo +1.88 fmt && cargo +1.88 clippy --all-targets && cargo +1.88 test` (123 passed, no new warnings)
- `cd frontend && npm run check` (0 errors) `&& npm run build` (ok)