### PR TITLE
Upgrade runewood to 0.1.0 (#227)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "ky": "^1.7.0",
     "marked": "^18.0.5",
     "paneforge": "^1.0.2",
-    "runewood": "^0.0.2",
+    "runewood": "^0.1.0",
     "svelte-dnd-action": "^0.9.50",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2202,13 +2202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"runewood@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "runewood@npm:0.0.2"
+"runewood@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "runewood@npm:0.1.0"
   dependencies:
     pixi-filters: "npm:^6.1.5"
     pixi.js: "npm:^8.19.0"
-  checksum: 10c0/abd626796fb3d37d383b6130333a317a3acd33d72968bb748752f7f3f1c9f46eb4935b67b6bfb9703e1fd02fc9d401f4d6984b908028ccce82c5b3f6a1ea6659
+  checksum: 10c0/9e76c8790d849c317bb0e185a72d89c8610554980af2c27990f7b0636ad5013431d0b9e0fb9a8ea6a793d543d76f93c8c1d561ababa7d28ea334847d98b1a538
   languageName: node
   linkType: hard
 
@@ -2251,7 +2251,7 @@ __metadata:
     marked: "npm:^18.0.5"
     mode-watcher: "npm:^1.1.0"
     paneforge: "npm:^1.0.2"
-    runewood: "npm:^0.0.2"
+    runewood: "npm:^0.1.0"
     svelte: "npm:^5.1.0"
     svelte-check: "npm:^4.0.0"
     svelte-dnd-action: "npm:^0.9.50"


### PR DESCRIPTION
## What
Closes #227. Bumps `runewood` from `^0.0.2` to `^0.1.0` (the new latest published version, just released) and refreshes the Yarn Berry lockfile (`frontend/yarn.lock`).

## Compatibility review
Checked the 0.1.0 controller surface against the watch page activity-forest integration (`frontend/src/routes/watch/+page.svelte` + `frontend/src/lib/runewood/mapEvent.ts`). Everything we use is unchanged, so **no integration changes were needed**:

- `createRunewood(el, options)` with `theme`, `bloom`, `cameraMode`, `rootLabel`, `exclude`, `actorLingerMs` -> all options still present.
- `controller.seed(paths)`, `controller.ingest(mapped)`, `controller.destroy()` -> unchanged.
- `controller.highlight(files, { id, color })` -> still returns a `{ id, update, clear }` handle.
- `controller.on('nodeHover', ...)` -> still emitted; payload `{ path, screen: { x, y } } | null` matches the tooltip handler.
- `RunewoodController` / `RunewoodHighlight` / `Hsl` / `RunewoodEvent` types still exported; `mapEvent.ts` (and the local `DEFAULT_EXCLUDES`) is unaffected.

## Validation
- `npm run check` (svelte-check): 0 errors, 0 warnings.
- `npm run build`: passes. `runewood` is a lazy import on the watch page, so the initial bundle is unaffected.

## Acceptance criteria
- [x] `runewood` at the latest published version in `package.json` (`^0.1.0`) and `yarn.lock` (`0.1.0`).
- [x] Watch page forest still seeds the full tree, lights nodes on live activity, CI highlights color per-PR, and the nodeHover tooltip works (API verified unchanged; build + check green).
- [x] No console errors from runewood on load (lazy import path and option/method surface verified against the new types).
- [x] `npm run check` and `npm run build` pass.

## Possible follow-ups (not in scope)
0.1.0 adds capabilities worth a future ticket: a playback transport (`play`/`pause`/`seek`/`setSpeed`, `getState`), `nodeClick`/`actorClick` deep-link events, click-to-follow (`followActor`) and `setCameraMode`, per-actor avatars (`resolveAvatar` / `setAvatar`, e.g. agent icons on the forest), a `parchment` theme, and a new `runewood/git` export subpath.

Note: this repo uses Yarn Berry, so the lockfile is `frontend/yarn.lock` (there is no `package-lock.json`, despite the ticket wording).