### PR TITLE
Pre-configure git identity for all workspace clones (#214)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,12 @@ HOST_REPO_DIR=
 # Seeds the initial environment profile on first run (editable later in the UI).
 # Examples: JalapenoLabs, MooreslabAI.
 ORG_NAME=JalapenoLabs
+
+# --- Git identity -------------------------------------------------------------
+# The author/committer the agent's `git commit` uses across every repo cloned
+# flat under /workspace. The workspace entrypoint writes these system-wide so no
+# repo needs per-repo `git config`. Set them to your identity; if left blank a
+# safe fallback ("Seraphim <seraphim@users.noreply.github.com>") is used so a
+# commit never fails with "Author identity unknown".
+GIT_USER_NAME=Alex Navarro
+GIT_USER_EMAIL=alex@navarrotech.net

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,11 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   `current_session_id`; Claude auto-compacts.
 - **Auth:** `CLAUDE_CODE_OAUTH_TOKEN` (subscription) for Claude; mounted host
   `~/.ssh` for `git@` clones; `GH_TOKEN` for HTTPS + octocrab.
+- **Git identity (issue #214):** the entrypoint writes a SYSTEM-wide
+  `git config --system user.name/email` from `GIT_USER_NAME` / `GIT_USER_EMAIL`
+  (`.env`, with a safe `Seraphim` fallback), so the agent can commit in every flat
+  clone under `/workspace` without per-repo setup. A repo-local `user.*` still
+  overrides it.
 - **Local DB validation:** PostgreSQL 17 (client + server) is baked into the
   workspace image, and `pg-ephemeral` boots a throwaway PG17 on `127.0.0.1` and
   prints a `DATABASE_URL` (`export DATABASE_URL="$(pg-ephemeral)"`), so the agent
@@ -304,8 +309,9 @@ docker compose logs api --tail 50
 docker compose down           # stop, keep volumes (scripts/stop.sh)
 ```
 
-`.env` (gitignored) holds the Postgres creds (bootstrap), ports, `SSH_HOME`, and
-`TS_AUTHKEY`. The **Claude OAuth + GitHub tokens are NOT in `.env`** — set them in
+`.env` (gitignored) holds the Postgres creds (bootstrap), ports, `SSH_HOME`,
+`TS_AUTHKEY`, and the agent's git identity (`GIT_USER_NAME` / `GIT_USER_EMAIL`).
+The **Claude OAuth + GitHub tokens are NOT in `.env`** — set them in
 the Settings UI (stored in the DB; a worm scanning `.env` files can't harvest
 them). The Postgres password stays in `.env` because the API needs it to connect
 before it can read anything; for at-rest protection use host disk encryption

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,11 @@ services:
       # Tokens are injected per-exec by the API from the database, not baked in.
       # Writable, persistent config dir for the agent's Claude session/config.
       CLAUDE_CONFIG_DIR: /workspace/.claude
+      # Git identity for the agent's commits in every cloned repo (issue #214).
+      # The entrypoint writes these system-wide; the fallback keeps a commit from
+      # ever failing with "Author identity unknown" when .env omits them.
+      GIT_USER_NAME: ${GIT_USER_NAME:-Seraphim}
+      GIT_USER_EMAIL: ${GIT_USER_EMAIL:-seraphim@users.noreply.github.com}
     volumes:
       # Persistent agent home: cloned repos + the single Claude conversation.
       - workspace-data:/workspace

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -33,6 +33,17 @@ if [ -n "${GH_TOKEN:-}" ]; then
   runuser -u "${AGENT_USER}" -- gh auth setup-git >/dev/null 2>&1 || true
 fi
 
+# --- Git identity so every cloned repo can commit (issue #214) ----------------
+# Without this the agent's `git commit` fails with "Author identity unknown" in any
+# repo that lacks a local user.*; only the per-repo case was ever set before. Write
+# it SYSTEM-wide (/etc/gitconfig) so it covers every user and every `docker exec`,
+# across all the flat clones under /workspace, with no per-repo setup. The values
+# are deployment-specific (config, not code): supplied via `.env` (GIT_USER_NAME /
+# GIT_USER_EMAIL), with a safe fallback so a commit never hard-fails when unset. A
+# repo-local `user.*` still overrides this when a task needs a different identity.
+git config --system user.name "${GIT_USER_NAME:-Seraphim}"
+git config --system user.email "${GIT_USER_EMAIL:-seraphim@users.noreply.github.com}"
+
 # --- Docker: let the non-root agent use the mounted host socket --------------
 # docker-compose bind-mounts the host's /var/run/docker.sock so the agent can run
 # docker (and Earthly) for the repos it works on, e.g. `docker run postgres:17`.


### PR DESCRIPTION
Closes #214.

## Problem

The agent's `git commit` failed with "Author identity unknown" in any repo that lacked a local `user.*` (only Seraphim's clone had one set). There was no global identity in the workspace, so the first commit in a fresh sibling clone (e.g. Plunder) errored out.

## Fix

Set the identity once, system-wide, at workspace boot, so every repo cloned flat under `/workspace` can commit with no per-repo setup.

- **`workspace/entrypoint.sh`**: writes `git config --system user.name/email` (root, `/etc/gitconfig`) on every container start, so it applies to every user and every `docker exec`. A repo-local `user.*` still overrides it when a task needs a different identity.
- **Config, not code** (per the "config-only differences" principle): the values come from `GIT_USER_NAME` / `GIT_USER_EMAIL` in `.env`, plumbed through `docker-compose.yml`. A safe fallback (`Seraphim <seraphim@users.noreply.github.com>`) is applied both in compose and the entrypoint, so a commit never hard-fails when they are unset.
- **`.env.example`**: documents the two vars, defaulting to the JalapenoLabs identity (Alex Navarro) from the issue.
- **`CLAUDE.md`**: records the mechanism (the `.env` contents line and the workspace-auth section).

Writing it system-wide rather than baking a name into the image keeps the same image working for both the JalapenoLabs and MooreslabAI deployments (they just differ by `.env`).

## Checks

Only shell/compose/env/docs changed (no Rust or frontend source), so the `api` and `frontend` CI jobs are unaffected. Validated locally:
- `bash -n workspace/entrypoint.sh` (syntax OK)
- `docker compose --env-file .env.example config` resolves `GIT_USER_NAME` / `GIT_USER_EMAIL` correctly with no errors.