### PR TITLE
Surface repo issue-sync failures with a banner and notification (#213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,12 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 - **`repositories`** — `full_name`, `clone_url`, `default_branch`,
   `branch_template`, `setup_script` (per-repo setup), `instructions`,
   `review_policy` (NULL = inherit default), `enabled`, `sync_issues` (poll this
-  repo for issues), `issue_labels` (label filter). There is **no** separate
-  issue-source entity; a repo with `sync_issues` is its own source. Bulk
-  onboarding is the one-shot **Import from org** action (`POST /repos/import-org`).
+  repo for issues), `issue_labels` (label filter), and `sync_error` /
+  `sync_error_at` (issue #213: the last issue-sync failure for the repo, NULL when
+  the most recent sync succeeded; set when listing the repo's issues fails, cleared
+  on the next clean sync). There is **no** separate issue-source entity; a repo
+  with `sync_issues` is its own source. Bulk onboarding is the one-shot **Import
+  from org** action (`POST /repos/import-org`).
 - **`tasks`** — the cards: `source_kind`, `external_id`, `repo_id`, `title`,
   `board_column`, `position` (fractional rank), `status`, `branch`, `pr_url`,
   `error`, `hold`, `session_id`.
@@ -227,6 +230,14 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    never clobber human curation, and a card the agent is mid-work on
    (`in_progress`) is left alone. The poll also pulls recently-closed issues
    (`git::list_recently_closed_issues`) since the open list can't reveal a closure.
+   A repo whose issue list fails no longer fails silently (issue #213): each repo
+   syncs as its own fallible unit (`sync_repo_issues`), and a failure records a
+   per-repo `sync_error` (with the HTTP status and, for 403/404, a "grant the token
+   access" hint), shows a persistent dismissible board banner + the error on the
+   repos page, and emits a one-time notification on the success->error transition
+   (`ServerEvent::RepoSyncError`). The next clean sync clears it; one repo's failure
+   never stops the others. (The webhook path delivers a single pre-fetched issue, so
+   it has no per-repo listing step to fail.)
 2. **agent** — single-threaded: when not paused, the config repo is healthy, and
    inside the availability schedule, it picks work by priority — (a) **resume** a
    task whose question the user just answered (`waiting_for_input` → deliver the

--- a/api/migrations/0040_repo_sync_error.sql
+++ b/api/migrations/0040_repo_sync_error.sql
@@ -1,0 +1,7 @@
+-- Per-repo issue-sync failures, surfaced loudly instead of only logged (issue #213).
+-- `sync_error` holds the last failure message (NULL when the most recent sync
+-- succeeded); `sync_error_at` stamps when it was recorded. Cleared on the next
+-- successful sync for the repo.
+ALTER TABLE repositories
+    ADD COLUMN sync_error    TEXT,
+    ADD COLUMN sync_error_at TIMESTAMPTZ;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -377,8 +377,22 @@ pub struct Repository {
     pub sync_issues: bool,
     /// Only sync issues carrying all of these labels (empty = no filter).
     pub issue_labels: Vec<String>,
+    /// The last issue-sync failure for this repo (issue #213), or `None` when the
+    /// most recent sync succeeded. Cleared on the next successful sync.
+    pub sync_error: Option<String>,
+    /// When [`Self::sync_error`] was recorded.
+    pub sync_error_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// A repository whose last issue sync failed (issue #213), for the board banner.
+/// Distinct from [`Repository`] so the payload carries only what the banner needs.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct RepoSyncError {
+    pub full_name: String,
+    pub sync_error: String,
+    pub sync_error_at: DateTime<Utc>,
 }
 
 /// What a repository delete will purge, so the UI can spell it out before the

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -15,8 +15,8 @@ use super::models::{
     AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials, EnvSuggestion, EnvVar,
     EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel,
     PendingPlacement, PendingQuestion, Question, QuestionOption, QuestionStatus, Railway,
-    RepoDeletionImpact, Repository, ReviewPolicy, Settings, SourceKind, StatsAggregate, Task,
-    TaskColumn, TaskPullRequest, TaskStatus, Turn,
+    RepoDeletionImpact, RepoSyncError, Repository, ReviewPolicy, Settings, SourceKind,
+    StatsAggregate, Task, TaskColumn, TaskPullRequest, TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -767,6 +767,36 @@ pub async fn list_repositories(pool: &PgPool) -> sqlx::Result<Vec<Repository>> {
 pub async fn list_repositories_to_sync(pool: &PgPool) -> sqlx::Result<Vec<Repository>> {
     sqlx::query_as::<_, Repository>(
         "SELECT * FROM repositories WHERE sync_issues = TRUE AND enabled = TRUE ORDER BY full_name",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Records a repo's issue-sync failure (issue #213), stamping the time so the UI
+/// can show when it began failing.
+pub async fn set_repo_sync_error(pool: &PgPool, id: Uuid, message: &str) -> sqlx::Result<()> {
+    sqlx::query("UPDATE repositories SET sync_error = $2, sync_error_at = now() WHERE id = $1")
+        .bind(id)
+        .bind(message)
+        .execute(pool)
+        .await
+        .map(|_| ())
+}
+
+/// Clears a repo's recorded issue-sync failure after a successful sync (issue #213).
+pub async fn clear_repo_sync_error(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
+    sqlx::query("UPDATE repositories SET sync_error = NULL, sync_error_at = NULL WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .map(|_| ())
+}
+
+/// Repos whose last issue sync failed, for the board's persistent banner (issue #213).
+pub async fn list_repo_sync_errors(pool: &PgPool) -> sqlx::Result<Vec<RepoSyncError>> {
+    sqlx::query_as::<_, RepoSyncError>(
+        "SELECT full_name, sync_error, sync_error_at FROM repositories \
+         WHERE sync_error IS NOT NULL ORDER BY full_name",
     )
     .fetch_all(pool)
     .await

--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -13,7 +13,9 @@ use uuid::Uuid;
 use tracing::{info, warn};
 
 use super::ApiResult;
-use crate::db::models::{HeartAttack, Railway, Settings, SourceKind, Task, TaskColumn, TaskStatus};
+use crate::db::models::{
+    HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn, TaskStatus,
+};
 use crate::db::queries;
 use crate::git;
 use crate::orchestrator;
@@ -32,6 +34,9 @@ pub struct BoardResponse {
     /// Unacknowledged heart attacks (turns that died), newest first, so the board
     /// can alert the operator with the diagnostic detail until they clear them.
     pub heart_attacks: Vec<HeartAttack>,
+    /// Repos whose last issue sync failed (issue #213), so the board can show a
+    /// persistent banner naming each failing repo and why until it recovers.
+    pub repo_sync_errors: Vec<RepoSyncError>,
 }
 
 /// `GET /api/v1/board` - every card, the org/pause settings, per-card counts of
@@ -47,12 +52,14 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
         .into_iter()
         .collect();
     let heart_attacks = queries::list_unacknowledged_heart_attacks(&state.db).await?;
+    let repo_sync_errors = queries::list_repo_sync_errors(&state.db).await?;
     Ok(Json(BoardResponse {
         tasks,
         settings,
         railways,
         suggestion_counts,
         heart_attacks,
+        repo_sync_errors,
     }))
 }
 

--- a/api/src/http/sse.rs
+++ b/api/src/http/sse.rs
@@ -30,6 +30,7 @@ pub async fn board_stream(
                 Ok(
                     ServerEvent::Task { .. }
                     | ServerEvent::Notification { .. }
+                    | ServerEvent::RepoSyncError { .. }
                     | ServerEvent::HeartAttack { .. }
                     | ServerEvent::TaskFinished { .. }
                     | ServerEvent::Compose { .. }
@@ -80,6 +81,11 @@ pub async fn notification_stream(
                     });
                     let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
                     yield Ok(Event::default().event("task_finished").data(data));
+                }
+                Ok(ServerEvent::RepoSyncError { repo, message }) => {
+                    let payload = serde_json::json!({ "repo": repo, "message": message });
+                    let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+                    yield Ok(Event::default().event("repo_sync_error").data(data));
                 }
                 Ok(ServerEvent::Board) => {
                     yield Ok(Event::default().event("refresh").data("{}"));

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -261,40 +261,28 @@ pub async fn sync_once(state: &AppState) -> Result<()> {
     let mut changed = false;
 
     for repo in &repos {
-        let Some((owner, name)) = repo.full_name.split_once('/') else {
-            warn!(repo = %repo.full_name, "repo full name is not owner/repo");
-            continue;
-        };
-
-        let issues = match git::list_open_issues(&github, owner, name, &repo.issue_labels).await {
-            Ok(issues) => issues,
-            Err(error) => {
-                warn!(error = %error, repo = %repo.full_name, "failed to list issues");
-                continue;
-            }
-        };
-
-        // GitHub lists newest first; insert oldest first so the newest issue ends
-        // up at the very top of Available (each new card is placed above the last).
-        for issue in issues.into_iter().rev() {
-            // Sync only ever lists open issues, so any issue we see here is open.
-            upsert_github_issue(state, repo.id, &issue, "open").await?;
-            changed = true;
-        }
-
-        // The open list above can't reveal an issue closed outside Seraphim (it
-        // simply drops out), so reconcile recently-closed issues separately and
-        // move any we still track to Done.
-        match git::list_recently_closed_issues(&github, owner, name, &repo.issue_labels).await {
-            Ok(numbers) => {
-                for number in numbers {
-                    if reflect_closed_github_issue(state, repo.id, &number.to_string()).await? {
-                        changed = true;
-                    }
+        // One repo's failure never stops the others (issue #213): sync each repo as
+        // its own fallible unit, then record or clear its per-repo sync error.
+        match sync_repo_issues(state, &github, repo, &mut changed).await {
+            Ok(()) => {
+                // A clean sync clears any prior failure, so the board banner clears
+                // itself on the next cycle with no restart needed.
+                if repo.sync_error.is_some() {
+                    queries::clear_repo_sync_error(&state.db, repo.id).await?;
+                    changed = true;
                 }
             }
             Err(error) => {
-                warn!(error = %error, repo = %repo.full_name, "failed to list closed issues");
+                let (status, detail) = github_error_parts(&error);
+                let message = format_repo_sync_error(&repo.full_name, status, &detail);
+                warn!(error = %error, repo = %repo.full_name, "failed to sync repo issues");
+                queries::set_repo_sync_error(&state.db, repo.id, &message).await?;
+                // Notify once, only on the success -> error transition, to avoid a
+                // toast every failing cycle; the banner carries the ongoing state.
+                if repo.sync_error.is_none() {
+                    state.notify_repo_sync_error(repo.full_name.clone(), message);
+                }
+                changed = true;
             }
         }
     }
@@ -350,6 +338,71 @@ pub async fn sync_once(state: &AppState) -> Result<()> {
         state.notify_board();
     }
     Ok(())
+}
+
+/// Syncs one repo's issues as a single fallible unit (issue #213): open issues into
+/// Available, then reconcile recently-closed ones to Done. Returning `Err` lets the
+/// caller record a per-repo sync failure (and notify) without aborting the whole
+/// pass; an `Ok` means the repo synced cleanly so any prior failure can be cleared.
+async fn sync_repo_issues(
+    state: &AppState,
+    github: &octocrab::Octocrab,
+    repo: &Repository,
+    changed: &mut bool,
+) -> Result<()> {
+    let (owner, name) = repo
+        .full_name
+        .split_once('/')
+        .ok_or_else(|| eyre!("repo full name is not owner/repo: {}", repo.full_name))?;
+
+    let issues = git::list_open_issues(github, owner, name, &repo.issue_labels).await?;
+    // GitHub lists newest first; insert oldest first so the newest issue ends up at
+    // the very top of Available (each new card is placed above the last).
+    for issue in issues.into_iter().rev() {
+        // Sync only ever lists open issues, so any issue we see here is open.
+        upsert_github_issue(state, repo.id, &issue, "open").await?;
+        *changed = true;
+    }
+
+    // The open list can't reveal an issue closed outside Seraphim (it simply drops
+    // out), so reconcile recently-closed issues and move any tracked ones to Done.
+    let numbers = git::list_recently_closed_issues(github, owner, name, &repo.issue_labels).await?;
+    for number in numbers {
+        if reflect_closed_github_issue(state, repo.id, &number.to_string()).await? {
+            *changed = true;
+        }
+    }
+
+    Ok(())
+}
+
+/// Extracts the GitHub HTTP status and message from a sync error's cause chain, or
+/// `(None, the full chain text)` for a non-GitHub error (issue #213).
+fn github_error_parts(error: &eyre::Report) -> (Option<u16>, String) {
+    for cause in error.chain() {
+        if let Some(octocrab::Error::GitHub { source, .. }) =
+            cause.downcast_ref::<octocrab::Error>()
+        {
+            return (Some(source.status_code.as_u16()), source.message.clone());
+        }
+    }
+    (None, format!("{error:#}"))
+}
+
+/// Builds the operator-facing issue-sync error message for a repo (issue #213).
+/// 403/404 get an actionable hint: a fine-grained PAT that cannot see a private repo
+/// gets 404 (not 403) on its issue list, so "grant the token access" is the fix for
+/// both. Other statuses (and non-GitHub errors) carry the underlying detail.
+fn format_repo_sync_error(repo: &str, status: Option<u16>, detail: &str) -> String {
+    match status {
+        Some(status @ (403 | 404)) => format!(
+            "GitHub returned {status} listing issues for {repo}. The token likely lacks access to \
+             this repo: add it to the PAT's selected repositories, or switch the PAT to all \
+             repositories."
+        ),
+        Some(status) => format!("GitHub returned {status} listing issues for {repo}: {detail}"),
+        None => format!("Could not sync issues for {repo}: {detail}"),
+    }
 }
 
 /// The position that places a brand-new card at the top of `column` (just above
@@ -2718,6 +2771,33 @@ mod tests {
     fn slugify_is_branch_safe() {
         assert_eq!(slugify("Fix the Login Bug!"), "fix-the-login-bug");
         assert_eq!(slugify("   spaces   "), "spaces");
+    }
+
+    #[test]
+    fn sync_error_message_hints_on_access_denied() {
+        // The 404 a fine-grained PAT returns for a repo it cannot see, and the 403
+        // for a denied one, both get the same actionable "grant the token access" hint.
+        for status in [403, 404] {
+            let message = format_repo_sync_error("JalapenoLabs/Plunder", Some(status), "Not Found");
+            assert!(message.contains("JalapenoLabs/Plunder"));
+            assert!(message.contains(&status.to_string()));
+            assert!(message.contains("selected repositories"));
+        }
+    }
+
+    #[test]
+    fn sync_error_message_keeps_detail_for_other_failures() {
+        // A non-access status surfaces the underlying GitHub message, not the hint.
+        let other = format_repo_sync_error("o/r", Some(500), "Server Error");
+        assert!(other.contains("500"));
+        assert!(other.contains("Server Error"));
+        assert!(!other.contains("selected repositories"));
+
+        // A non-GitHub error (no status) still names the repo and carries the cause.
+        let none = format_repo_sync_error("o/r", None, "connection reset");
+        assert!(none.contains("o/r"));
+        assert!(none.contains("connection reset"));
+        assert!(!none.contains("selected repositories"));
     }
 
     #[test]

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -541,6 +541,8 @@ mod tests {
             enabled: true,
             sync_issues: false,
             issue_labels: Vec::new(),
+            sync_error: None,
+            sync_error_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -38,6 +38,10 @@ pub enum ServerEvent {
         task_title: String,
         prompt: String,
     },
+    /// A repo's issue sync started failing (success -> error transition, issue
+    /// #213); drives a one-time alert toast and native notification. The ongoing
+    /// state is carried by the persistent board banner, not repeated per cycle.
+    RepoSyncError { repo: String, message: String },
     /// A turn died mid-flight (a "heart attack") and the defibrillator handled it;
     /// drives an alert toast and native notification so the operator notices.
     HeartAttack {
@@ -384,6 +388,15 @@ impl AppState {
             task_title,
             prompt,
         });
+    }
+
+    /// Announces a repo's issue-sync failure (issue #213), so the UI alerts the
+    /// operator once on the success -> error transition. The persistent board
+    /// banner (driven by [`Self::notify_board`]) carries the ongoing state.
+    pub fn notify_repo_sync_error(&self, repo: String, message: String) {
+        let _ = self
+            .events
+            .send(ServerEvent::RepoSyncError { repo, message });
     }
 
     /// Announces a heart attack so the UI alerts the operator immediately, in

--- a/frontend/src/lib/components/Notifications.svelte
+++ b/frontend/src/lib/components/Notifications.svelte
@@ -25,8 +25,9 @@
     taskId: string | null
     taskTitle: string
     prompt: string
-    // 'question' is the agent asking for input; 'heart_attack' is a dead turn.
-    kind: 'question' | 'heart_attack'
+    // 'question' is the agent asking for input; 'heart_attack' is a dead turn;
+    // 'repo_sync_error' is a repo whose issue sync started failing (issue #213).
+    kind: 'question' | 'heart_attack' | 'repo_sync_error'
   }
 
   function loadIds(key: string): Set<string> {
@@ -203,6 +204,15 @@
     playSound('attention')
   }
 
+  // A repo's issue sync started failing (issue #213). Fires once on the
+  // success-to-error transition; the board's banner persists the ongoing state.
+  function handleRepoSyncError(event: MessageEvent) {
+    const data = JSON.parse(event.data) as { repo: string; message: string }
+    pushToast(null, `Issue sync failed: ${data.repo}`, data.message, 'repo_sync_error')
+    notifyNatively(`Issue sync failed: ${data.repo}`, data.message)
+    playSound('attention')
+  }
+
   // A task finished (auto-merged to Done). Sound-only: the board already reflects
   // it, so no toast, just the completion chime.
   function handleTaskFinished() {
@@ -223,6 +233,7 @@
     eventSource = new EventSource('/api/v1/notifications/stream')
     eventSource.addEventListener('notification', handleNotification)
     eventSource.addEventListener('heart_attack', handleHeartAttack)
+    eventSource.addEventListener('repo_sync_error', handleRepoSyncError)
     eventSource.addEventListener('task_finished', handleTaskFinished)
     eventSource.addEventListener('refresh', () => {
       refresh()
@@ -320,7 +331,7 @@
   {#each toasts as toast (toast.id)}
     <div
       class="pointer-events-auto flex items-start overflow-hidden rounded-lg border bg-card shadow-2xl {toast.kind ===
-      'heart_attack'
+        'heart_attack' || toast.kind === 'repo_sync_error'
         ? 'border-destructive/60'
         : 'border-warning/50'}"
     >
@@ -332,6 +343,10 @@
         {#if toast.kind === 'heart_attack'}
           <span class="text-[10px] font-bold uppercase tracking-wide text-destructive"
             >Agent heart attack</span
+          >
+        {:else if toast.kind === 'repo_sync_error'}
+          <span class="text-[10px] font-bold uppercase tracking-wide text-destructive"
+            >Issue sync failed</span
           >
         {:else}
           <span class="text-[10px] font-bold uppercase tracking-wide text-warning"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -286,8 +286,19 @@ export type Repository = {
   enabled: boolean
   sync_issues: boolean
   issue_labels: string[]
+  // The last issue-sync failure for this repo (issue #213), or null when the most
+  // recent sync succeeded. Cleared automatically on the next successful sync.
+  sync_error: string | null
+  sync_error_at: string | null
   created_at: string
   updated_at: string
+}
+
+// A repo whose last issue sync failed (issue #213), for the board's sync banner.
+export type RepoSyncError = {
+  full_name: string
+  sync_error: string
+  sync_error_at: string
 }
 
 // What deleting a repository will purge, shown in the delete confirmation.
@@ -484,6 +495,8 @@ export type BoardResponse = {
   suggestion_counts: Record<string, number>
   // Unacknowledged heart attacks (dead turns), newest first, for the alert banner.
   heart_attacks: HeartAttack[]
+  // Repos whose last issue sync failed (issue #213), for a persistent banner.
+  repo_sync_errors: RepoSyncError[]
 }
 
 // A pull request the task has opened. A task may span several repos, so it can

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { DndEvent } from 'svelte-dnd-action'
-  import type { HeartAttack, Railway, Settings, Task, TaskColumn } from '$lib/types'
+  import type { HeartAttack, Railway, RepoSyncError, Settings, Task, TaskColumn } from '$lib/types'
 
   import { onMount, onDestroy } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
@@ -61,6 +61,15 @@
   // Unacknowledged heart attacks (dead turns) the defibrillator recorded; shown
   // as a dismissible alert banner so the operator notices and can read the logs.
   let heartAttacks = $state<HeartAttack[]>([])
+  // Repos whose last issue sync failed (issue #213). The banner persists while a
+  // repo is failing; `dismissedSyncRepos` hides one the operator has acknowledged,
+  // and a repo is un-dismissed automatically once it recovers (so a later failure
+  // surfaces again). The one-time toast is driven separately by the SSE transition.
+  let repoSyncErrors = $state<RepoSyncError[]>([])
+  let dismissedSyncRepos = new SvelteSet<string>()
+  const visibleSyncErrors = $derived(
+    repoSyncErrors.filter((repo) => !dismissedSyncRepos.has(repo.full_name))
+  )
   // Every railway (swimlane), already ordered `main` first then by rank.
   let railways = $state<Railway[]>([])
   // The board cards, grouped first by railway id, then by column. One array per
@@ -347,6 +356,15 @@
     railways = board.railways
     suggestionCounts = board.suggestion_counts
     heartAttacks = board.heart_attacks
+    repoSyncErrors = board.repo_sync_errors
+    // Forget a dismissal once its repo is no longer failing, so a fresh failure on
+    // that repo later raises the banner again instead of staying hidden.
+    const failing = new Set(repoSyncErrors.map((repo) => repo.full_name))
+    for (const name of dismissedSyncRepos) {
+      if (!failing.has(name)) {
+        dismissedSyncRepos.delete(name)
+      }
+    }
     repoNames = Object.fromEntries(repos.map((repo) => [repo.id, repo.full_name]))
 
     // Group every card by railway, then by column. A lane with no cards still gets
@@ -594,6 +612,33 @@
       </Button>
     </Alert.Root>
   {/if}
+
+  {#each visibleSyncErrors as repo (repo.full_name)}
+    <!-- A repo's issue sync is failing (issue #213). Persist the reason until it
+         recovers (it clears itself on the next successful sync), with a dismiss for
+         operators who have read it. -->
+    <Alert.Root variant="destructive" class="mx-6 mt-4 flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <Alert.Title class="flex items-center gap-1.5">
+          <RefreshCw class="size-4 flex-none" />
+          Issue sync failed: {repo.full_name}
+        </Alert.Title>
+        <Alert.Description class="break-words">
+          {repo.sync_error}
+        </Alert.Description>
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        class="flex-none"
+        title="Dismiss"
+        aria-label="Dismiss sync error"
+        onclick={() => dismissedSyncRepos.add(repo.full_name)}
+      >
+        <X class="size-4" />
+      </Button>
+    </Alert.Root>
+  {/each}
 
   {#if settings?.usage_paused_until && new Date(settings.usage_paused_until).getTime() > Date.now()}
     <Alert.Root class="mx-6 mt-4 border-warning/40">

--- a/frontend/src/routes/repos/+page.svelte
+++ b/frontend/src/routes/repos/+page.svelte
@@ -177,7 +177,14 @@
               {/if}
               {#if repo.setup_script.trim()}<span>setup script</span>{/if}
               {#if !repo.sync_issues}<span class="text-muted-foreground/70">sync off</span>{/if}
+              {#if repo.sync_issues && !repo.sync_error}<span class="text-success">syncing</span>{/if}
             </div>
+            <!-- Issue-sync failure, surfaced inline so it is not hidden (issue #213). -->
+            {#if repo.sync_error}
+              <div class="mt-0.5 text-xs break-words text-destructive">
+                Issue sync failing: {repo.sync_error}
+              </div>
+            {/if}
           </div>
 
           <!-- Actions. -->


### PR DESCRIPTION
Closes #213.

Issue sync used to only log a WARN and fail silently when a repo's issue list failed (e.g. a fine-grained PAT that cannot see a private repo gets a 404), so the operator had no idea a repo was not syncing. This surfaces failures loudly, per-repo.

## Backend
- **Per-repo sync error.** New `repositories.sync_error` / `sync_error_at` columns (migration `0040`). Each repo now syncs as its own fallible unit (`sync_repo_issues`); on failure the loop records a readable message that names the repo and the HTTP status, with an actionable hint for the access-denied case (403/404: "the token likely lacks access to this repo: add it to the PAT's selected repositories, or switch the PAT to all repositories"). It is cleared on the next successful sync. One repo's failure still never stops the rest of the pass.
- **One-time notification.** `ServerEvent::RepoSyncError` fires a toast + native notification only on the success -> error transition (when `sync_error` was previously NULL), not every failing cycle.
- **Board payload.** `repo_sync_errors` added to `BoardResponse`.
- **Pure + tested.** `format_repo_sync_error` (the message/hint builder) and `github_error_parts` (pull the status/message out of the octocrab error in the eyre chain) are split out; the message builder is unit-tested (403/404 hint, other-status detail, non-GitHub error).

## Frontend
- **Board banner.** A persistent, dismissible banner per failing repo (in the style of the config-repo-error and heart-attack banners), naming the repo and the reason. It auto-clears when the error resolves; a dismissal is forgotten once that repo recovers, so a later failure raises the banner again.
- **Notification.** The Notifications component handles the `repo_sync_error` SSE event (alert toast + native notification + attention sound).
- **Repositories page.** Each repo shows its sync status (a green "syncing" hint when healthy) and the error inline when present.

## Acceptance
- Adding a repo the token cannot read raises a visible banner plus a one-time notification within a sync cycle, naming the repo and the reason.
- Fixing access clears the banner automatically on the next cycle, no restart.
- Other repos keep syncing throughout (each repo is an independent fallible unit).

## Notes
- The webhook path delivers a single pre-fetched issue, so it has no per-repo issue-listing step to fail; the poll path (the stated priority) is the one covered.

## Checks
- `cd api && cargo +1.88 fmt && cargo +1.88 clippy --all-targets && cargo +1.88 test` (125 passed, +2 new; 0 clippy errors)
- `cd frontend && npm run check` (0 errors) `&& npm run build` (ok)