### PR TITLE
Address PR review comments before auto-merge (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,10 +287,13 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    answers via `prompt::build_resume`), (b) a PR with failing CI to fix
    (`ci_failing`), (c) a PR whose auto-merge failed on a conflict to resolve
    (`merge_conflict` → `prompt::build_merge_conflict`: merge the base in, resolve,
-   keep migrations linear), (d) top of **To Do** (fresh issue → branch → Claude
-   turn → detect PR → **In Review**, or **park** as `waiting_for_input` if the
-   agent asked a question), then (e) when nothing else is queued, *revisit* a PR it
-   gave up on (`ci_blocked`), cooldown-gated (`REVISIT_COOLDOWN`, 15 min). The agent
+   keep migrations linear), (d) a green PR with unresolved review comments to
+   address (`addressing_review` → `prompt::build_address_review`: apply/decline
+   each comment, reply, resolve the threads, push), (e) top of **To Do** (fresh
+   issue → branch → Claude turn → detect PR → **In Review**, or **park** as
+   `waiting_for_input` if the agent asked a question), then (f) when nothing else is
+   queued, *revisit* a PR it gave up on (`ci_blocked`), cooldown-gated
+   (`REVISIT_COOLDOWN`, 15 min). The agent
    asks via the `seraphim-ask` CLI and records environment recommendations via the
    `seraphim-suggest` CLI (both baked into the workspace image), posting to
    `POST /agent/questions` and `POST /agent/suggestions`; the exec injects
@@ -302,7 +305,9 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    have all merged. The pure, unit-tested `orchestrator::review::decide` takes the
    tick's action from the set of PRs (`refresh_task_prs` updates each PR's CI +
    lifecycle first): any open PR failing → hand back to the agent; any pending →
-   wait; merge the green `auto_squash_merge` PRs now; once all are settled and at
+   wait; once every open PR is green, before merging or holding, address any
+   unresolved review comments (see below); then merge the green `auto_squash_merge`
+   PRs now; once all are settled and at
    least one merged → **Done** (and, for a GitHub-sourced task, close the linked
    issue with `state_reason: "completed"` when `close_issue_on_done` is set, the
    default; best-effort); open passing human-review PRs → hold. A red PR is bounded
@@ -314,6 +319,25 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    pushes nothing (genuinely unresolvable) or the budget is exhausted, it falls
    back to `ci_blocked` for a human. The single-PR case is just a one-row set, so
    its behavior is unchanged.
+   - **Review-comment addressing (issue #255):** a green, (auto-)approved PR can
+     still carry unresolved review threads from the org CI reviewer bots
+     (`mooreslabai-claude`, `mooreslabai-codex`) or humans, which auto-merge would
+     otherwise paper over. Before merging (auto policy) or holding (human-review
+     policy), `review::decide` checks each green open PR for unresolved review
+     threads (octocrab GraphQL `reviewThreads { isResolved }`, via
+     `git::list_unresolved_review_threads`; only inline review threads count, so
+     purely informational or approving comments never block). If any are
+     actionable and the task has attempts left, it flags `addressing_review`
+     (`queries::flag_review_addressing`) and emits a synthetic `ci`-style feed
+     note; the agent loop then picks it up (`pick_next_review_address`) and runs an
+     addressing turn (`build_address_review`) listing each comment tagged with
+     `repo#pr` + `file:line` + author + body, plus the handles to reply and
+     resolve. The turn is best-effort and never blocks on "nothing pushed" (a
+     comment may only warrant a reply or be declined): it always returns to review.
+     Bounded by `MAX_REVIEW_FIX_ATTEMPTS` (3) on a dedicated `review_fix_attempts`
+     counter (separate from `ci_fix_attempts`); once the threads are resolved the
+     loop merges, and once the budget is spent the threads no longer block the
+     merge, so the queue never stalls on a genuinely unresolvable thread.
 4. **defibrillator** (dead-agent management) — recovers turns that die mid-flight,
    which we call a **"heart attack"**: the agent hangs with no output, its stream
    breaks, or the turn aborts internally, leaving the card stranded `in_progress`

--- a/api/migrations/0041_addressing_review_status.sql
+++ b/api/migrations/0041_addressing_review_status.sql
@@ -1,0 +1,19 @@
+-- PR review-comment addressing before auto-merge (issue #255).
+--
+-- Once a task's pull requests are green and (auto-)approved, but before the final
+-- merge, the review loop checks for unresolved review threads (from the org CI
+-- reviewer bots AND humans). If any are present, the task is handed back to the
+-- agent to address them: push commits, reply to and resolve the threads. A new
+-- operational sub-state marks such a task so the agent picks it up proactively,
+-- re-engages on its branch, and the review loop re-checks afterwards. It is
+-- bounded by its own attempt budget; once the threads are resolved (or the budget
+-- is spent) the review loop proceeds to merge, so the queue never stalls.
+--
+-- Adding an enum value is transaction-safe on Postgres 12+ as long as the value
+-- isn't used in this same migration (it isn't).
+ALTER TYPE task_status ADD VALUE IF NOT EXISTS 'addressing_review'; -- green PR with unresolved review threads; agent to address
+
+-- How many addressing turns the agent has already spent on this task's review
+-- comments. Kept separate from ci_fix_attempts so the CI-fix and review-address
+-- cycles bound independently (a PR can legitimately need both).
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS review_fix_attempts INTEGER NOT NULL DEFAULT 0;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -127,6 +127,10 @@ pub enum TaskStatus {
     /// Auto-merge failed (typically a conflict with the base because another PR
     /// landed first); queued for the agent to resolve and push, then re-merge.
     MergeConflict,
+    /// The PR is green and (auto-)approved but has unresolved review threads
+    /// (reviewer bots or humans); queued for the agent to address them before the
+    /// merge proceeds.
+    AddressingReview,
     Merging,
     Done,
     Failed,
@@ -547,6 +551,9 @@ pub struct Task {
     pub error: Option<String>,
     /// Fix turns already spent on this task's failing CI (bounds retry thrash).
     pub ci_fix_attempts: i32,
+    /// Addressing turns already spent on this task's PR review comments (bounds
+    /// retry thrash, independent of `ci_fix_attempts`).
+    pub review_fix_attempts: i32,
     pub hold: bool,
     /// When true, while this task is in progress the agent pulls no new work, so
     /// dependent tasks wait until it finishes (queue serialization).

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1903,7 +1903,8 @@ pub async fn set_task_status(pool: &PgPool, id: Uuid, status: TaskStatus) -> sql
 pub async fn reclaim_orphaned_tasks(pool: &PgPool) -> sqlx::Result<u64> {
     let result = sqlx::query(
         "UPDATE tasks SET board_column = 'todo', status = 'queued', error = NULL, \
-         ci_fix_attempts = 0, updated_at = now() WHERE board_column = 'in_progress'",
+         ci_fix_attempts = 0, review_fix_attempts = 0, updated_at = now() \
+         WHERE board_column = 'in_progress'",
     )
     .execute(pool)
     .await?;
@@ -1998,11 +1999,41 @@ pub async fn pick_next_merge_conflict(
     .await
 }
 
+/// The next PR whose unresolved review comments the agent should address: top of
+/// `In Review` flagged `addressing_review`, not on hold.
+///
+/// Like [`pick_next_ci_fix`] this re-engages an existing PR, so it takes priority
+/// over fresh To Do work; placed after CI fixes and conflict resolution since a
+/// red or unmergeable PR is the more urgent block.
+pub async fn pick_next_review_address(
+    pool: &PgPool,
+    railway_id: Uuid,
+) -> sqlx::Result<Option<Task>> {
+    sqlx::query_as::<_, Task>(
+        "SELECT * FROM tasks WHERE board_column = 'in_review' AND status = 'addressing_review' \
+         AND hold = FALSE AND railway_id = $1 ORDER BY position ASC LIMIT 1",
+    )
+    .bind(railway_id)
+    .fetch_optional(pool)
+    .await
+}
+
 /// Increments a task's CI-fix attempt counter, returning the new count.
 pub async fn bump_ci_fix_attempt(pool: &PgPool, id: Uuid) -> sqlx::Result<i32> {
     sqlx::query_scalar(
         "UPDATE tasks SET ci_fix_attempts = ci_fix_attempts + 1, last_activity_at = now(), \
          updated_at = now() WHERE id = $1 RETURNING ci_fix_attempts",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+}
+
+/// Increments a task's review-address attempt counter, returning the new count.
+pub async fn bump_review_fix_attempt(pool: &PgPool, id: Uuid) -> sqlx::Result<i32> {
+    sqlx::query_scalar(
+        "UPDATE tasks SET review_fix_attempts = review_fix_attempts + 1, last_activity_at = now(), \
+         updated_at = now() WHERE id = $1 RETURNING review_fix_attempts",
     )
     .bind(id)
     .fetch_one(pool)
@@ -2068,6 +2099,24 @@ pub async fn flag_merge_conflict(pool: &PgPool, id: Uuid, note: &str) -> sqlx::R
     .bind(id)
     .bind(TaskStatus::MergeConflict)
     .bind(note)
+    .fetch_one(pool)
+    .await
+}
+
+/// Flags a green, (auto-)approved PR that still has unresolved review threads for
+/// the agent to address before the merge. The card keeps its `in_review` lane and
+/// PR; only the status changes so the agent picks it up proactively.
+///
+/// Like [`flag_merge_conflict`] this does not set `finished_at` (the task is not
+/// finished, just handed back). It clears `error` because this is a normal step,
+/// not a failure, so a stale CI/conflict note doesn't linger on the card.
+pub async fn flag_review_addressing(pool: &PgPool, id: Uuid) -> sqlx::Result<Task> {
+    sqlx::query_as::<_, Task>(
+        "UPDATE tasks SET status = $2, error = NULL, last_activity_at = now(), updated_at = now() \
+         WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(TaskStatus::AddressingReview)
     .fetch_one(pool)
     .await
 }

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -238,6 +238,164 @@ pub async fn pr_status(octo: &Octocrab, owner: &str, repo: &str, number: u64) ->
     })
 }
 
+/// One unresolved review thread on a pull request, reduced to its originating
+/// (first) comment, which is the actionable item the agent must address.
+///
+/// Carries the GraphQL `thread_id` (for `resolveReviewThread`) and the REST
+/// `comment_id` of the first comment (for posting a reply), so the agent has the
+/// exact handles it needs without re-deriving them.
+#[derive(Debug, Clone)]
+pub struct ReviewThread {
+    pub repo_full_name: String,
+    pub pr_number: i64,
+    /// GraphQL node id of the thread, used to resolve it once handled.
+    pub thread_id: String,
+    /// REST database id of the originating comment, used to reply to it. `None`
+    /// if GitHub did not surface one (e.g. a comment from a deleted account).
+    pub comment_id: Option<i64>,
+    /// The file the thread is anchored to (`None` for a file-less thread).
+    pub path: Option<String>,
+    /// The line the thread is anchored to, when GitHub still resolves it (an
+    /// outdated thread may report none).
+    pub line: Option<i64>,
+    pub author: String,
+    pub body: String,
+}
+
+/// Lists a pull request's unresolved review threads (inline review comments not
+/// marked resolved), from reviewer bots and humans alike, via the GraphQL API.
+///
+/// REST has no notion of thread resolution, so this uses GraphQL `reviewThreads`.
+/// Only each thread's first (originating) comment is returned, the actionable
+/// item; replies are omitted to keep the brief focused. Resolved threads and
+/// threads with no comment are skipped. Capped at the first 100 threads, which
+/// comfortably covers any real PR.
+///
+/// # Errors
+/// If the GraphQL request fails or the response can't be parsed.
+pub async fn list_unresolved_review_threads(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> Result<Vec<ReviewThread>> {
+    // First 100 threads, first comment of each: the originating comment carries
+    // the file/line/author/body the agent needs to act, plus the handles to reply
+    // and resolve.
+    const QUERY: &str = "\
+        query($owner:String!,$repo:String!,$number:Int!){\
+          repository(owner:$owner,name:$repo){\
+            pullRequest(number:$number){\
+              reviewThreads(first:100){\
+                nodes{\
+                  id isResolved\
+                  comments(first:1){\
+                    nodes{ databaseId path line originalLine body author{login} }\
+                  }\
+                }\
+              }\
+            }\
+          }\
+        }";
+
+    let response: ReviewThreadsResponse = octo
+        .graphql(&json!({
+            "query": QUERY,
+            "variables": { "owner": owner, "repo": repo, "number": number },
+        }))
+        .await
+        .wrap_err("failed to query pull request review threads")?;
+
+    let nodes = response
+        .data
+        .and_then(|data| data.repository)
+        .and_then(|repository| repository.pull_request)
+        .map(|pull| pull.review_threads.nodes)
+        .unwrap_or_default();
+
+    let mut threads = Vec::new();
+    for node in nodes {
+        if node.is_resolved {
+            continue;
+        }
+        let Some(comment) = node.comments.nodes.into_iter().next() else {
+            continue; // A thread with no comment has nothing to address.
+        };
+        threads.push(ReviewThread {
+            repo_full_name: format!("{owner}/{repo}"),
+            pr_number: i64::try_from(number).unwrap_or_default(),
+            thread_id: node.id,
+            comment_id: comment.database_id,
+            path: comment.path,
+            // Fall back to the original line when the current line is stale.
+            line: comment.line.or(comment.original_line),
+            author: comment
+                .author
+                .map(|author| author.login)
+                .unwrap_or_default(),
+            body: comment.body,
+        });
+    }
+    Ok(threads)
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewThreadsResponse {
+    data: Option<ReviewThreadsData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewThreadsData {
+    repository: Option<ReviewRepositoryNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewRepositoryNode {
+    #[serde(rename = "pullRequest")]
+    pull_request: Option<ReviewPullRequestNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewPullRequestNode {
+    #[serde(rename = "reviewThreads")]
+    review_threads: ReviewThreadConnection,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewThreadConnection {
+    nodes: Vec<ReviewThreadNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewThreadNode {
+    id: String,
+    #[serde(rename = "isResolved")]
+    is_resolved: bool,
+    comments: ReviewCommentConnection,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewCommentConnection {
+    nodes: Vec<ReviewCommentNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewCommentNode {
+    #[serde(rename = "databaseId")]
+    database_id: Option<i64>,
+    path: Option<String>,
+    line: Option<i64>,
+    #[serde(rename = "originalLine")]
+    original_line: Option<i64>,
+    body: String,
+    author: Option<ReviewAuthorNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewAuthorNode {
+    login: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct CombinedStatus {
     state: String,

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -95,6 +95,11 @@ const PR_DETECT_GRACE: Duration = Duration::from_secs(15 * 60);
 /// for a human. Bounds thrash when a failure is unfixable or out of scope.
 const MAX_CI_FIX_ATTEMPTS: i32 = 3;
 
+/// How many turns the agent spends addressing a PR's review comments before the
+/// merge proceeds regardless. Bounds thrash when a reviewer thread is one the
+/// agent can't (or won't) resolve, so the queue never stalls on it.
+const MAX_REVIEW_FIX_ATTEMPTS: i32 = 3;
+
 /// How long a blocked PR rests before the idle agent circles back to retry it,
 /// so a genuinely stuck PR is revisited periodically rather than in a tight loop.
 const REVISIT_COOLDOWN: Duration = Duration::from_secs(15 * 60);
@@ -150,6 +155,9 @@ enum WorkMode {
     /// A PR whose auto-merge failed on a conflict: re-engage to merge the base in
     /// and resolve it, then let the review loop re-merge.
     ResolveConflict,
+    /// A green, (auto-)approved PR with unresolved review threads: re-engage to
+    /// address the comments (push fixes, reply, resolve) before the merge.
+    AddressReview,
     /// A PR the agent gave up on (CI or merge conflict), retried while idle.
     Revisit,
 }
@@ -1346,6 +1354,13 @@ async fn next_actionable_task(
     if let Some(task) = queries::pick_next_merge_conflict(&state.db, railway.id).await? {
         return Ok(Some((task, WorkMode::ResolveConflict)));
     }
+    // Addressing a green PR's review comments also re-engages an existing PR, so
+    // it takes priority over fresh work (but sits below CI and conflict fixes,
+    // which unblock a red or unmergeable PR). The review loop flagged it once the
+    // PR was green with unresolved threads.
+    if let Some(task) = queries::pick_next_review_address(&state.db, railway.id).await? {
+        return Ok(Some((task, WorkMode::AddressReview)));
+    }
     // A blocking task in progress (being worked or parked waiting for input)
     // serializes this railway's queue: pull no new To Do work until it finishes.
     // Resumes and CI fixes above continue existing in-flight work and are not gated.
@@ -1384,9 +1399,10 @@ async fn work_task(
         WorkMode::Resume => work_fresh(state, handle, task, true).await,
         // Every "re-engage on an existing PR" mode shares one flow; the mode only
         // chooses the prompt and whether the attempt budget is reset.
-        WorkMode::FixCi | WorkMode::ResolveConflict | WorkMode::Revisit => {
-            work_pr_fix(state, handle, task, mode).await
-        }
+        WorkMode::FixCi
+        | WorkMode::ResolveConflict
+        | WorkMode::AddressReview
+        | WorkMode::Revisit => work_pr_fix(state, handle, task, mode).await,
     }
 }
 
@@ -1635,6 +1651,13 @@ async fn work_pr_fix(
             task.error.as_deref().unwrap_or_default(),
             &comments,
         ),
+        WorkMode::AddressReview => {
+            // Gather the unresolved review threads across the task's PRs so the
+            // prompt lists each one (best-effort; an empty list falls back to a
+            // "inspect them yourself" note in the builder).
+            let threads = collect_unresolved_review_threads(state, &github, &task).await;
+            prompt::build_address_review(&settings, &repo, &task, &branch, &threads, &comments)
+        }
         WorkMode::Revisit => prompt::build_revisit(
             &settings,
             &repo,
@@ -1643,12 +1666,18 @@ async fn work_pr_fix(
             task.error.as_deref().unwrap_or_default(),
             &comments,
         ),
-        // work_task only routes the three PR-fix modes here.
+        // work_task only routes the PR-fix modes here.
         WorkMode::Fresh | WorkMode::Resume => {
             unreachable!("work_pr_fix is only called for PR-fix modes")
         }
     };
-    let attempt = queries::bump_ci_fix_attempt(&state.db, task.id).await?;
+    // Review addressing has its own attempt budget; the CI/conflict/revisit modes
+    // share the CI-fix counter.
+    let attempt = if mode == WorkMode::AddressReview {
+        queries::bump_review_fix_attempt(&state.db, task.id).await?
+    } else {
+        queries::bump_ci_fix_attempt(&state.db, task.id).await?
+    };
     let outcome = run_agent_turn(state, handle, &settings, &task, prompt).await?;
     persist_session(state, handle, &outcome).await?;
     // A hard reset during the turn owns this task now; yield to it.
@@ -1667,6 +1696,18 @@ async fn work_pr_fix(
     }
     if let Some(message) = outcome.error {
         return fail(state, &task, &message).await;
+    }
+
+    // Review addressing is best-effort and must never stall the queue: whether or
+    // not the agent pushed a commit (a comment may only warrant a reply, or be one
+    // it declines), return to review. The review loop re-checks the threads and,
+    // once they are resolved or the budget is spent, proceeds to merge.
+    if mode == WorkMode::AddressReview {
+        queries::move_task(&state.db, task.id, TaskColumn::InReview, task.position).await?;
+        queries::set_task_status(&state.db, task.id, TaskStatus::AwaitingReview).await?;
+        state.notify_board();
+        info!(task_id = %task.id, attempt, "addressed review comments; awaiting re-check");
+        return Ok(());
     }
 
     // A pushed commit moves a tip in some repo; nothing pushed in any means the
@@ -2158,10 +2199,21 @@ async fn review_task(
     for pr in &prs {
         let auto_merge =
             pr_repo_policy(state, settings, pr).await? == ReviewPolicy::AutoSquashMerge;
-        views.push(pr_review_of(pr, auto_merge));
+        // Only a green, open PR is a candidate for addressing review comments. For
+        // any other state CI handling or the merge takes priority anyway, so skip
+        // the extra GraphQL lookup.
+        let unresolved_review = if pr.pr_state == "open" && pr.ci_state == "passing" {
+            pr_has_unresolved_review_threads(github, pr).await
+        } else {
+            false
+        };
+        views.push(pr_review_of(pr, auto_merge, unresolved_review));
     }
 
-    match review::decide(&views) {
+    // Once the attempt budget is spent, unresolved threads no longer block the
+    // merge, so a thread the agent can't resolve can't stall the task forever.
+    let review_attempts_remaining = task.review_fix_attempts < MAX_REVIEW_FIX_ATTEMPTS;
+    match review::decide(&views, review_attempts_remaining) {
         // Still settling (CI pending, or no actionable PR this tick): re-check next.
         ReviewDecision::Wait => {}
         // Open, passing PRs remain that need a human to merge; keep awaiting. Only
@@ -2175,6 +2227,9 @@ async fn review_task(
         }
         // A failing PR: hand back to the agent (or block once the cap is hit).
         ReviewDecision::Fix => handle_ci_failing(state, github, task, &prs).await?,
+        // A green PR with unresolved review threads: hand back to the agent to
+        // address the comments before the merge.
+        ReviewDecision::AddressReview => handle_review_addressing(state, task).await?,
         // Merge the green, auto-merge PRs now; the next tick finishes once all are.
         ReviewDecision::Merge(indices) => {
             merge_task_prs(state, github, task, &prs, &indices).await?;
@@ -2530,8 +2585,10 @@ async fn pr_repo_policy(
     Ok(policy.unwrap_or(settings.default_review_policy))
 }
 
-/// Maps a stored PR row to the pure review view.
-fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool) -> PrReview {
+/// Maps a stored PR row to the pure review view. `unresolved_review` is whether
+/// the open PR still carries unresolved review threads to address (only computed,
+/// and only meaningful, for a green open PR).
+fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool, unresolved_review: bool) -> PrReview {
     match pr.pr_state.as_str() {
         "merged" => PrReview::Merged,
         "closed" => PrReview::Closed,
@@ -2542,8 +2599,83 @@ fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool) -> PrReview {
                 _ => PrCi::Pending,
             },
             auto_merge,
+            unresolved_review,
         },
     }
+}
+
+/// Whether a tracked PR has any unresolved review threads (reviewer-bot or human).
+/// Best-effort: a malformed repo name or a GraphQL failure is logged and treated
+/// as "none", so a transient lookup error never blocks an otherwise-ready merge.
+async fn pr_has_unresolved_review_threads(
+    github: &octocrab::Octocrab,
+    pr: &TaskPullRequest,
+) -> bool {
+    let Some((owner, name)) = pr.repo_full_name.split_once('/') else {
+        return false;
+    };
+    let number = u64::try_from(pr.pr_number).unwrap_or_default();
+    match git::list_unresolved_review_threads(github, owner, name, number).await {
+        Ok(threads) => !threads.is_empty(),
+        Err(error) => {
+            warn!(error = %error, pr = %pr.pr_url, "could not list review threads; treating as none");
+            false
+        }
+    }
+}
+
+/// Gathers the unresolved review threads across all of a task's open PRs, for the
+/// addressing prompt. Best-effort: a lookup that fails for one PR is logged and
+/// skipped rather than failing the whole turn.
+async fn collect_unresolved_review_threads(
+    state: &AppState,
+    github: &octocrab::Octocrab,
+    task: &Task,
+) -> Vec<git::ReviewThread> {
+    let mut threads = Vec::new();
+    let prs = match queries::list_task_prs(&state.db, task.id).await {
+        Ok(prs) => prs,
+        Err(error) => {
+            warn!(error = %error, task_id = %task.id, "could not list task PRs for review threads");
+            return threads;
+        }
+    };
+    for pr in prs {
+        if pr.pr_state != "open" {
+            continue;
+        }
+        let Some((owner, name)) = pr.repo_full_name.split_once('/') else {
+            continue;
+        };
+        let number = u64::try_from(pr.pr_number).unwrap_or_default();
+        match git::list_unresolved_review_threads(github, owner, name, number).await {
+            Ok(mut found) => threads.append(&mut found),
+            Err(error) => {
+                warn!(error = %error, pr = %pr.pr_url, "could not list review threads for the prompt");
+            }
+        }
+    }
+    threads
+}
+
+/// Hands a task back to the agent to address its PR review comments: flags it
+/// `addressing_review` (the agent loop picks it up via `pick_next_review_address`)
+/// and emits a feed line so the addressing pass is visible.
+async fn handle_review_addressing(state: &AppState, task: &Task) -> Result<()> {
+    // Only act on the transition; a steady-state re-detect each tick stays quiet.
+    if task.status != TaskStatus::AddressingReview {
+        queries::flag_review_addressing(&state.db, task.id).await?;
+        emit_ci_note(
+            state,
+            task.id,
+            "Addressing PR review comments before merge",
+            "review-address",
+        )
+        .await?;
+        state.notify_board();
+        info!(task_id = %task.id, "green PR has unresolved review comments; handing back to the agent");
+    }
+    Ok(())
 }
 
 /// The repos whose branch the CI-fix turn should check out: the focus repo (so
@@ -2714,6 +2846,23 @@ async fn emit_lifecycle_event(
     state.notify_task(
         task_id,
         serde_json::json!({ "type": "lifecycle", "payload": payload, "created_at": Utc::now() }),
+    );
+    Ok(())
+}
+
+/// Emits a synthetic, informational `ci`-style event onto a task's feed and
+/// history (`status: "info"`, which renders neutral). Used for orchestration
+/// moments that aren't a Claude or PR-lifecycle event, e.g. starting the
+/// review-comment addressing pass. Reuses the synthetic CI turn like the CI-step
+/// watcher and the lifecycle events, so it renders with no special transport.
+async fn emit_ci_note(state: &AppState, task_id: uuid::Uuid, text: &str, key: &str) -> Result<()> {
+    let turn = queries::get_or_create_ci_turn(&state.db, task_id).await?;
+    let seq = queries::next_event_seq(&state.db, turn.id).await?;
+    let payload = serde_json::json!({ "status": "info", "text": text, "key": key });
+    queries::append_event(&state.db, turn.id, seq, "ci", payload.clone()).await?;
+    state.notify_task(
+        task_id,
+        serde_json::json!({ "type": "ci", "payload": payload, "created_at": Utc::now() }),
     );
     Ok(())
 }
@@ -3146,6 +3295,7 @@ mod tests {
             pr_url: None,
             error: None,
             ci_fix_attempts: 0,
+            review_fix_attempts: 0,
             hold: false,
             blocking: false,
             notes: String::new(),

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -6,7 +6,7 @@
 //! PR, or a CI-fix protocol that re-engages on the PR's existing branch.
 
 use crate::db::models::{AnswerKind, Question, Repository, Settings, SourceKind, Task};
-use crate::git::IssueComment;
+use crate::git::{IssueComment, ReviewThread};
 
 use super::provision::repo_dir_name;
 
@@ -239,6 +239,132 @@ pub fn build_revisit(
     ));
 
     prompt
+}
+
+/// Builds the instruction text to address unresolved PR review comments before
+/// the PR merges.
+///
+/// Sent when a task's PR(s) are green and (auto-)approved but still carry
+/// unresolved review threads, from the org CI reviewer bots or humans. The agent
+/// works the existing `branch` (each repo with a PR is checked out): it makes the
+/// changes the actionable comments call for, replies to and resolves the threads
+/// it handles, and pushes, after which the review loop re-checks and merges.
+/// `threads` are the unresolved threads across the task's PRs (each tagged with
+/// its `repo#pr` plus `file:line`). The pass is best-effort: the agent is told to
+/// reply and move on rather than force out-of-scope changes, so the queue never
+/// stalls.
+pub fn build_address_review(
+    settings: &Settings,
+    repo: &Repository,
+    task: &Task,
+    branch: &str,
+    threads: &[ReviewThread],
+    comments: &[IssueComment],
+) -> String {
+    let repo_path = format!("/workspace/{}", repo_dir_name(&repo.full_name));
+    let mut prompt = context_header(settings, repo, task, comments);
+
+    prompt.push_str(&format!(
+        "# Addressing pull request review comments\n\
+         - Your pull request for this issue passed CI and was (auto-)approved, but reviewers \
+         (the org CI reviewer bots and/or humans) left review comments that have not been \
+         addressed. Make a best-effort pass to address them before the merge.\n\
+         - Your cwd is `/workspace`. The focus repo `{repo}` is at `{repo_path}`, already checked \
+         out on branch `{branch}` with your earlier commits. If this issue spans several repos, \
+         each one with a PR is also checked out on `{branch}` as a sibling directory; each comment \
+         below is tagged with its `repo#pr` so you know which repo it belongs to.\n\
+         - These automated reviewers (and humans) are NOT the authority on the code; you are. They \
+         can be wrong, hallucinate, or ask for defensive code that isn't warranted. Apply the \
+         comments that genuinely improve the change; for ones you disagree with or that are out of \
+         scope, do not force the change.\n\
+         - For each comment you act on: make the fix on this branch. For each comment you decline: \
+         decide deliberately. Either way, reply to the thread (a short note saying what you did or \
+         why you didn't) and resolve it, so the conversation is closed out.\n\
+         {reply}\
+         - When you have addressed what you reasonably can, run the project's build/tests/linters, \
+         then commit and push. Do not open a new pull request; the existing one updates \
+         automatically. It is fine if a comment needs no code change (a reply and resolve is \
+         enough).\n\
+         - Do not get stuck: if a thread needs a decision you can't make or is genuinely \
+         unresolvable, leave a brief reply explaining why and move on. The merge proceeds once the \
+         threads are handled or the attempt budget is spent.\n\
+         - After pushing (or replying where no code change was needed), stop and finish with a short \
+         summary. Do not watch or wait for CI; Seraphim re-checks the PR and merges it (or brings \
+         you back) automatically.\n\n",
+        repo = repo.full_name,
+        repo_path = repo_path,
+        branch = branch,
+        reply = REVIEW_THREAD_COMMANDS,
+    ));
+
+    prompt.push_str(&render_review_threads(threads));
+    prompt
+}
+
+/// Concrete commands for replying to and resolving a review thread, shared into
+/// the addressing prompt so the agent has exact handles rather than guessing.
+const REVIEW_THREAD_COMMANDS: &str = "\
+    - To reply to a thread, post to its first comment id (the `comment id` shown below):\n\
+    \x20    `gh api repos/OWNER/REPO/pulls/PR/comments/COMMENT_ID/replies -X POST -f body='...'`\n\
+    - To resolve a thread, use the GraphQL `resolveReviewThread` mutation on its thread id (the \
+    `thread id` shown below):\n\
+    \x20    `gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:\"THREAD_ID\"})\
+    {thread{id}}}'`\n";
+
+/// Renders the unresolved review threads for the addressing brief, each tagged
+/// with `repo#pr`, its `file:line`, the author, and the identifiers the agent
+/// needs to reply and resolve. Returns a short fallback when the list is empty.
+fn render_review_threads(threads: &[ReviewThread]) -> String {
+    if threads.is_empty() {
+        return "# Review comments\n(The unresolved comments could not be enumerated; inspect the \
+                PR's review threads yourself with `gh api` or `gh pr view`.)\n"
+            .to_string();
+    }
+
+    let mut section = format!(
+        "# Review comments\n\
+         {count} unresolved review thread{plural} across this task's pull request(s), each with \
+         the handles to reply and resolve it:\n\n",
+        count = threads.len(),
+        plural = if threads.len() == 1 { "" } else { "s" },
+    );
+
+    for (index, thread) in threads.iter().enumerate() {
+        let location = match (&thread.path, thread.line) {
+            (Some(path), Some(line)) => format!("{path}:{line}"),
+            (Some(path), None) => path.clone(),
+            _ => "(not anchored to a file)".to_string(),
+        };
+        let author = if thread.author.is_empty() {
+            "unknown"
+        } else {
+            &thread.author
+        };
+        let comment_id = thread
+            .comment_id
+            .map_or_else(|| "(unknown)".to_string(), |id| id.to_string());
+        let owner_repo = thread
+            .repo_full_name
+            .split('/')
+            .next_back()
+            .unwrap_or(&thread.repo_full_name);
+        section.push_str(&format!(
+            "## {n}. {repo}#{pr} {location} (by {author})\n\
+             - repo: {full_repo} | thread id: {thread_id} | comment id: {comment_id}\n\
+             {body}\n\n",
+            n = index + 1,
+            repo = owner_repo,
+            pr = thread.pr_number,
+            location = location,
+            author = author,
+            full_repo = thread.repo_full_name,
+            thread_id = thread.thread_id,
+            comment_id = comment_id,
+            body = thread.body.trim(),
+        ));
+    }
+
+    section
 }
 
 /// The shared prompt header: who the agent is, the org/global/repo instructions,
@@ -570,6 +696,7 @@ mod tests {
             pr_url: None,
             error: None,
             ci_fix_attempts: 0,
+            review_fix_attempts: 0,
             hold: false,
             blocking: false,
             notes: String::new(),
@@ -713,6 +840,61 @@ mod tests {
         assert!(prompt.contains("single linear sequence"));
         // It must not tell the agent to open a new PR; the existing one updates.
         assert!(prompt.contains("Do not open a new pull request"));
+    }
+
+    fn review_thread(
+        repo_full_name: &str,
+        pr: i64,
+        path: &str,
+        line: i64,
+        author: &str,
+        body: &str,
+    ) -> ReviewThread {
+        ReviewThread {
+            repo_full_name: repo_full_name.to_string(),
+            pr_number: pr,
+            thread_id: "PRRT_thread1".to_string(),
+            comment_id: Some(987_654),
+            path: Some(path.to_string()),
+            line: Some(line),
+            author: author.to_string(),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn address_review_prompt_lists_each_comment_with_its_handles() {
+        let threads = [review_thread(
+            "navarrotech/seraphim",
+            11,
+            "api/src/orchestrator/review.rs",
+            42,
+            "mooreslabai-claude",
+            "This branch can panic on an empty slice.",
+        )];
+        let prompt = build_address_review(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &threads,
+            &[],
+        );
+
+        // It reorients the agent to the addressing pass and stays on the branch.
+        assert!(prompt.contains("Addressing pull request review comments"));
+        assert!(prompt.contains("Do not open a new pull request"));
+        // Each comment is rendered tagged with repo#pr and file:line, plus the
+        // handles the agent needs to reply and resolve.
+        assert!(prompt
+            .contains("seraphim#11 api/src/orchestrator/review.rs:42 (by mooreslabai-claude)"));
+        assert!(prompt.contains("This branch can panic on an empty slice."));
+        assert!(prompt.contains("thread id: PRRT_thread1"));
+        assert!(prompt.contains("comment id: 987654"));
+        // It carries the reply + resolve commands and the not-the-authority guidance.
+        assert!(prompt.contains("resolveReviewThread"));
+        assert!(prompt.contains("/replies"));
+        assert!(prompt.contains("NOT the authority"));
     }
 
     #[test]

--- a/api/src/orchestrator/review.rs
+++ b/api/src/orchestrator/review.rs
@@ -17,9 +17,12 @@ pub enum PrCi {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrReview {
     /// Still open, with its current CI verdict; `auto_merge` is its repo's policy.
+    /// `unresolved_review` is whether it still carries unresolved review threads
+    /// (reviewer-bot or human) the agent should address before the merge.
     Open {
         ci: PrCi,
         auto_merge: bool,
+        unresolved_review: bool,
     },
     Merged,
     /// Closed without merging (the agent or a human abandoned this repo's PR).
@@ -31,6 +34,9 @@ pub enum PrReview {
 pub enum ReviewDecision {
     /// At least one open PR's CI failed: hand the task back to the agent to fix.
     Fix,
+    /// A green PR carries unresolved review threads: hand the task back to the
+    /// agent to address the comments before merging.
+    AddressReview,
     /// Something is still running (CI pending, or no PR detected yet); wait.
     Wait,
     /// These open, passing, auto-merge PRs (by index) should be squash-merged now.
@@ -42,9 +48,14 @@ pub enum ReviewDecision {
 }
 
 /// Decides the next action for a task given its PRs. Order matters: a failing PR
-/// is fixed first; then we wait on any pending CI; then merge what we can; then,
-/// once nothing is open, finish if anything merged.
-pub fn decide(prs: &[PrReview]) -> ReviewDecision {
+/// is fixed first; then we wait on any pending CI; then, once everything is green,
+/// unresolved review comments are addressed (while the budget lasts) before we
+/// merge what we can; then, once nothing is open, finish if anything merged.
+///
+/// `review_attempts_remaining` is whether the task still has addressing turns left
+/// in its budget. Once it is exhausted, unresolved review threads no longer block
+/// the merge, so a genuinely unresolvable thread can't stall the queue forever.
+pub fn decide(prs: &[PrReview], review_attempts_remaining: bool) -> ReviewDecision {
     if prs.is_empty() {
         // Detection hasn't found a PR yet (e.g. GitHub indexing lag); re-check.
         return ReviewDecision::Wait;
@@ -74,6 +85,23 @@ pub fn decide(prs: &[PrReview]) -> ReviewDecision {
         return ReviewDecision::Wait;
     }
 
+    // Everything open is green. Before merging (auto policy) or holding for a human
+    // (human-review policy), address any unresolved review threads on a green PR,
+    // for either policy, as long as the attempt budget lasts.
+    if review_attempts_remaining
+        && prs.iter().any(|pr| {
+            matches!(
+                pr,
+                PrReview::Open {
+                    unresolved_review: true,
+                    ..
+                }
+            )
+        })
+    {
+        return ReviewDecision::AddressReview;
+    }
+
     let to_merge: Vec<usize> = prs
         .iter()
         .enumerate()
@@ -82,7 +110,8 @@ pub fn decide(prs: &[PrReview]) -> ReviewDecision {
                 pr,
                 PrReview::Open {
                     ci: PrCi::Passing,
-                    auto_merge: true
+                    auto_merge: true,
+                    ..
                 }
             )
         })
@@ -111,24 +140,47 @@ mod tests {
     use super::*;
 
     fn open(ci: PrCi, auto_merge: bool) -> PrReview {
-        PrReview::Open { ci, auto_merge }
+        PrReview::Open {
+            ci,
+            auto_merge,
+            unresolved_review: false,
+        }
+    }
+
+    fn open_with_comments(ci: PrCi, auto_merge: bool) -> PrReview {
+        PrReview::Open {
+            ci,
+            auto_merge,
+            unresolved_review: true,
+        }
+    }
+
+    // Most cases don't exercise the budget, so they pass it as available.
+    fn decide_ready(prs: &[PrReview]) -> ReviewDecision {
+        decide(prs, true)
     }
 
     #[test]
     fn no_prs_waits() {
-        assert_eq!(decide(&[]), ReviewDecision::Wait);
+        assert_eq!(decide_ready(&[]), ReviewDecision::Wait);
     }
 
     #[test]
     fn single_pr_mirrors_the_old_flow() {
         // pending -> wait, passing+auto -> merge, merged -> done.
-        assert_eq!(decide(&[open(PrCi::Pending, true)]), ReviewDecision::Wait);
         assert_eq!(
-            decide(&[open(PrCi::Passing, true)]),
+            decide_ready(&[open(PrCi::Pending, true)]),
+            ReviewDecision::Wait
+        );
+        assert_eq!(
+            decide_ready(&[open(PrCi::Passing, true)]),
             ReviewDecision::Merge(vec![0])
         );
-        assert_eq!(decide(&[PrReview::Merged]), ReviewDecision::Done);
-        assert_eq!(decide(&[open(PrCi::Failing, true)]), ReviewDecision::Fix);
+        assert_eq!(decide_ready(&[PrReview::Merged]), ReviewDecision::Done);
+        assert_eq!(
+            decide_ready(&[open(PrCi::Failing, true)]),
+            ReviewDecision::Fix
+        );
     }
 
     #[test]
@@ -138,13 +190,13 @@ mod tests {
             open(PrCi::Failing, true),
             PrReview::Merged,
         ];
-        assert_eq!(decide(&prs), ReviewDecision::Fix);
+        assert_eq!(decide_ready(&prs), ReviewDecision::Fix);
     }
 
     #[test]
     fn waits_for_a_pending_pr_before_merging_others() {
         let prs = [open(PrCi::Passing, true), open(PrCi::Pending, true)];
-        assert_eq!(decide(&prs), ReviewDecision::Wait);
+        assert_eq!(decide_ready(&prs), ReviewDecision::Wait);
     }
 
     #[test]
@@ -155,27 +207,69 @@ mod tests {
             PrReview::Merged,
             open(PrCi::Passing, true),
         ];
-        assert_eq!(decide(&prs), ReviewDecision::Merge(vec![0, 2]));
+        assert_eq!(decide_ready(&prs), ReviewDecision::Merge(vec![0, 2]));
     }
 
     #[test]
     fn passing_human_review_pr_holds_for_a_human() {
         let prs = [PrReview::Merged, open(PrCi::Passing, false)];
-        assert_eq!(decide(&prs), ReviewDecision::Hold);
+        assert_eq!(decide_ready(&prs), ReviewDecision::Hold);
+    }
+
+    #[test]
+    fn green_pr_with_unresolved_comments_addresses_before_merge() {
+        // Auto-merge policy: address the comments instead of merging.
+        assert_eq!(
+            decide_ready(&[open_with_comments(PrCi::Passing, true)]),
+            ReviewDecision::AddressReview
+        );
+        // Human-review policy: still address before the human merges.
+        assert_eq!(
+            decide_ready(&[open_with_comments(PrCi::Passing, false)]),
+            ReviewDecision::AddressReview
+        );
+    }
+
+    #[test]
+    fn unresolved_comments_yield_to_failing_or_pending_ci() {
+        // CI takes priority: a failing/pending PR is handled before addressing.
+        assert_eq!(
+            decide_ready(&[open_with_comments(PrCi::Failing, true)]),
+            ReviewDecision::Fix
+        );
+        assert_eq!(
+            decide_ready(&[open_with_comments(PrCi::Pending, true)]),
+            ReviewDecision::Wait
+        );
+    }
+
+    #[test]
+    fn exhausted_budget_merges_over_unresolved_comments() {
+        // With no addressing turns left, the comments no longer block the merge,
+        // so the queue can't stall on a genuinely unresolvable thread.
+        assert_eq!(
+            decide(&[open_with_comments(PrCi::Passing, true)], false),
+            ReviewDecision::Merge(vec![0])
+        );
+        // And a human-review PR just holds for a human.
+        assert_eq!(
+            decide(&[open_with_comments(PrCi::Passing, false)], false),
+            ReviewDecision::Hold
+        );
     }
 
     #[test]
     fn done_only_when_every_pr_is_settled_and_one_merged() {
         // All merged -> done; a closed (abandoned) PR alongside merged still done.
         assert_eq!(
-            decide(&[PrReview::Merged, PrReview::Merged]),
+            decide_ready(&[PrReview::Merged, PrReview::Merged]),
             ReviewDecision::Done
         );
         assert_eq!(
-            decide(&[PrReview::Merged, PrReview::Closed]),
+            decide_ready(&[PrReview::Merged, PrReview::Closed]),
             ReviewDecision::Done
         );
         // All closed, nothing merged -> hold, don't falsely complete.
-        assert_eq!(decide(&[PrReview::Closed]), ReviewDecision::Hold);
+        assert_eq!(decide_ready(&[PrReview::Closed]), ReviewDecision::Hold);
     }
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -12,6 +12,7 @@ export type TaskStatus =
   | 'ci_failing'
   | 'ci_blocked'
   | 'merge_conflict'
+  | 'addressing_review'
   | 'merging'
   | 'done'
   | 'failed'
@@ -27,6 +28,7 @@ export const STATUS_LABELS = {
   ci_failing: 'CI failing',
   ci_blocked: 'CI blocked',
   merge_conflict: 'resolving conflict',
+  addressing_review: 'addressing review',
   merging: 'merging',
   done: 'done',
   failed: 'failed'
@@ -43,6 +45,7 @@ export const STATUS_BADGE = {
   ci_failing: 'border-warning/40 text-warning',
   ci_blocked: 'border-destructive/40 text-destructive',
   merge_conflict: 'border-warning/40 text-warning',
+  addressing_review: 'border-primary/40 text-primary',
   merging: 'border-primary/40 text-primary',
   done: 'border-success/40 text-success',
   failed: 'border-destructive/40 text-destructive'


### PR DESCRIPTION
Closes #255.

## What this does

When a task's pull requests are green and (auto-)approved, the review loop now makes a best-effort pass to address unresolved review comments (from the org CI reviewer bots `mooreslabai-claude` / `mooreslabai-codex` and humans) before the final auto-merge, instead of merging over them.

## How it works

- **New task state `addressing_review`** plus a dedicated `review_fix_attempts` budget (migration `0041`), bounded by `MAX_REVIEW_FIX_ATTEMPTS` (3) and independent of the CI-fix counter.
- **`review::decide` gains an `AddressReview` decision** (still pure + unit-tested): once every open PR is green, if any green PR still carries unresolved review threads and the budget lasts, hand the task back to the agent instead of merging (auto policy) or holding (human-review policy). Once threads are resolved the loop merges; once the budget is spent they no longer block, so the queue never stalls on a genuinely unresolvable thread.
- **`git::list_unresolved_review_threads`** reads unresolved review threads via the GraphQL `reviewThreads { isResolved }` API (REST has no thread-resolution concept). Only inline review threads count, so approving or purely informational comments never block or delay a merge.
- **New agent pick path** (`queries::pick_next_review_address`) between merge-conflict and top-of-To-Do, routed through the shared `work_pr_fix` flow with a new `prompt::build_address_review`. The prompt lists each comment tagged with `repo#pr` + `file:line` + author + body, plus the exact handles to reply (`/replies`) and resolve (`resolveReviewThread`). It reminds the agent the bots are not the authority, and the turn is best-effort: it always returns to review (a comment may only warrant a reply, or be declined), so nothing-pushed never blocks.
- Emits a synthetic `ci`-style feed note when the addressing pass starts, so the live feed shows it.
- Works for multi-repo tasks (each PR in `task_pull_requests` is checked).

## Acceptance criteria

- Agent PRs with reviewer-bot/human inline comments get a follow-up commit and/or thread replies before auto-merge, when actionable. ✅
- Threads the agent addresses are replied to and/or resolved (prompt gives the commands). ✅
- Un-actionable or approving comments do not block or delay merge (only unresolved inline threads trigger). ✅
- Bounded retries (`MAX_REVIEW_FIX_ATTEMPTS`); once spent, merge proceeds. ✅
- Respects review policy (auto_squash_merge merges after; human_review still addresses before a human merges). ✅
- `CLAUDE.md` documents the new state and loop path. ✅

## Testing

- `cargo +1.88 fmt`, `cargo +1.88 clippy --all-targets` (no new warnings), `cargo +1.88 test` (134 passed) including new `review`/`prompt` tests.
- All migrations applied cleanly on an ephemeral PostgreSQL 17; new column + enum value verified.
- `npm run check` (0 errors) and `npm run build` pass.

Branched off `develop`.