### PR TITLE
Add .github/actionlint.yaml declaring the self-hosted runner label (#228)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint configuration.
+#
+# Declares the custom labels carried by our self-hosted runner so actionlint does
+# not flag them as unknown. The CI jobs target `runs-on: [self-hosted, Linux, X64,
+# fedora]`; `self-hosted`, `Linux`, and `X64` are GitHub built-ins, but `fedora`
+# is our own label and must be listed here, otherwise every workflow edit recurs
+# with a false positive that buries genuine findings (issue #228).
+self-hosted-runner:
+  labels:
+    - fedora


### PR DESCRIPTION
## What
Closes #228. Adds a repo-root `.github/actionlint.yaml` declaring the custom self-hosted runner label `fedora`.

## Why
All three CI jobs in `.github/workflows/ci.yml` target `runs-on: [self-hosted, Linux, X64, fedora]`. `self-hosted`, `Linux`, and `X64` are GitHub built-ins, but `fedora` is our own self-hosted label, so actionlint reports it as unknown. That false positive recurs on every workflow edit and buries genuine findings. Declaring the label makes actionlint run clean so any new finding is real signal. Pairs with the actionlint tool added to the workstation image in #220.

## Change
```yaml
self-hosted-runner:
  labels:
    - fedora
```

## Verification
Ran actionlint locally against the repo:
- Without the config: `label "fedora" is unknown` on all three jobs (lines 24, 95, 130), exit 1.
- With the config: clean, exit 0.