### PR TITLE
Run frontend unit tests (yarn test) in CI (#212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: yarn check
 
+      # Vitest unit tests (issue #212): pure-logic regressions (e.g. the runewood
+      # event mapper) are gated in CI, not just the type-check + build.
+      - name: Test
+        if: ${{ !cancelled() }}
+        run: yarn test
+
       - name: Build
         if: ${{ !cancelled() }}
         run: yarn build


### PR DESCRIPTION
Closes #212.

## Problem
PR #209 added Vitest to the frontend: a `test: "vitest run"` script and `src/**/*.test.ts` files (e.g. the runewood event mapper, `src/lib/runewood/mapEvent.test.ts`). CI's Frontend (SvelteKit) job only ran the type-check and build, so those unit tests were never gated and a pure-logic regression could merge green.

## Change
Add a `Test` step to the Frontend (SvelteKit) job in `.github/workflows/ci.yml` that runs `yarn test` after install, placed between the type-check and the build. It uses the same `if: ${{ !cancelled() }}` guard as the surrounding checks, preserving the workflow's no-fail-fast behavior (a failure in one step still lets the others run and report).

## Validation
- Ran `yarn test` locally in `frontend/`: 13 tests pass (`src/lib/runewood/mapEvent.test.ts`).
- Linted the workflow with actionlint: no new findings from this change. (The only output is the pre-existing `fedora` self-hosted runner-label note on all three jobs, unrelated to this change.)