### PR TITLE
Verify actionlint is on PATH at image build time (#252)

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -55,14 +55,24 @@ RUN curl -fsSL https://github.com/earthly/earthly/releases/latest/download/earth
 # --- actionlint (GitHub Actions workflow linter) -----------------------------
 # Lets the agent validate `.github/workflows/*.yml` locally (bad `${{ }}`
 # expressions, unknown contexts, shell mistakes) before pushing, instead of
-# fetching the release binary ad hoc each time (issue #220). Pinned, prebuilt
-# release tarball (the binary sits at the archive root), matching the gh/doctl
-# pattern above; no Go toolchain needed.
+# fetching the release binary ad hoc each time (issues #220, #252). Pinned,
+# prebuilt release tarball (the binary sits at the archive root), matching the
+# gh/doctl pattern above; no Go toolchain needed.
 ARG ACTIONLINT_VERSION=1.7.12
 RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz \
     && tar -xzf /tmp/actionlint.tgz -C /tmp actionlint \
     && install -m 0755 /tmp/actionlint /usr/local/bin/actionlint \
     && rm -rf /tmp/actionlint*
+
+# Verification gate (issue #252): #220 installed actionlint but it was reported
+# unresolvable on PATH in the running container, and the ticket closed without
+# this check. Fail the BUILD here unless `actionlint --version` resolves both for
+# root (the default `docker exec` user) and for the `codespace` agent user in a
+# login shell, the exact context of the acceptance check
+# (`docker exec seraphim-workspace bash -lc 'actionlint --version'`). A binary
+# that lands off PATH can no longer ship silently.
+RUN actionlint --version \
+    && runuser -l codespace -c 'actionlint --version'
 
 # --- Rust / Cargo (not in the universal image) -------------------------------
 # Installed system-wide so every user/shell finds it on PATH; the registry/cache


### PR DESCRIPTION
## What
Closes #252 (regression of #220). Adds a build-time verification gate so the workspace image cannot ship with `actionlint` installed but unresolvable on `PATH` again.

## Findings
The pinned actionlint install from #220 **is** present in `workspace/Dockerfile` on `develop` (`/usr/local/bin/actionlint`, `ARG ACTIONLINT_VERSION=1.7.12`, not `@latest`), so the install + pin acceptance items were already satisfied. The "regression" is that the **running** `seraphim-workspace` container predates that merge (I confirmed `command -v actionlint` returns nothing in the live workspace), and #220 was closed without the verification the ticket now mandates. The deliverable here is that verification gate plus a rebuild.

## Change (`workspace/Dockerfile`, workspace-image only)
Added a `RUN` immediately after the actionlint install that fails the build unless `actionlint --version` resolves:
- as **root** (the default `docker exec` user), and
- as the **`codespace`** agent user in a **login shell** (`runuser -l codespace -c '...'`), which is exactly the acceptance check `docker exec seraphim-workspace bash -lc 'actionlint --version'` and the precise #220 failure mode (binary present but not resolvable for the agent's shell).

Also cross-referenced #252 in the install comment. The version stays pinned at 1.7.12.

## Validation
Can't build the full multi-GB image here, but I validated the exact gate commands in this universal-devcontainer-based environment (the image's base): downloaded the pinned `v1.7.12` tarball (binary present at archive root), installed to `/usr/local/bin`, and ran both gate commands. Both print `1.7.12`, including the `runuser -l codespace` login-shell check. Confirmed `entrypoint.sh` does no PATH manipulation, so the build-time gate reflects runtime resolution.

## Acceptance criteria
- [x] After a `workspace` rebuild + recreate, `docker exec seraphim-workspace bash -lc 'actionlint --version'` prints a version (now enforced at build time, so the build fails otherwise).
- [x] An agent can run `actionlint` with no per-run install (binary on `/usr/local/bin`, gate proves it resolves).
- [x] Version pinned (1.7.12), not floating `@latest`.

## Notes
Workspace-image change only, so shipping needs a `docker compose build workspace` + recreate (the deployed image still predates #220). No app code, so no cargo/npm surfaces are affected.