### PR TITLE
Workspace: init submodules reliably and fail loudly when access is missing (#251)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,15 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 - **Two-tier setup:** environment setup (`settings.base_setup_script`) runs once
   per provision/recreate (install CLIs/toolchains); per-repo setup
   (`repositories.setup_script`) runs after each clone (e.g. `yarn install`).
+- **Submodules (issue #251):** a cloned repo's git submodules are initialized
+  automatically (`provision::submodule_update_snippet`, generic to any repo with a
+  `.gitmodules`), before its setup script, on clone and after a branch checkout.
+  It does NOT fail silently: a denied/missing private submodule (the common cause:
+  the mounted host SSH/deploy key lacks read access, e.g. Plunder's private `brand`
+  submodule) aborts prep with a message naming the offending submodule URL(s) and
+  the fix (grant the key read access; for `brand` that is the `BRAND_DEPLOY_KEY`
+  deploy key), instead of a generic build failure mid-task. Relies on the mounted
+  host key only; no private key material is baked into the image.
 - **`~/.claude`** comes from cloning `settings.config_repo_url` into
   `CLAUDE_CONFIG_DIR=/workspace/.claude` (git init+fetch+checkout so untracked
   `projects/` — the persisted session — survives). No host mount. This is a

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -248,6 +248,9 @@ pub async fn prepare_branch(
     script.push_str(&format!("cd \"{dir}\"\n", dir = dir));
     script.push_str(reset_tree_snippet());
     script.push_str(&branch_prep_snippet(&repo.default_branch, branch));
+    // Re-sync submodules to the freshly-checked-out branch's pinned commits, failing
+    // loudly if a private submodule is inaccessible (issue #251).
+    script.push_str(&submodule_update_snippet(&dir));
 
     run(state, handle.container(), &script).await
 }
@@ -265,8 +268,7 @@ pub async fn prepare_branch(
 fn branch_prep_snippet(default: &str, branch: &str) -> String {
     format!(
         "git fetch origin \"{default}\"\n\
-         git checkout -B \"{branch}\" \"origin/{default}\"\n\
-         git submodule update --init --recursive || true\n"
+         git checkout -B \"{branch}\" \"origin/{default}\"\n"
     )
 }
 
@@ -293,12 +295,39 @@ pub async fn prepare_existing_branch(
     script.push_str(&format!(
         "git fetch origin\n\
          git checkout -B \"{branch}\" \"origin/{branch}\"\n\
-         git reset --hard \"origin/{branch}\"\n\
-         git submodule update --init --recursive || true\n",
+         git reset --hard \"origin/{branch}\"\n",
         branch = branch,
     ));
+    // Re-sync submodules to this branch's pinned commits, failing loudly if a
+    // private submodule is inaccessible (issue #251).
+    script.push_str(&submodule_update_snippet(&dir));
 
     run(state, handle.container(), &script).await
+}
+
+/// Bash that initializes a repo's git submodules (issue #251), generic to any repo
+/// that has them: a no-op when there is no `.gitmodules`, otherwise
+/// `git submodule update --init --recursive`.
+///
+/// Crucially it does NOT fail silently (the same principle as the config-repo and
+/// repo-sync error paths). The common failure is the workspace's mounted SSH /
+/// deploy key lacking read access to a *private* submodule repo (e.g. Plunder's
+/// `brand`); when that happens this names the offending submodule URL(s) and the
+/// fix, then exits non-zero, so the operator gets an actionable message up front
+/// instead of a generic build failure mid-task. Runs under the caller's `set -e`.
+fn submodule_update_snippet(dir: &str) -> String {
+    format!(
+        "if [ -f \"{dir}/.gitmodules\" ]; then\n\
+         if ! git -C \"{dir}\" submodule update --init --recursive; then\n\
+         echo \"ERROR: could not initialize git submodules for {dir}.\" >&2\n\
+         echo \"The workspace SSH/deploy key likely lacks read access to a private submodule repo:\" >&2\n\
+         git config -f \"{dir}/.gitmodules\" --get-regexp 'submodule[.].*[.]url' 2>/dev/null | awk '{{ print \"  - \" $2 }}' >&2\n\
+         echo \"Grant the mounted host SSH key (or a deploy key) read access to the repo(s) above, then re-provision.\" >&2\n\
+         echo \"For Plunder's private brand submodule this is the BRAND_DEPLOY_KEY deploy key (companion ticket).\" >&2\n\
+         exit 1\n\
+         fi\n\
+         fi\n"
+    )
 }
 
 /// Bash to clone-or-update a single repo, write its CLAUDE.md, and (on a fresh
@@ -324,19 +353,26 @@ fn repo_block(repo: &Repository, always_setup: bool) -> String {
         String::new()
     };
 
-    // Submodules are common across the user's orgs, so fetch them on update and
-    // pull them down on a fresh clone.
+    // Clone (or fetch) the superproject, then initialize submodules explicitly via
+    // `submodule_update_snippet` so a missing/private submodule fails loudly and
+    // helpfully rather than as a silent partial clone (issue #251). Submodules are
+    // brought up BEFORE the setup script, since a repo's build/setup (e.g. Plunder's)
+    // may import from a submodule.
+    let submodules = submodule_update_snippet(&dir);
     format!(
         "if [ -d \"{dir}/.git\" ]; then\n\
-           git -C \"{dir}\" fetch origin --recurse-submodules || true\n\
+           git -C \"{dir}\" fetch origin || true\n\
+           {submodules}\
            {update_setup}\
          else\n\
-           git clone --recurse-submodules \"{clone_url}\" \"{dir}\"\n\
+           git clone \"{clone_url}\" \"{dir}\"\n\
+           {submodules}\
            {clone_setup}\
          fi\n\
          {claude_md}",
         dir = dir,
         clone_url = repo.clone_url,
+        submodules = submodules,
         claude_md = write_file_snippet(&format!("{dir}/CLAUDE.md"), &repo.instructions),
     )
 }
@@ -377,7 +413,31 @@ async fn run(state: &AppState, container: &str, script: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::branch_prep_snippet;
+    use super::{branch_prep_snippet, repo_block, submodule_update_snippet};
+    use crate::db::models::Repository;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn repo() -> Repository {
+        Repository {
+            id: Uuid::nil(),
+            railway_id: Uuid::nil(),
+            full_name: "JalapenoLabs/Plunder".to_string(),
+            clone_url: "git@github.com:JalapenoLabs/Plunder.git".to_string(),
+            default_branch: "main".to_string(),
+            branch_template: None,
+            setup_script: String::new(),
+            instructions: String::new(),
+            review_policy: None,
+            enabled: true,
+            sync_issues: false,
+            issue_labels: Vec::new(),
+            sync_error: None,
+            sync_error_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
 
     #[test]
     fn branch_prep_fetches_the_target_then_cuts_from_its_fresh_tip() {
@@ -398,5 +458,43 @@ mod tests {
         let script = branch_prep_snippet("main", "branch");
         assert!(!script.contains("pull"));
         assert!(!script.contains("git fetch origin \"main\" || true"));
+        // Submodule handling moved to `submodule_update_snippet`, which no longer
+        // swallows failures; the silenced form must be gone (issue #251).
+        assert!(!script.contains("submodule update --init --recursive || true"));
+    }
+
+    #[test]
+    fn submodule_snippet_inits_and_fails_loudly_with_an_actionable_message() {
+        let script = submodule_update_snippet("/workspace/Plunder");
+
+        // Only acts when the repo actually has submodules, so it is a safe no-op
+        // for the common (no-submodule) repo.
+        assert!(script.contains(".gitmodules"));
+        // Initializes recursively.
+        assert!(
+            script.contains("git -C \"/workspace/Plunder\" submodule update --init --recursive")
+        );
+        // Does NOT fail silently (the whole point of issue #251).
+        assert!(!script.contains("submodule update --init --recursive || true"));
+        // On failure it names the access problem + the offending repo URLs + the fix,
+        // then exits non-zero so it surfaces instead of a generic mid-task failure.
+        assert!(script.contains("read access to a private submodule repo"));
+        assert!(script.contains("--get-regexp"));
+        assert!(script.contains("BRAND_DEPLOY_KEY"));
+        assert!(script.contains("exit 1"));
+    }
+
+    #[test]
+    fn repo_block_initializes_submodules_explicitly_without_recurse_clone() {
+        let script = repo_block(&repo(), true);
+
+        // The clone no longer relies on `--recurse-submodules` (which would fail with
+        // a generic message); submodules are initialized by the explicit, loud snippet.
+        assert!(!script.contains("--recurse-submodules"));
+        assert!(
+            script.contains("git submodule update --init --recursive")
+                || script.contains("submodule update --init --recursive")
+        );
+        assert!(script.contains("exit 1"));
     }
 }


### PR DESCRIPTION
## What
Closes #251. Makes the workspace initialize a cloned repo's git submodules reliably, and fail with a clear, actionable message when a private submodule can't be cloned, instead of letting it surface as a generic build failure mid-task.

## Problem
Submodule init was happening but silently: the per-task branch-prep paths used `git submodule update --init --recursive || true` (the `|| true` swallowed failures), and `repo_block` relied on `git clone --recurse-submodules` failing with a generic git error. So a missing/private submodule (e.g. Plunder's private `brand`, added in Plunder #102) produced a confusing downstream build failure rather than a named, fixable error.

## Change (`api/src/orchestrator/provision.rs`)
- New `submodule_update_snippet(dir)`: generic to **any** repo with a `.gitmodules` (not brand-specific), a no-op otherwise. Runs `git submodule update --init --recursive`, and on failure does **not** fail silently. It prints, to stderr, the offending submodule URL(s) (from `.gitmodules`), that the cause is usually the mounted SSH/deploy key lacking read access to a private submodule repo, and the fix (grant read access; for `brand` that is the `BRAND_DEPLOY_KEY` deploy key from the companion Plunder ticket), then `exit 1`. This mirrors the existing "don't fail silently" pattern (config-repo / repo-sync errors).
- `repo_block`: clone the superproject (dropped `--recurse-submodules`), then init submodules via the explicit snippet **before** the setup script (a repo's build may import from a submodule), on both fresh-clone and update paths.
- `prepare_branch` / `prepare_existing_branch`: removed the silenced `|| true` submodule lines; re-sync submodules via the snippet after the branch checkout (so they match the branch's pinned commits), failing loudly.
- No private key material is baked into the image; this relies on the mounted host SSH key only.

## Tests
Added unit tests (pure, I/O-free) and the suite passes (130 total):
- the snippet inits recursively, guards on `.gitmodules`, never uses `|| true`, and on failure names the access problem + lists the submodule URLs + points at `BRAND_DEPLOY_KEY` + `exit 1`;
- `repo_block` no longer uses `--recurse-submodules` and includes the loud snippet;
- `branch_prep_snippet` no longer carries the silenced submodule line.

## Acceptance criteria
- [x] Cloning a repo with submodules initializes them automatically in the workspace.
- [x] A denied/missing private submodule produces a clear, actionable error naming the repo and the fix, not a generic failure.
- [x] `cargo fmt` / `clippy` / `test` pass. (No UI surface added, so no `npm` changes.)

## Notes / possible follow-up
The optional robustness item (a provision-time pre-flight SSH read-access check recorded as a persisted operator-facing status, like `config_repo_error`, with a board banner) was left out to keep scope tight; the loud, named failure already tells the operator exactly which repo needs access. Happy to add the persisted-status + banner as a follow-up if you want it surfaced in the UI. Credential provisioning itself lives in the companion Plunder ticket.