### PR TITLE
Preinstall actionlint in the workstation image (#220)

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -3,9 +3,9 @@
 # Based on Microsoft's universal devcontainer image: Python, Node (via nvm), Go,
 # Java, .NET, PHP, Ruby, plus version managers, out of the box. On top we add the
 # tools the agents need that it doesn't ship: Rust/Cargo, the Claude Code CLI, the
-# GitHub CLI, a Docker client, Earthly, and the org cloud CLIs (jira, doctl,
-# gcloud, wrangler, bunny). Work runs as the image's non-root `codespace` user;
-# the API drives it via `docker exec`, the container itself just idles.
+# GitHub CLI, a Docker client, Earthly, actionlint, and the org cloud CLIs (jira,
+# doctl, gcloud, wrangler, bunny). Work runs as the image's non-root `codespace`
+# user; the API drives it via `docker exec`, the container itself just idles.
 
 FROM mcr.microsoft.com/devcontainers/universal:latest
 
@@ -50,6 +50,18 @@ RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${
 RUN curl -fsSL https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 \
         -o /usr/local/bin/earthly \
     && chmod +x /usr/local/bin/earthly
+
+# --- actionlint (GitHub Actions workflow linter) -----------------------------
+# Lets the agent validate `.github/workflows/*.yml` locally (bad `${{ }}`
+# expressions, unknown contexts, shell mistakes) before pushing, instead of
+# fetching the release binary ad hoc each time (issue #220). Pinned, prebuilt
+# release tarball (the binary sits at the archive root), matching the gh/doctl
+# pattern above; no Go toolchain needed.
+ARG ACTIONLINT_VERSION=1.7.12
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz \
+    && tar -xzf /tmp/actionlint.tgz -C /tmp actionlint \
+    && install -m 0755 /tmp/actionlint /usr/local/bin/actionlint \
+    && rm -rf /tmp/actionlint*
 
 # --- Rust / Cargo (not in the universal image) -------------------------------
 # Installed system-wide so every user/shell finds it on PATH; the registry/cache


### PR DESCRIPTION
Closes #220.

## Problem
Linting GitHub Actions workflows (catching bad `${{ }}` expressions, unknown contexts, and shell mistakes before pushing) needs [actionlint](https://github.com/rhysd/actionlint), which the workstation image did not ship. Validating a workflow edit meant downloading the release binary ad hoc (via `download-actionlint.bash`) every time.

## Change
Bake `actionlint` into the workstation image (`workspace/Dockerfile`):

- Installed from its pinned, prebuilt release tarball (the `actionlint` binary sits at the archive root), mirroring the existing `gh`/`doctl` release-tarball pattern. No Go toolchain required.
- Pinned via an `ACTIONLINT_VERSION=1.7.12` build arg for reproducible image builds, matching how `DOCKER_VERSION` and the Rust toolchain are pinned (rather than `latest`/`@latest`).
- Placed alongside the other dev CLIs, above the Rust layer.
- Header comment updated to list actionlint among the baked-in tools.

Now `actionlint .github/workflows/*.yml` works out of the box on a fresh workspace.

## Validation
Dockerfile only; no Rust or frontend code changed, so the cargo and npm CI jobs are unaffected. The workstation image is built only at deployment, not in CI. Verified the exact download/extract/run sequence locally: it fetches `actionlint_1.7.12_linux_amd64.tar.gz`, extracts the root `actionlint` binary, and runs (`actionlint --version` reports 1.7.12).