### PR TITLE
Show PR and issue lifecycle events in the activity feed (#226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,19 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   `board_column`, `position` (fractional rank), `status`, `branch`, `pr_url`,
   `error`, `hold`, `session_id`.
 - **`turns`** / **`events`** — per-task Claude invocations and the append-only
-  parsed stream-json (live feed + chat history).
+  parsed stream-json (live feed + chat history). Beyond the Claude stream, the
+  orchestrator injects synthetic non-Claude events into the same `events` table +
+  task SSE stream so they render with no special transport: `ci` step activity
+  (issue #185, `orchestrator::ci_watch`) and `lifecycle` PR/issue moments (issue
+  #226, `orchestrator::emit_lifecycle_event`). A `lifecycle` payload is
+  `{ action: pr_opened | pr_merged | pr_closed | issue_closed, title, url, repo,
+  number }`, kept source-agnostic so a future Jira source (transition, comment)
+  can reuse it; `repo` is the short repo name, set only when the task spans more
+  than one repo so the feed shows a `repo#number` tag exactly when it
+  disambiguates. Each fires once per genuine transition (PR detection, our
+  squash-merge, an external merge/close found by the review refresh, a per-task
+  reset close, and the issue-close-on-Done path). Both flow through the
+  synthetic CI turn (`get_or_create_ci_turn`).
 - **`environment_suggestions`** — setup recommendations the agent makes after a
   task (`title`, `detail`, `acknowledged`). Posted by the agent's
   `seraphim-suggest` helper; shown loudly on the board and as checkboxes on the

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -139,6 +139,7 @@ pub async fn list_org_repos(octo: &Octocrab, owner: &str) -> Result<Vec<Discover
 #[derive(Debug, Clone)]
 pub struct OpenPr {
     pub number: u64,
+    pub title: String,
     pub html_url: String,
     pub head_sha: String,
 }
@@ -176,6 +177,7 @@ pub async fn find_open_pr_for_branch(
 
     Ok(Some(OpenPr {
         number: pull.number,
+        title: pull.title.unwrap_or_default(),
         html_url: pull.html_url.map(|url| url.to_string()).unwrap_or_default(),
         head_sha: pull.head.sha,
     }))
@@ -194,6 +196,7 @@ pub enum PrLifecycle {
 #[derive(Debug, Clone)]
 pub struct PrStatus {
     pub lifecycle: PrLifecycle,
+    pub title: String,
     pub head_sha: String,
 }
 
@@ -209,6 +212,8 @@ pub async fn pr_status(octo: &Octocrab, owner: &str, repo: &str, number: u64) ->
         state: String,
         #[serde(default)]
         merged: bool,
+        #[serde(default)]
+        title: String,
         head: Head,
     }
     let pull: Pull = octo
@@ -224,6 +229,7 @@ pub async fn pr_status(octo: &Octocrab, owner: &str, repo: &str, number: u64) ->
     };
     Ok(PrStatus {
         lifecycle,
+        title: pull.title,
         head_sha: pull.head.sha,
     })
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -35,6 +35,7 @@ pub async fn provision_workspace(state: &AppState) -> Result<()> {
     provision::provision_workspace(state, &main).await
 }
 
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -1121,6 +1122,41 @@ async fn reset_github_side(
                     Ok(()) => {
                         summary.pr_closed = true;
                         info!(task_id = %task.id, pr = pull.number, "reset: closed the pull request");
+
+                        // Surface the close once (#226) and consume the tracked row by
+                        // marking it closed, so the review loop's refresh never
+                        // re-announces this same closure if the task is re-worked later.
+                        let multi = task_is_multi_repo(state, task.id).await;
+                        let number = i64::try_from(pull.number).unwrap_or_default();
+                        if let Err(error) = queries::upsert_task_pr(
+                            &state.db,
+                            task.id,
+                            Some(repo.id),
+                            &repo.full_name,
+                            number,
+                            &pull.html_url,
+                            &pull.head_sha,
+                            "",
+                            "closed",
+                        )
+                        .await
+                        {
+                            warn!(error = %error, task_id = %task.id, "reset: failed to mark the PR closed");
+                        }
+                        if let Err(error) = emit_lifecycle_event(
+                            state,
+                            task.id,
+                            "pr_closed",
+                            &pull.title,
+                            &pull.html_url,
+                            short_repo_name(&repo.full_name),
+                            number,
+                            multi,
+                        )
+                        .await
+                        {
+                            warn!(error = %error, task_id = %task.id, "reset: failed to emit pr_closed lifecycle event");
+                        }
                     }
                     Err(error) => {
                         warn!(error = %error, task_id = %task.id, "reset: failed to close the pull request");
@@ -2137,7 +2173,7 @@ async fn review_task(
             if let Some(repo_id) = task.repo_id {
                 if let Some(repo) = queries::get_repository(&state.db, repo_id).await? {
                     if let Ok((owner, name)) = split_full_name(&repo.full_name) {
-                        close_linked_issue(github, settings, task, owner, name).await;
+                        close_linked_issue(state, github, settings, task, owner, name).await;
                     }
                 }
             }
@@ -2185,6 +2221,31 @@ async fn merge_task_prs(
                 )
                 .await?;
                 info!(task_id = %task.id, pr = %pr.pr_url, "auto-merged a PR");
+
+                // Surface the merge in the activity feed and the task's history (#226).
+                // The PR title is not stored on the row, so read it back (a rare path,
+                // one GET per merged PR); a lookup failure just drops the title.
+                let multi = prs
+                    .iter()
+                    .map(|other| other.repo_full_name.as_str())
+                    .collect::<HashSet<_>>()
+                    .len()
+                    > 1;
+                let title = git::pr_status(github, owner, name, number)
+                    .await
+                    .map(|status| status.title)
+                    .unwrap_or_default();
+                emit_lifecycle_event(
+                    state,
+                    task.id,
+                    "pr_merged",
+                    &title,
+                    &pr.pr_url,
+                    short_repo_name(&pr.repo_full_name),
+                    pr.pr_number,
+                    multi,
+                )
+                .await?;
             }
             Err(error) => {
                 if task.ci_fix_attempts < MAX_CI_FIX_ATTEMPTS {
@@ -2284,7 +2345,19 @@ async fn detect_task_prs(
     let Some(branch) = task.branch.as_deref() else {
         return Ok(0);
     };
+
+    // The PRs already tracked before this pass, so we announce "PR opened" only for
+    // genuinely new ones (#226). Detection runs repeatedly (the In Review transition
+    // plus the review loop's re-detect while awaiting), so the existing-row guard is
+    // what keeps each PR's opened line to exactly once, surviving process restarts.
+    let known: HashSet<(String, i64)> = queries::list_task_prs(&state.db, task.id)
+        .await?
+        .into_iter()
+        .map(|pr| (pr.repo_full_name, pr.pr_number))
+        .collect();
+
     let mut found = 0;
+    let mut opened: Vec<(String, String, i64, String)> = Vec::new();
     for repo in queries::list_repositories(&state.db)
         .await?
         .into_iter()
@@ -2296,13 +2369,14 @@ async fn detect_task_prs(
         let Some(pull) = git::find_open_pr_for_branch(github, owner, name, branch).await? else {
             continue;
         };
+        let number = i64::try_from(pull.number).unwrap_or_default();
         let ci = ci_state_label(&git::ci_status(github, owner, name, &pull.head_sha).await?);
         queries::upsert_task_pr(
             &state.db,
             task.id,
             Some(repo.id),
             &repo.full_name,
-            i64::try_from(pull.number).unwrap_or_default(),
+            number,
             &pull.html_url,
             &pull.head_sha,
             ci,
@@ -2310,6 +2384,33 @@ async fn detect_task_prs(
         )
         .await?;
         found += 1;
+        if !known.contains(&(repo.full_name.clone(), number)) {
+            opened.push((
+                repo.full_name.clone(),
+                pull.title.clone(),
+                number,
+                pull.html_url,
+            ));
+        }
+    }
+
+    // Announce each newly detected PR once the full set is known, so the multi-repo
+    // tag reflects the whole task rather than detection order.
+    if !opened.is_empty() {
+        let multi = task_is_multi_repo(state, task.id).await;
+        for (full_name, title, number, url) in opened {
+            emit_lifecycle_event(
+                state,
+                task.id,
+                "pr_opened",
+                &title,
+                &url,
+                short_repo_name(&full_name),
+                number,
+                multi,
+            )
+            .await?;
+        }
     }
     Ok(found)
 }
@@ -2336,6 +2437,9 @@ async fn refresh_task_prs(
     github: &octocrab::Octocrab,
     task: &Task,
 ) -> Result<Vec<TaskPullRequest>> {
+    // Whether this task spans more than one repo, so a settled-PR line names the
+    // repo (#226). Computed once; the PR set is stable across this refresh.
+    let multi = task_is_multi_repo(state, task.id).await;
     for pr in queries::list_task_prs(&state.db, task.id).await? {
         if pr.pr_state != "open" {
             continue; // merged/closed PRs are settled.
@@ -2366,6 +2470,28 @@ async fn refresh_task_prs(
             pr_state,
         )
         .await?;
+
+        // A PR that settled outside Seraphim (it was open in our DB until this poll)
+        // gets one lifecycle line on the transition. Our own squash-merge marks the
+        // row "merged" before this runs, so it is skipped above and never doubled.
+        let action = match status.lifecycle {
+            git::PrLifecycle::Merged => Some("pr_merged"),
+            git::PrLifecycle::Closed => Some("pr_closed"),
+            git::PrLifecycle::Open => None,
+        };
+        if let Some(action) = action {
+            emit_lifecycle_event(
+                state,
+                task.id,
+                action,
+                &status.title,
+                &pr.pr_url,
+                short_repo_name(&pr.repo_full_name),
+                pr.pr_number,
+                multi,
+            )
+            .await?;
+        }
     }
     Ok(queries::list_task_prs(&state.db, task.id).await?)
 }
@@ -2467,6 +2593,7 @@ async fn collect_failing_checks(
 /// is logged and swallowed so it never affects the completed task. Closing an
 /// already-closed issue is harmless.
 async fn close_linked_issue(
+    state: &AppState,
     github: &octocrab::Octocrab,
     settings: &crate::db::models::Settings,
     task: &Task,
@@ -2490,11 +2617,87 @@ async fn close_linked_issue(
     )
     .await
     {
-        Ok(_) => info!(task_id = %task.id, issue = %task.external_id, "closed the linked issue"),
+        Ok(_) => {
+            info!(task_id = %task.id, issue = %task.external_id, "closed the linked issue");
+            // Surface the closure in the activity feed and the task's history (#226).
+            let number = task.external_id.trim().parse::<i64>().unwrap_or_default();
+            let url = format!("https://github.com/{owner}/{repo_name}/issues/{number}");
+            let multi = task_is_multi_repo(state, task.id).await;
+            if let Err(error) = emit_lifecycle_event(
+                state,
+                task.id,
+                "issue_closed",
+                &task.title,
+                &url,
+                short_repo_name(repo_name),
+                number,
+                multi,
+            )
+            .await
+            {
+                warn!(error = %error, task_id = %task.id, "failed to emit issue_closed lifecycle event");
+            }
+        }
         Err(error) => {
             warn!(error = %error, task_id = %task.id, "failed to close the linked issue");
         }
     }
+}
+
+/// The short repo name (the part after the owner), e.g. `Plunder` from
+/// `JalapenoLabs/Plunder`. Used to tag a lifecycle line for a multi-repo task.
+fn short_repo_name(repo_full_name: &str) -> &str {
+    repo_full_name.rsplit('/').next().unwrap_or(repo_full_name)
+}
+
+/// Whether the task's tracked PRs span more than one repo, so a lifecycle line
+/// should name the repo (`repo#number`) to disambiguate. Single-repo tasks read
+/// cleanly without the tag, matching how the CI events stay untagged when there
+/// is only one PR. Any lookup failure degrades to "not multi-repo" (no tag).
+async fn task_is_multi_repo(state: &AppState, task_id: uuid::Uuid) -> bool {
+    let prs = queries::list_task_prs(&state.db, task_id)
+        .await
+        .unwrap_or_default();
+    let repos: HashSet<&str> = prs.iter().map(|pr| pr.repo_full_name.as_str()).collect();
+    repos.len() > 1
+}
+
+/// Persists and broadcasts a deterministic PR/issue lifecycle event (#226): the
+/// open/merge/close moments the orchestrator drives via octocrab, which otherwise
+/// never reach the activity feed. It mirrors the CI watcher's `emit_persisted`
+/// exactly: the event lands in the synthetic CI turn (so it flows through the same
+/// `events` table + task SSE stream as agent and CI events) and is streamed live.
+///
+/// The payload is kept source-agnostic so a future Jira source (transition,
+/// comment) can reuse this same `lifecycle` type. `repo` is the short repo name,
+/// included only when the task spans more than one repo (empty otherwise), so the
+/// frontend shows a `repo#number` tag exactly when it disambiguates.
+#[allow(clippy::too_many_arguments)]
+async fn emit_lifecycle_event(
+    state: &AppState,
+    task_id: uuid::Uuid,
+    action: &str,
+    title: &str,
+    url: &str,
+    repo: &str,
+    number: i64,
+    multi_repo: bool,
+) -> Result<()> {
+    let turn = queries::get_or_create_ci_turn(&state.db, task_id).await?;
+    let seq = queries::next_event_seq(&state.db, turn.id).await?;
+    let payload = serde_json::json!({
+        "action": action,
+        "title": title,
+        "url": url,
+        "repo": if multi_repo { repo } else { "" },
+        "number": number,
+    });
+    queries::append_event(&state.db, turn.id, seq, "lifecycle", payload.clone()).await?;
+    state.notify_task(
+        task_id,
+        serde_json::json!({ "type": "lifecycle", "payload": payload, "created_at": Utc::now() }),
+    );
+    Ok(())
 }
 
 /// Records a task failure: captures the message and surfaces it in `In Review`.

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -447,6 +447,9 @@
     if (event.type === 'ci') {
       return String(payload?.text ?? '')
     }
+    if (event.type === 'lifecycle') {
+      return lifecycleText(payload)
+    }
     return JSON.stringify(event.payload)
   }
 
@@ -461,6 +464,43 @@
         return 'text-success'
       default:
         return 'text-info'
+    }
+  }
+
+  // A deterministic PR/issue lifecycle line (#226). The repo is named
+  // (`repo#number`) only when the backend marked the task multi-repo (empty
+  // `repo` otherwise); the issue line already carries its number.
+  function lifecycleText(payload: Record<string, unknown>): string {
+    const action = String(payload?.action ?? '')
+    const repo = String(payload?.repo ?? '')
+    const number = payload?.number
+    const title = String(payload?.title ?? '')
+    switch (action) {
+      case 'pr_opened':
+        return `${repo ? `${repo}#${number} ` : ''}PR opened: ${title}`
+      case 'pr_merged':
+        return `${repo ? `${repo}#${number} ` : ''}PR merged: ${title}`
+      case 'pr_closed':
+        return `${repo ? `${repo}#${number} ` : ''}PR closed: ${title}`
+      case 'issue_closed':
+        return `${repo ? `${repo} ` : ''}Issue closed: #${number}`
+      default:
+        return JSON.stringify(payload)
+    }
+  }
+
+  // Lifecycle dot color follows the action: merge / issue-closed-on-done is
+  // progress (green), a PR closed without merging is an abandonment (red), and an
+  // opened PR is the neutral primary.
+  function lifecycleColor(payload: Record<string, unknown>): string {
+    switch (payload?.action) {
+      case 'pr_merged':
+      case 'issue_closed':
+        return 'text-success'
+      case 'pr_closed':
+        return 'text-destructive'
+      default:
+        return 'text-primary'
     }
   }
 
@@ -845,6 +885,16 @@
                         <div class="min-w-0 flex-1"><AnsiLog text={ciPayload.log} isError /></div>
                       </div>
                     {/if}
+                  </div>
+                {:else if event.type === 'lifecycle'}
+                  <!-- A deterministic PR/issue lifecycle moment (#226): a colored
+                       dot (green merged / red closed / primary opened) + the line. -->
+                  {@const lifecyclePayload = event.payload as Record<string, unknown>}
+                  <div class="flex items-start gap-2 py-0.5">
+                    <span class="w-[1ch] flex-none {lifecycleColor(lifecyclePayload)}">⬢</span>
+                    <span class="min-w-0 flex-1 whitespace-pre-wrap break-words {lifecycleColor(lifecyclePayload)}"
+                      >{describe(event)}</span
+                    >
                   </div>
                 {:else if collapsible}
                   <button

--- a/frontend/src/routes/watch/+page.svelte
+++ b/frontend/src/routes/watch/+page.svelte
@@ -214,7 +214,8 @@
     tool_use: { glyph: '⚙', color: 'text-primary' },
     result: { glyph: '✓', color: 'text-success' },
     rate_limit: { glyph: '◷', color: 'text-info' },
-    ci: { glyph: '●', color: 'text-info' }
+    ci: { glyph: '●', color: 'text-info' },
+    lifecycle: { glyph: '⬢', color: 'text-primary' }
   }
 
   // CI glyph color follows the step status (green pass / red fail / info running),
@@ -227,6 +228,20 @@
       return 'text-success'
     }
     return 'text-info'
+  }
+
+  // Lifecycle glyph color follows the action (#226), since one lifecycle type
+  // covers opened / merged / closed: a merge or an issue closed-on-done is
+  // progress (green), a PR closed without merging is an abandonment (red), and a
+  // freshly opened PR is the neutral primary.
+  function lifecycleGlyphColor(action: string | undefined): string {
+    if (action === 'pr_merged' || action === 'issue_closed') {
+      return 'text-success'
+    }
+    if (action === 'pr_closed') {
+      return 'text-destructive'
+    }
+    return 'text-primary'
   }
 
   function firstLine(text: unknown, max = 120): string {
@@ -263,6 +278,31 @@
         return describeRateLimit(payload)
       case 'ci':
         return firstLine(payload?.text)
+      case 'lifecycle':
+        return lifecycleLine(payload)
+      default:
+        return null
+    }
+  }
+
+  // Formats a PR/issue lifecycle event into its feed line (#226). The repo is
+  // named (`repo#number`) only when the backend marked the task multi-repo (it
+  // sends an empty `repo` otherwise), matching how CI stays untagged for a single
+  // PR. The issue line already carries the number, so it only prefixes the repo.
+  function lifecycleLine(payload: Record<string, unknown>): string | null {
+    const action = String(payload?.action ?? '')
+    const repo = String(payload?.repo ?? '')
+    const number = payload?.number
+    const title = firstLine(payload?.title)
+    switch (action) {
+      case 'pr_opened':
+        return `${repo ? `${repo}#${number} ` : ''}PR opened: ${title}`
+      case 'pr_merged':
+        return `${repo ? `${repo}#${number} ` : ''}PR merged: ${title}`
+      case 'pr_closed':
+        return `${repo ? `${repo}#${number} ` : ''}PR closed: ${title}`
+      case 'issue_closed':
+        return `${repo ? `${repo} ` : ''}Issue closed: #${number}`
       default:
         return null
     }
@@ -271,7 +311,12 @@
   async function pushFeed(taskId: string, type: string, payload: Record<string, unknown>, at: number) {
     const text = summarize(type, payload)
     if (!text) return
-    const status = type === 'ci' ? String(payload?.status ?? '') : undefined
+    const status =
+      type === 'ci'
+        ? String(payload?.status ?? '')
+        : type === 'lifecycle'
+          ? String(payload?.action ?? '')
+          : undefined
     const entry: FeedEntry = { id: feedSeq++, taskId, type, text, at, status }
     feed = [...feed, entry].slice(-MAX_FEED)
     // Keep the newest line in view (terminal-style autoscroll).
@@ -710,7 +755,12 @@
           {/if}
           {#each feed as entry (entry.id)}
             {@const meta = GLYPHS[entry.type] ?? { glyph: '·', color: 'text-muted-foreground' }}
-            {@const glyphColor = entry.type === 'ci' ? ciGlyphColor(entry.status) : meta.color}
+            {@const glyphColor =
+              entry.type === 'ci'
+                ? ciGlyphColor(entry.status)
+                : entry.type === 'lifecycle'
+                  ? lifecycleGlyphColor(entry.status)
+                  : meta.color}
             {@const hue = taskHue(entry.taskId)}
             <div
               class="flex items-center gap-2 py-0.5"


### PR DESCRIPTION
## What
Closes #226. Surfaces the deterministic PR/issue lifecycle moments the orchestrator drives via octocrab, which previously never reached the activity feed: `PR opened`, `PR merged`, `PR closed`, and `Issue closed: #<id>`. The feed and a task's saved history now tell the whole story, not just the Claude stream + CI steps.

## Backend
- New `emit_lifecycle_event` helper that mirrors the CI watcher exactly: it persists into the synthetic CI turn (`get_or_create_ci_turn` + `append_event`) and broadcasts via `notify_task`, so the events flow through the same `events` table + task SSE stream with no special transport. One `notify_task` reaches both the global `/activity/stream` and the per-task stream.
- New `lifecycle` event type with a source-agnostic payload `{ action, title, url, repo, number }`, kept generic so a future Jira source (transition, comment) can reuse it rather than inventing a parallel type.
- Called at each transition, once per genuine transition:
  - **pr_opened**: in `detect_task_prs`, only for PRs not already tracked (the existing-row guard keeps it to once across the In Review transition and the review loop's re-detect, surviving restarts).
  - **pr_merged**: in `merge_task_prs` on a successful squash-merge, and in `refresh_task_prs` for an external merge (our own merge marks the row `merged` first, so refresh skips it: never doubled).
  - **pr_closed**: in `refresh_task_prs` for an external close, and in the per-task reset path (which also marks the tracked row closed so a later refresh never re-announces it).
  - **issue_closed**: in `close_linked_issue` on the issue-close-on-Done path.
- `OpenPr` and `PrStatus` now carry the PR `title` (it is already in the fetched pull object, so no extra calls except one title read-back after our own squash-merge, a rare path).
- The repo is named (`repo#number`) only when the task spans more than one repo, matching how CI stays untagged for a single PR.

## Frontend
- Watch feed (`watch/+page.svelte`): a `lifecycle` `GLYPHS` entry, a `summarize` case formatting each action into its line, and a per-action glyph color (merged / issue-closed green, closed red, opened primary).
- Per-task history (`task/[id]/+page.svelte`): renders the same `lifecycle` type so the saved timeline shows these too, with the matching colored dot.

## Acceptance criteria
- [x] Opening, merging, and closing a PR, and closing a linked issue, each add exactly one line to the live feed and the task's saved history.
- [x] Lines name the repo for multi-repo tasks.
- [x] Events fire once per transition, not on every poll.
- [x] Glyph colors distinguish merged / closed / opened.
- [x] `cargo fmt` / `clippy` / `test` (125 pass) and `npm run check` / `build` pass.

## Notes
Backend + frontend, so shipping needs both an `api` and a `frontend` rebuild. CLAUDE.md updated to document the new `lifecycle` event type.