### PR TITLE
Automation: fire Created rules from the poll sync, and warn on a missing webhook (#229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,9 +191,17 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   title/body/comment/state) matches, its action runs (move the card to top/bottom
   of To Do). The rule shape + the pure matcher live in `src/automation/`
   (unit-tested, I/O-free); firing lives in `orchestrator::run_github_automation`
-  (called from `http/webhooks.rs`). Source-agnostic (rules can target `any`), but
-  only GitHub events are wired so far; it's webhook-driven (the poll sync does not
-  fire rules, to avoid re-firing every cycle).
+  (called from `http/webhooks.rs` and the poll sync). Source-agnostic (rules can
+  target `any`), but only GitHub events are wired so far. The webhook is the
+  realtime path for all triggers; the poll sync is the reliable fallback for
+  `Created` rules (issue #229): when `upsert_github_issue` first inserts an issue
+  (it returns whether the issue was brand-new), `sync_repo_issues` fires `Created`
+  automation for it, exactly once on that first-insert transition, never re-firing
+  as the same issue is re-listed each poll. So `Created` rules work without any
+  webhook; `Updated` / `Comment` triggers remain webhook-only (poll-firing those
+  needs change detection). When an enabled rule exists but no GitHub webhook secret
+  is set, the Automation page shows a dismissible notice so a rule never sits
+  silently inert.
 
 ## How the agent runtime works (the workspace)
 

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -25,6 +25,9 @@ pub struct OpenIssue {
     /// The login and avatar of whoever opened the issue, for the board card.
     pub author_login: String,
     pub author_avatar_url: String,
+    /// The issue's label names, so the automation matcher can test label rules on
+    /// both the poll and webhook paths (issue #229).
+    pub labels: Vec<String>,
 }
 
 /// Lists open issues for a repo (excluding PRs), optionally label-filtered.
@@ -56,6 +59,7 @@ pub async fn list_open_issues(
             url: issue.html_url.to_string(),
             author_login: issue.user.login,
             author_avatar_url: issue.user.avatar_url.to_string(),
+            labels: issue.labels.into_iter().map(|label| label.name).collect(),
         })
         .collect())
 }

--- a/api/src/http/webhooks.rs
+++ b/api/src/http/webhooks.rs
@@ -123,7 +123,6 @@ async fn apply_github_event(state: &AppState, event: GithubIssueEvent) -> Result
         });
 
     let open_issue = event.issue.to_open_issue();
-    let labels = event.issue.label_names();
     let mut changed = false;
 
     if event.issue.state == "open" && matches_labels {
@@ -155,17 +154,8 @@ async fn apply_github_event(state: &AppState, event: GithubIssueEvent) -> Result
         } else {
             automation::Trigger::Updated
         };
-        if orchestrator::run_github_automation(
-            state,
-            &repo,
-            &open_issue,
-            &labels,
-            "open",
-            trigger,
-            "",
-            "",
-        )
-        .await?
+        if orchestrator::run_github_automation(state, &repo, &open_issue, "open", trigger, "", "")
+            .await?
         {
             changed = true;
         }
@@ -191,12 +181,10 @@ async fn apply_github_comment_event(state: &AppState, event: GithubCommentEvent)
     }
 
     let open_issue = event.issue.to_open_issue();
-    let labels = event.issue.label_names();
     orchestrator::run_github_automation(
         state,
         &repo,
         &open_issue,
-        &labels,
         "open",
         automation::Trigger::Comment,
         event.comment.body.as_deref().unwrap_or(""),
@@ -235,11 +223,8 @@ impl GithubIssue {
             url: self.html_url.clone(),
             author_login: self.user.login.clone(),
             author_avatar_url: self.user.avatar_url.clone(),
+            labels: self.labels.iter().map(|label| label.name.clone()).collect(),
         }
-    }
-
-    fn label_names(&self) -> Vec<String> {
-        self.labels.iter().map(|label| label.name.clone()).collect()
     }
 }
 

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -361,8 +361,29 @@ async fn sync_repo_issues(
     // the very top of Available (each new card is placed above the last).
     for issue in issues.into_iter().rev() {
         // Sync only ever lists open issues, so any issue we see here is open.
-        upsert_github_issue(state, repo.id, &issue, "open").await?;
+        let is_new = upsert_github_issue(state, repo.id, &issue, "open").await?;
         *changed = true;
+
+        // Fire `Created` automation on the poll path too, but only on the first
+        // insert of an issue (issue #229): without a webhook this is the only way a
+        // "created" rule ever runs, and the is-new guard keeps it to exactly once,
+        // never re-firing as the same issue is re-listed every poll. `Updated` /
+        // `Comment` triggers stay webhook-only (poll-firing those needs change
+        // detection), so this passes `Created` explicitly.
+        if is_new
+            && run_github_automation(
+                state,
+                repo,
+                &issue,
+                "open",
+                automation::Trigger::Created,
+                "",
+                "",
+            )
+            .await?
+        {
+            *changed = true;
+        }
     }
 
     // The open list can't reveal an issue closed outside Seraphim (it simply drops
@@ -462,7 +483,6 @@ pub async fn run_github_automation(
     state: &AppState,
     repo: &Repository,
     issue: &git::OpenIssue,
-    labels: &[String],
     issue_state: &str,
     trigger: automation::Trigger,
     comment: &str,
@@ -477,7 +497,7 @@ pub async fn run_github_automation(
         trigger,
         repo: &repo.full_name,
         author: &issue.author_login,
-        labels,
+        labels: &issue.labels,
         title: &issue.title,
         body: &issue.body,
         state: issue_state,
@@ -510,12 +530,16 @@ pub async fn run_github_automation(
 /// Available; an existing one only refreshes its cached fields, keeping its
 /// human-curated column and position. Shared by the poll sync and the realtime
 /// webhook so both place and dedupe issues identically.
+///
+/// Returns whether the issue was brand-new to the board (no task existed yet), so
+/// the poll path can fire `Created` automation exactly once, on first insert
+/// (issue #229).
 pub async fn upsert_github_issue(
     state: &AppState,
     repo_id: uuid::Uuid,
     issue: &git::OpenIssue,
     external_state: &str,
-) -> Result<()> {
+) -> Result<bool> {
     let external_id = issue.number.to_string();
     let position = top_of_column_position(state, TaskColumn::Available).await?;
 
@@ -534,26 +558,20 @@ pub async fn upsert_github_issue(
     )
     .await?;
 
-    // Honor a route-planner placement, but only the first time the issue is brought
-    // in: an already-tracked card is curated by the operator and must not be moved,
-    // so we only consume the placement when no task exists yet. With no placement
-    // (the common case) this is one cheap query and the default upsert runs exactly
-    // as before. See `placement::resolve`.
-    let pending =
-        match queries::find_issue_task(&state.db, SourceKind::Github, Some(repo_id), &external_id)
+    // Whether the issue is brand-new to the board (no task yet). This both drives
+    // the route-planner placement below (an already-tracked card is operator-curated
+    // and must not be moved, so a placement is consumed only on first insert) and is
+    // returned so the poll path fires `Created` automation exactly once.
+    let is_new =
+        queries::find_issue_task(&state.db, SourceKind::Github, Some(repo_id), &external_id)
             .await?
-        {
-            Some(_) => None,
-            None => {
-                queries::take_pending_placement(
-                    &state.db,
-                    SourceKind::Github,
-                    Some(repo_id),
-                    &external_id,
-                )
-                .await?
-            }
-        };
+            .is_none();
+    let pending = if is_new {
+        queries::take_pending_placement(&state.db, SourceKind::Github, Some(repo_id), &external_id)
+            .await?
+    } else {
+        None
+    };
 
     match placement::resolve(pending.as_ref()) {
         placement::Placement::Default => {
@@ -597,7 +615,7 @@ pub async fn upsert_github_issue(
             .await?;
         }
     }
-    Ok(())
+    Ok(is_new)
 }
 
 /// Reflects an issue closed outside Seraphim by moving its tracked task to Done.

--- a/frontend/src/routes/automation/+page.svelte
+++ b/frontend/src/routes/automation/+page.svelte
@@ -15,11 +15,12 @@
   import type { RuleRequest } from '$lib/api'
 
   import { onMount } from 'svelte'
-  import { Plus, Trash2, Zap } from '@lucide/svelte'
+  import { Info, Plus, Trash2, X, Zap } from '@lucide/svelte'
 
   import {
     createAutomationRule,
     deleteAutomationRule,
+    getSettings,
     listAutomationRules,
     updateAutomationRule
   } from '$lib/api'
@@ -47,6 +48,17 @@
 
   let rules = $state<RuleDraft[]>([])
   let loading = $state(true)
+
+  // Whether a GitHub webhook secret is configured. Without one, `Updated` /
+  // `Comment` rules never fire (only the realtime webhook path evaluates them);
+  // `Created` rules still fire from the poll sync (issue #229). Drives the notice
+  // below so an enabled rule never sits silently inert.
+  let githubWebhookConfigured = $state(true)
+  let webhookNoticeDismissed = $state(false)
+  const hasEnabledRules = $derived(rules.some((rule) => rule.enabled))
+  const showWebhookNotice = $derived(
+    hasEnabledRules && !githubWebhookConfigured && !webhookNoticeDismissed
+  )
 
   const FIELDS: { value: RuleField; label: string; placeholder: string; list: boolean }[] = [
     { value: 'labels', label: 'Labels', placeholder: 'automation, bug', list: true },
@@ -145,8 +157,9 @@
   async function load() {
     loading = true
     try {
-      const fetched = await listAutomationRules()
+      const [fetched, settings] = await Promise.all([listAutomationRules(), getSettings()])
       rules = fetched.map(toDraft)
+      githubWebhookConfigured = settings.github_webhook_secret_set
     } finally {
       loading = false
     }
@@ -208,14 +221,45 @@
         <Zap class="size-6 text-primary" /> Automation
       </h1>
       <p class="mt-1 max-w-2xl text-sm text-muted-foreground">
-        Rules react to issue events from the realtime webhooks. When an issue is created, updated, or
-        commented on and a rule's conditions match, its action runs, for example moving the card to
-        the top of To Do. Try: <em>labels has one of "automation, bug" AND author is exactly
+        Rules react to issue events and, on a match, run their action (for example moving the card to
+        the top of To Do). Try: <em>labels has one of "automation, bug" AND author is exactly
         navarrotech</em>, or a comment that contains "Jarvis, can you take this on?".
+        <strong>Created</strong> rules fire as issues sync onto the board, with or without a webhook;
+        <strong>Updated</strong> and <strong>Comment</strong> rules fire only from a configured GitHub
+        webhook.
       </p>
     </div>
     <Button onclick={addRule}><Plus class="size-4" /> New rule</Button>
   </header>
+
+  {#if showWebhookNotice}
+    <!-- Don't fail silently (issue #229): an enabled rule with no webhook secret
+         would leave Updated/Comment triggers inert. Created still works via the
+         poll, so this is informational, not alarming, and dismissible. -->
+    <div class="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-sm">
+      <Info class="mt-0.5 size-5 flex-none text-amber-500" />
+      <div class="min-w-0 flex-1 space-y-1">
+        <p class="font-medium">No GitHub webhook is configured.</p>
+        <p class="text-muted-foreground">
+          <strong>Created</strong> rules still fire as issues sync onto the board, so they work now.
+          But <strong>Updated</strong> and <strong>Comment</strong> rules need a webhook: set a GitHub
+          webhook secret in <a class="underline" href="/settings">Settings</a>, then add a repo (or
+          org) webhook for the <em>Issues</em> and <em>Issue comments</em> events with that secret,
+          pointing at <code class="rounded bg-muted px-1">POST /api/v1/webhooks/github</code> on this
+          instance's Tailscale URL.
+        </p>
+      </div>
+      <button
+        type="button"
+        onclick={() => (webhookNoticeDismissed = true)}
+        title="Dismiss"
+        aria-label="Dismiss notice"
+        class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+      >
+        <X class="size-4" />
+      </button>
+    </div>
+  {/if}
 
   {#if loading}
     <p class="text-muted-foreground">Loading…</p>


### PR DESCRIPTION
## What
Closes #229. Automation rules previously fired only from the webhook path, so on a poll-only instance (no GitHub webhook configured) a `Created` rule never fired, and the operator got no indication why. This makes `Created` rules work without a webhook and surfaces a clear, dismissible notice when an enabled rule has no webhook to back its `Updated`/`Comment` triggers.

## Backend (`api/`)
- **`upsert_github_issue` now returns whether the issue was brand-new** to the board. It already computed this (to gate route-planner placement); the value is now also returned. No behavior change to placement.
- **`sync_repo_issues` fires `Created` automation on first insert**, exactly once on that genuine transition (the same `run_github_automation` the webhook uses, with `Trigger::Created`). It never re-fires as the same issue is re-listed every poll, mirroring the "once per transition" guard used elsewhere. `Updated` / `Comment` triggers stay webhook-only (poll-firing those needs change detection, out of scope).
- **`OpenIssue` now carries its label names**, so label-based rules match on the poll path too. `run_github_automation` reads `issue.labels` and its separate `labels` param is dropped; the two webhook callers and `to_open_issue` are updated to match (removes the parallel `label_names()` plumbing).

## Frontend (Automation page)
- Documents which triggers need a webhook: `Created` fires as issues sync (with or without a webhook); `Updated` / `Comment` fire only from a configured webhook.
- Shows a **dismissible** notice when at least one enabled rule exists but no GitHub webhook secret is set, explaining that `Created` still works and how to set up a webhook (secret in Settings, then a repo/org webhook for the Issues + Issue comments events pointing at `POST /api/v1/webhooks/github` over the Tailscale URL). Informational, not alarming.

## Acceptance criteria
- [x] A `Created` rule moves a newly-synced matching issue to the configured To Do position on the poll path, with no webhook configured.
- [x] It fires exactly once (on first insert), not on every poll of the same issue.
- [x] An enabled rule plus a missing webhook secret produces a clear, dismissible notice rather than silent inaction.
- [x] The Automation UI documents which triggers need a webhook.
- [x] `cargo fmt` / `clippy` / `test` (125 pass) and `npm run check` / `build` pass.

## Notes
Backend + frontend, so shipping needs both an `api` and a `frontend` rebuild. CLAUDE.md's automation section updated to reflect that the poll path now fires `Created` rules.