### PR TITLE
Preinstall Playwright Chromium and OS deps in the workspace image (#215)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,14 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   can verify migrations / integration tests against the same major as CI and
   prod without a daemon. The entrypoint also aligns the agent to the mounted host
   Docker socket's group, so `docker` / `earthly` work without `sudo` too.
+- **Browser e2e (issue #215):** Playwright's Chromium plus its OS libraries are
+  baked into the workspace image, into a shared world-readable
+  `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` (the official Playwright-in-Docker
+  convention) so any user finds it, so the agent can run Plunder's `yarn test:e2e`
+  immediately with no per-run `playwright install --with-deps`. The browser is
+  pinned to the Playwright version Plunder uses (`PLAYWRIGHT_VERSION` build arg);
+  if that drifts, only the browser re-downloads on first run, never the slow apt
+  dependency step.
 
 ### The orchestrator loops (`api/src/orchestrator/mod.rs`)
 1. **sync** — polls every repo with `sync_issues` for open issues and upserts

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -3,9 +3,10 @@
 # Based on Microsoft's universal devcontainer image: Python, Node (via nvm), Go,
 # Java, .NET, PHP, Ruby, plus version managers, out of the box. On top we add the
 # tools the agents need that it doesn't ship: Rust/Cargo, the Claude Code CLI, the
-# GitHub CLI, a Docker client, Earthly, and the org cloud CLIs (jira, doctl,
-# gcloud, wrangler, bunny). Work runs as the image's non-root `codespace` user;
-# the API drives it via `docker exec`, the container itself just idles.
+# GitHub CLI, a Docker client, Earthly, the org cloud CLIs (jira, doctl, gcloud,
+# wrangler, bunny), and Playwright's Chromium for Plunder's e2e suite. Work runs
+# as the image's non-root `codespace` user; the API drives it via `docker exec`,
+# the container itself just idles.
 
 FROM mcr.microsoft.com/devcontainers/universal:latest
 
@@ -98,6 +99,26 @@ RUN node_dir="$(runuser -l codespace -c 'command -v node' | xargs dirname)" \
     && for b in node npm npx corepack yarn pnpm claude wrangler bunny; do \
          [ -x "$node_dir/$b" ] && ln -sf "$node_dir/$b" "/usr/local/bin/$b"; \
        done; true
+
+# --- Playwright Chromium for Plunder's e2e suite (issue #215) -----------------
+# Plunder's `yarn test:e2e` drives headless Chromium through Playwright. Baking
+# the browser plus its OS libraries into the image lets an agent reproduce and fix
+# e2e failures on a fresh workspace immediately, instead of spending minutes on
+# `playwright install --with-deps chromium` every run (a ~114MB browser plus the
+# apt libs headless-shell needs, e.g. libatk-1.0.so.0, which otherwise fails to
+# launch with "error while loading shared libraries").
+#
+# Browsers live in a shared, world-readable path (the official Playwright-in-Docker
+# convention) and the matching env var is baked in, so Plunder's own Playwright
+# finds the baked build no matter which user runs it. Chromium builds are pinned to
+# a Playwright version, so we track the version Plunder uses; if Plunder later bumps
+# Playwright, only the small browser re-downloads on first run (into this writable
+# path), while the slow, root-only apt dependency step here always applies.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ARG PLAYWRIGHT_VERSION=1.61.0
+RUN npx -y "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium \
+    && chmod -R a+w /ms-playwright \
+    && rm -rf /var/lib/apt/lists/*
 
 # --- Seraphim agent helpers (post to the API; env injected per turn) ---------
 COPY seraphim-suggest /usr/local/bin/seraphim-suggest


### PR DESCRIPTION
Closes #215.

## Problem
Verifying Plunder's e2e suite (`yarn test:e2e`) on a fresh workspace required `yarn playwright install chromium` followed by `sudo yarn playwright install-deps chromium`. Without the OS libraries, chromium-headless-shell fails to launch with `error while loading shared libraries: libatk-1.0.so.0`. That cost a few minutes (a ~114MB browser plus apt deps) on every run before an agent could reproduce or fix an e2e failure.

## Change
Bake Playwright's Chromium plus its OS dependencies into the workstation image (`workspace/Dockerfile`):

- `npx playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium`, run as root so the apt dependency step (the slow, sudo-needing part) succeeds. This installs the full Chromium and the headless shell that Plunder's e2e actually launches.
- Pinned to `PLAYWRIGHT_VERSION=1.61.0`, the version Plunder currently uses (`@playwright/test ^1.61.0`), exposed as a build arg so it is easy to bump. Chromium builds are Playwright-version-specific; if Plunder drifts, only the small browser re-downloads on first run, never the apt step.
- Browsers install into a shared, world-readable `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` (the official Playwright-in-Docker convention), baked as an env var so Plunder's own Playwright finds the build no matter which user runs it. The path is left writable so a drifted version can add its build there.
- Placed above the frequently-changing `COPY` layers so the heavy browser layer stays cached across helper-script edits.

Documented in `CLAUDE.md` alongside the other baked-in workspace tooling.

## Validation
Dockerfile + docs only; no Rust or frontend code changed, so the cargo and npm CI jobs are unaffected. The workstation image is built only at deployment, not in CI. Verified the pinned CLI form is valid (`npx playwright@1.61.0 install --help` lists `--with-deps`).