### PR TITLE
Automation: split 'is exactly' into case-sensitive and case-insensitive operators (#230)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,8 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   webhook delivers an issue `created`/`updated`/`comment` event, each enabled
   rule whose source + trigger match is checked against the event; if its
   condition group (AND/OR of `{field, operator, values}`, operators
-  exactly/contains/has_one_of/is_empty/is_not_empty over labels/author/repo/
+  exactly (case-insensitive)/exactly_case_sensitive/contains/has_one_of/is_empty/
+  is_not_empty over labels/author/repo/
   title/body/comment/state) matches, its action runs (move the card to top/bottom
   of To Do). The rule shape + the pure matcher live in `src/automation/`
   (unit-tested, I/O-free); firing lives in `orchestrator::run_github_automation`

--- a/api/src/automation/mod.rs
+++ b/api/src/automation/mod.rs
@@ -52,6 +52,8 @@ pub enum Field {
 pub enum Operator {
     /// Equals one of the values (case-insensitive).
     Exactly,
+    /// Equals one of the values (case-sensitive).
+    ExactlyCaseSensitive,
     /// Contains one of the values as a substring (case-insensitive).
     Contains,
     /// For a list field: shares at least one value. For a scalar: same as `exactly`.
@@ -139,40 +141,84 @@ impl Condition {
         }
     }
 
-    /// Non-empty values, trimmed and lowercased, for case-insensitive matching.
-    fn needles(&self) -> impl Iterator<Item = String> + '_ {
+    /// Non-empty rule values, trimmed. Case folding is deferred to the comparison
+    /// (see [`str_eq`] / [`str_contains`]) so the case-sensitive and
+    /// case-insensitive operators share one matching path (issue #230).
+    fn needles(&self) -> impl Iterator<Item = &str> + '_ {
         self.values
             .iter()
-            .map(|value| value.trim().to_ascii_lowercase())
+            .map(|value| value.trim())
             .filter(|value| !value.is_empty())
     }
 
+    /// Whether this condition's operator compares with case respected. Only the
+    /// dedicated case-sensitive "exactly" does; everything else stays
+    /// case-insensitive, so existing rules keep their meaning.
+    fn case_sensitive(&self) -> bool {
+        matches!(self.operator, Operator::ExactlyCaseSensitive)
+    }
+
     fn eval_scalar(&self, value: &str) -> bool {
-        let value = value.trim().to_ascii_lowercase();
+        let value = value.trim();
+        let case_sensitive = self.case_sensitive();
         match self.operator {
             Operator::IsEmpty => value.is_empty(),
             Operator::IsNotEmpty => !value.is_empty(),
-            Operator::Exactly | Operator::HasOneOf => self.needles().any(|needle| needle == value),
-            Operator::Contains => self.needles().any(|needle| value.contains(&needle)),
+            Operator::Exactly | Operator::ExactlyCaseSensitive | Operator::HasOneOf => self
+                .needles()
+                .any(|needle| str_eq(needle, value, case_sensitive)),
+            Operator::Contains => self
+                .needles()
+                .any(|needle| str_contains(value, needle, case_sensitive)),
         }
     }
 
     fn eval_list(&self, items: &[String]) -> bool {
-        let present: Vec<String> = items
+        let present: Vec<&str> = items
             .iter()
-            .map(|item| item.trim().to_ascii_lowercase())
+            .map(|item| item.trim())
             .filter(|item| !item.is_empty())
             .collect();
+        let case_sensitive = self.case_sensitive();
         match self.operator {
             Operator::IsEmpty => present.is_empty(),
             Operator::IsNotEmpty => !present.is_empty(),
-            Operator::Exactly | Operator::HasOneOf => self
-                .needles()
-                .any(|needle| present.iter().any(|item| item == &needle)),
-            Operator::Contains => self
-                .needles()
-                .any(|needle| present.iter().any(|item| item.contains(&needle))),
+            Operator::Exactly | Operator::ExactlyCaseSensitive | Operator::HasOneOf => {
+                self.needles().any(|needle| {
+                    present
+                        .iter()
+                        .any(|item| str_eq(item, needle, case_sensitive))
+                })
+            }
+            Operator::Contains => self.needles().any(|needle| {
+                present
+                    .iter()
+                    .any(|item| str_contains(item, needle, case_sensitive))
+            }),
         }
+    }
+}
+
+/// Equality of two already-trimmed strings, honoring case only when asked. ASCII
+/// case folding mirrors the engine's prior behavior (it lowercased with
+/// `to_ascii_lowercase`); non-ASCII bytes compare verbatim either way.
+fn str_eq(left: &str, right: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        left == right
+    } else {
+        left.eq_ignore_ascii_case(right)
+    }
+}
+
+/// Substring test, honoring case only when asked. The case-insensitive path
+/// lowercases both sides, matching the engine's prior `contains` behavior.
+fn str_contains(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        haystack.contains(needle)
+    } else {
+        haystack
+            .to_ascii_lowercase()
+            .contains(&needle.to_ascii_lowercase())
     }
 }
 
@@ -281,6 +327,85 @@ mod tests {
             conditions: vec![condition(Field::Body, Operator::IsNotEmpty, &[])],
         };
         assert!(not_empty_body.matches(&ctx(Trigger::Created, &labels)));
+    }
+
+    #[test]
+    fn exactly_is_case_insensitive_for_scalar_and_labels() {
+        // The existing operator must stay case-insensitive (no behavior change on
+        // upgrade): a rule value of "Bug" still matches "bug".
+        let scalar = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(
+                Field::Author,
+                Operator::Exactly,
+                &["NavarroTech"],
+            )],
+        };
+        assert!(scalar.matches(&ctx(Trigger::Created, &[]))); // author is "navarrotech"
+
+        let labels = vec!["bug".to_string()];
+        let list = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(Field::Labels, Operator::Exactly, &["Bug"])],
+        };
+        assert!(list.matches(&ctx(Trigger::Created, &labels)));
+    }
+
+    #[test]
+    fn exactly_case_sensitive_requires_identical_case() {
+        // Scalar: matches the same case, rejects a different case.
+        let same = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(
+                Field::Author,
+                Operator::ExactlyCaseSensitive,
+                &["navarrotech"],
+            )],
+        };
+        assert!(same.matches(&ctx(Trigger::Created, &[]))); // author is "navarrotech"
+
+        let differing = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(
+                Field::Author,
+                Operator::ExactlyCaseSensitive,
+                &["NavarroTech"],
+            )],
+        };
+        assert!(!differing.matches(&ctx(Trigger::Created, &[])));
+
+        // Labels: same-case label matches, differing case does not. Surrounding
+        // whitespace is still trimmed, as for the case-insensitive operator.
+        let labels = vec!["Bug".to_string()];
+        let label_same = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(
+                Field::Labels,
+                Operator::ExactlyCaseSensitive,
+                &[" Bug "],
+            )],
+        };
+        assert!(label_same.matches(&ctx(Trigger::Created, &labels)));
+
+        let label_differing = RuleGroup {
+            combinator: Combinator::And,
+            conditions: vec![condition(
+                Field::Labels,
+                Operator::ExactlyCaseSensitive,
+                &["bug"],
+            )],
+        };
+        assert!(!label_differing.matches(&ctx(Trigger::Created, &labels)));
+    }
+
+    #[test]
+    fn exactly_case_sensitive_round_trips_through_json() {
+        // The serde name must be stable so the frontend dropdown value round-trips.
+        let condition = condition(Field::Author, Operator::ExactlyCaseSensitive, &["x"]);
+        let json = serde_json::to_value(&condition).unwrap();
+        assert_eq!(json["operator"], "exactly_case_sensitive");
+        let parsed: Condition = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.operator, Operator::ExactlyCaseSensitive);
     }
 
     #[test]

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -439,7 +439,13 @@ export type RuleField =
   | 'comment'
   | 'comment_author'
   | 'state'
-export type RuleOperator = 'exactly' | 'contains' | 'has_one_of' | 'is_empty' | 'is_not_empty'
+export type RuleOperator =
+  | 'exactly'
+  | 'exactly_case_sensitive'
+  | 'contains'
+  | 'has_one_of'
+  | 'is_empty'
+  | 'is_not_empty'
 export type QueuePosition = 'top' | 'bottom'
 // A rule's source: a real source kind or 'any' to match all.
 export type RuleSource = 'github' | 'jira' | 'internal' | 'any'

--- a/frontend/src/routes/automation/+page.svelte
+++ b/frontend/src/routes/automation/+page.svelte
@@ -60,7 +60,8 @@
   ]
   const OPERATORS: { value: RuleOperator; label: string; needsValues: boolean }[] = [
     { value: 'has_one_of', label: 'has one of', needsValues: true },
-    { value: 'exactly', label: 'is exactly', needsValues: true },
+    { value: 'exactly', label: 'is exactly (case-insensitive)', needsValues: true },
+    { value: 'exactly_case_sensitive', label: 'is exactly (case-sensitive)', needsValues: true },
     { value: 'contains', label: 'contains', needsValues: true },
     { value: 'is_empty', label: 'is empty', needsValues: false },
     { value: 'is_not_empty', label: 'is not empty', needsValues: false }


### PR DESCRIPTION
## What
Closes #230. Splits the automation "is exactly" condition operator into two explicit choices: case-insensitive (the existing behavior) and a new case-sensitive variant.

## Backend (`api/src/automation/mod.rs`)
- Adds `Operator::ExactlyCaseSensitive` (serde `exactly_case_sensitive`). The existing `Exactly` is left unchanged and case-insensitive, so every saved rule keeps its current meaning (no silent behavior change on upgrade).
- Refactors the matcher to fold case into the comparison rather than pre-lowercasing: `needles()` now only trims, and two small helpers `str_eq` / `str_contains` take a `case_sensitive` flag. Both operators share one code path across scalar fields (author/repo/title/body/state) and the list field (labels). Only `ExactlyCaseSensitive` is case-sensitive; `contains` / `has_one_of` / `is_empty` / `is_not_empty` stay case-insensitive exactly as before (the case-insensitive path keeps using `eq_ignore_ascii_case` / lowercased `contains`, matching prior behavior).
- Unit tests: case-sensitive matching (matches same case, rejects differing case) and that the case-insensitive operator is untouched, for both a scalar field and labels, plus a serde round-trip for the new value.

## Frontend
- `RuleOperator` type gains `'exactly_case_sensitive'` (`frontend/src/lib/types.ts`).
- The operator dropdown lists both, relabeled `is exactly (case-insensitive)` and `is exactly (case-sensitive)` (`frontend/src/routes/automation/+page.svelte`), so the value round-trips through create/edit.

## Acceptance criteria
- [x] The rule builder lists both case-sensitive and case-insensitive "is exactly".
- [x] A case-sensitive rule matches only on identical case; the case-insensitive rule behaves as today.
- [x] Existing saved rules continue to behave exactly as before (case-insensitive).
- [x] `cargo fmt` / `clippy` / `test` and `npm run check` / `build` pass.

## Notes
Backend + frontend, so shipping needs both an `api` and a `frontend` rebuild. CLAUDE.md updated to list the new operator.