### PR TITLE
Auto-base stacked tickets on their open dependency PR branch (#256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,20 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    `POST /agent/questions` and `POST /agent/suggestions`; the exec injects
    `SERAPHIM_TASK_ID` + `SERAPHIM_API_URL`. One task awaited to completion before
    the next (no overlap).
+   - **Stacked dependencies (issue #256):** a fresh ticket that depends on another
+     ticket whose PR is still open builds on a default branch that lacks that work.
+     A `Depends on:` marker in the ticket body (e.g. `Depends on: A1 (package
+     scaffold), #5`) is parsed (pure, unit-tested `orchestrator::dependencies`) and
+     each reference matched, by GitHub issue number or a title word-set match,
+     against the railway's in-flight tasks that have an open PR
+     (`queries::list_open_dependency_candidates`). Each matched dependency's PR
+     branch and its repos are surfaced in the fresh-work prompt
+     (`prompt::build` → "Stacked on unmerged dependencies"), which tells the agent
+     to `git merge origin/<dep-branch>` first and NOT re-implement that work. The
+     branch is still cut from the default branch (issue #256 option 2); merging the
+     dependency in is robust across a chain (A3 → A2 → A1, since A2's branch already
+     carries A1). When the dependency has merged it is no longer an open-PR
+     candidate, so the ticket builds from the default branch as before.
 3. **review** — gates each task on **all** of its pull requests. A task can span
    several repos (the agent opens a same-named branch + PR in each); every PR is
    tracked in `task_pull_requests` and the task only reaches **Done** once they

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -565,6 +565,18 @@ pub struct Task {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A candidate dependency task: an in-flight task (same railway) with an open PR
+/// and a branch, against which a new ticket's `Depends on:` references are matched
+/// to surface its unmerged PR branch (issue #256).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DependencyCandidate {
+    pub id: Uuid,
+    pub source_kind: SourceKind,
+    pub external_id: String,
+    pub title: String,
+    pub branch: String,
+}
+
 /// One pull request opened for a task. A multi-repo task has several; the review
 /// loop gates Done on all of them. `ci_state` is `pending`/`passing`/`failing`
 /// (only meaningful while open); `pr_state` is `open`/`merged`/`closed`.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,11 +12,11 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials, EnvSuggestion, EnvVar,
-    EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel,
-    PendingPlacement, PendingQuestion, Question, QuestionOption, QuestionStatus, Railway,
-    RepoDeletionImpact, RepoSyncError, Repository, ReviewPolicy, Settings, SourceKind,
-    StatsAggregate, Task, TaskColumn, TaskPullRequest, TaskStatus, Turn,
+    AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials, DependencyCandidate,
+    EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment,
+    NetworkAccessLevel, PendingPlacement, PendingQuestion, Question, QuestionOption,
+    QuestionStatus, Railway, RepoDeletionImpact, RepoSyncError, Repository, ReviewPolicy, Settings,
+    SourceKind, StatsAggregate, Task, TaskColumn, TaskPullRequest, TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -2098,6 +2098,28 @@ pub async fn set_task_pr(pool: &PgPool, id: Uuid, pr_url: &str) -> sqlx::Result<
     .bind(id)
     .bind(pr_url)
     .fetch_one(pool)
+    .await
+}
+
+/// In-flight tasks on a railway that have at least one open PR and a branch, as
+/// candidate dependencies for a new ticket (issue #256). Excludes `exclude_id`
+/// (the ticket being started). One row per task (a task with several open PRs
+/// collapses to one). The caller matches the new ticket's `Depends on:`
+/// references against these and resolves the matches to their PR branches.
+pub async fn list_open_dependency_candidates(
+    pool: &PgPool,
+    railway_id: Uuid,
+    exclude_id: Uuid,
+) -> sqlx::Result<Vec<DependencyCandidate>> {
+    sqlx::query_as::<_, DependencyCandidate>(
+        "SELECT DISTINCT t.id, t.source_kind, t.external_id, t.title, t.branch \
+         FROM tasks t \
+         JOIN task_pull_requests p ON p.task_id = t.id AND p.pr_state = 'open' \
+         WHERE t.railway_id = $1 AND t.id <> $2 AND t.branch IS NOT NULL",
+    )
+    .bind(railway_id)
+    .bind(exclude_id)
+    .fetch_all(pool)
     .await
 }
 

--- a/api/src/orchestrator/dependencies.rs
+++ b/api/src/orchestrator/dependencies.rs
@@ -1,0 +1,228 @@
+//! Parsing and matching of a ticket's stated dependencies on other tickets.
+//!
+//! A ticket that builds on another ("A2 depends on A1") can name that dependency
+//! with a `Depends on:` line in its body. When the dependency's pull request is
+//! still open, its work is not yet on the default branch, so a branch cut from the
+//! default branch can't build until the dependency is merged in (issue #256).
+//!
+//! This module turns the free-text marker into reference tokens and matches each
+//! against an in-flight task, so the orchestrator can surface the dependency's PR
+//! branch in the agent's brief. It is pure (no I/O), so the parsing and matching
+//! rules are unit-testable in isolation; the orchestrator supplies the candidate
+//! tasks and resolves the matched ones to PR branches.
+
+use std::collections::HashSet;
+
+/// Words shorter than this (after normalization) are dropped when matching, so a
+/// stray single letter can't pull in an unrelated task. A roadmap key like `a1`
+/// is two characters, so it survives.
+const MIN_SIGNIFICANT_WORD_LEN: usize = 2;
+
+/// Common words carrying no identifying signal, dropped from both sides before
+/// the word-set match so they neither cause nor block a match.
+const STOP_WORDS: &[&str] = &[
+    "the", "and", "for", "with", "this", "that", "from", "into", "ticket", "issue", "pr",
+];
+
+/// Extracts the dependency reference tokens from a ticket body.
+///
+/// Recognizes a `Depends on:` marker (also `Depends:`, `Dependency:`,
+/// `Dependencies:`, with or without a trailing colon, case-insensitive, and
+/// tolerant of leading list bullets and Markdown emphasis), then splits the rest
+/// of that line into individual references on commas, semicolons, and the word
+/// "and". Returns the trimmed tokens in order, deduped, empty when there is no
+/// marker.
+///
+/// For example, `Depends on: A1 (package scaffold), A2 (#5)` yields
+/// `["A1 (package scaffold)", "A2 (#5)"]`.
+pub fn parse_dependency_refs(body: &str) -> Vec<String> {
+    let mut refs: Vec<String> = Vec::new();
+    for line in body.lines() {
+        let Some(rest) = dependency_marker_rest(line) else {
+            continue;
+        };
+        for token in split_references(rest) {
+            let token = token.trim().to_string();
+            // Skip empties and explicit "no dependency" placeholders.
+            let lower = token.to_ascii_lowercase();
+            if token.is_empty() || lower == "none" || lower == "n/a" || lower == "na" {
+                continue;
+            }
+            if !refs.contains(&token) {
+                refs.push(token);
+            }
+        }
+    }
+    refs
+}
+
+/// Returns the text following a `Depends on:`-style marker on `line`, or `None`
+/// if the line is not such a marker. Strips leading list bullets / quote markers
+/// and Markdown emphasis so `- **Depends on:** A1` is recognized.
+fn dependency_marker_rest(line: &str) -> Option<&str> {
+    // Longest markers first so "depends on" wins over "depends".
+    const MARKERS: &[&str] = &["depends on", "dependencies", "dependency", "depends"];
+
+    // Drop leading bullets, quote markers, emphasis, and whitespace. We trim from
+    // the original slice (not a lowercased copy) so the returned text keeps its
+    // original casing for display and number extraction.
+    let trimmed = line.trim_start_matches(|c: char| {
+        c.is_whitespace() || matches!(c, '-' | '*' | '>' | '_' | '`' | '#' | '+')
+    });
+    let lower = trimmed.to_ascii_lowercase();
+    for marker in MARKERS {
+        if let Some(after) = lower.strip_prefix(marker) {
+            // The marker may be followed by a colon and/or emphasis/whitespace; the
+            // remainder must be separated from the marker (a colon or whitespace),
+            // so "dependsonfoo" is not mistaken for a marker.
+            let after_trimmed = after.trim_start_matches(|c: char| {
+                c.is_whitespace() || matches!(c, ':' | '*' | '_' | '`')
+            });
+            if after_trimmed.len() == after.len() {
+                continue; // No separator after the marker; not a real marker.
+            }
+            // Slice the original `trimmed` by the consumed byte length (ASCII
+            // markers, so lengths line up with the lowercased copy).
+            let consumed = trimmed.len() - after_trimmed.len();
+            return Some(trimmed[consumed..].trim());
+        }
+    }
+    None
+}
+
+/// Splits a dependency list into individual reference tokens on commas,
+/// semicolons, and the standalone word "and".
+fn split_references(list: &str) -> Vec<String> {
+    list.split([',', ';'])
+        .flat_map(|part| part.split(" and "))
+        .map(|part| part.trim().to_string())
+        .collect()
+}
+
+/// Whether a parsed reference token names the given candidate task.
+///
+/// Matches in two ways, either sufficient: an explicit GitHub issue number in the
+/// reference (`#5`) equal to the candidate's `external_id` (only for GitHub
+/// tasks), or a word-set overlap where one side's significant words are a subset
+/// of the other's (so `A1 (package scaffold)` matches a task titled
+/// `A1: Package scaffold`, and a bare `A1` matches it too, without `A1` matching
+/// `A10`).
+pub fn reference_matches(reference: &str, title: &str, external_id: &str, is_github: bool) -> bool {
+    if is_github && reference_issue_numbers(reference).contains(external_id) {
+        return true;
+    }
+
+    let reference_words = significant_words(reference);
+    let title_words = significant_words(title);
+    if reference_words.is_empty() || title_words.is_empty() {
+        return false;
+    }
+    reference_words.is_subset(&title_words) || title_words.is_subset(&reference_words)
+}
+
+/// The set of `#`-prefixed issue numbers named in a reference, as strings (to
+/// compare directly against a task's `external_id`).
+fn reference_issue_numbers(reference: &str) -> HashSet<String> {
+    let mut numbers = HashSet::new();
+    for (index, character) in reference.char_indices() {
+        if character != '#' {
+            continue;
+        }
+        let digits: String = reference[index + 1..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if !digits.is_empty() {
+            numbers.insert(digits);
+        }
+    }
+    numbers
+}
+
+/// Normalizes text into its set of significant words: lowercased, with every
+/// non-alphanumeric character treated as a separator, dropping stop words and
+/// very short tokens so only identifying words remain.
+fn significant_words(text: &str) -> HashSet<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|word| word.len() >= MIN_SIGNIFICANT_WORD_LEN && !STOP_WORDS.contains(word))
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_an_inline_depends_on_line_with_multiple_refs() {
+        let body = "Some description.\n\nDepends on: A1 (package scaffold), A2 and A3\n\nMore.";
+        assert_eq!(
+            parse_dependency_refs(body),
+            vec![
+                "A1 (package scaffold)".to_string(),
+                "A2".to_string(),
+                "A3".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn recognizes_bullets_emphasis_and_marker_variants() {
+        assert_eq!(
+            parse_dependency_refs("- **Depends on:** A1"),
+            vec!["A1".to_string()]
+        );
+        assert_eq!(
+            parse_dependency_refs("> Dependencies: foo, bar"),
+            vec!["foo".to_string(), "bar".to_string()]
+        );
+        assert_eq!(
+            parse_dependency_refs("Depends A1"), // no colon, separated by space
+            vec!["A1".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_non_markers_and_placeholders() {
+        assert!(parse_dependency_refs("This depends on nothing in prose.").is_empty());
+        assert!(parse_dependency_refs("Independent of other work").is_empty());
+        assert!(parse_dependency_refs("Depends on: none").is_empty());
+        assert!(parse_dependency_refs("No marker here").is_empty());
+    }
+
+    #[test]
+    fn matches_by_issue_number_only_for_github() {
+        assert!(reference_matches("A2 (#5)", "Unrelated title", "5", true));
+        // Same token against a non-GitHub task does not number-match.
+        assert!(!reference_matches("A2 (#5)", "Unrelated title", "5", false));
+        // A different number does not match.
+        assert!(!reference_matches("see #6", "Unrelated", "5", true));
+    }
+
+    #[test]
+    fn matches_by_title_word_set() {
+        // Full key + parenthetical matches the task title both ways.
+        assert!(reference_matches(
+            "A1 (package scaffold)",
+            "A1: Package scaffold",
+            "4",
+            true
+        ));
+        // A bare roadmap key matches a title that begins with it.
+        assert!(reference_matches("A1", "A1: Package scaffold", "4", true));
+    }
+
+    #[test]
+    fn does_not_match_unrelated_or_lookalike_keys() {
+        // `A1` must not match `A10`.
+        assert!(!reference_matches("A1", "A10: Something else", "9", true));
+        // No shared significant words.
+        assert!(!reference_matches(
+            "A1 (package scaffold)",
+            "B2: Wire up the SDK",
+            "7",
+            true
+        ));
+    }
+}

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -12,6 +12,7 @@
 mod availability;
 mod ci_watch;
 pub mod compose;
+mod dependencies;
 mod network;
 mod placement;
 mod prompt;
@@ -1408,6 +1409,78 @@ async fn load_target_repos(state: &AppState, task: &Task) -> Vec<Repository> {
     repos
 }
 
+/// Resolves the open (unmerged) dependency PR branches a fresh ticket should build
+/// on top of (issue #256).
+///
+/// Parses a `Depends on:` marker in the ticket body and matches each reference
+/// against the railway's in-flight tasks that have an open PR, returning each
+/// matched dependency's branch and the repos where it has an open PR (so the agent
+/// merges it into the right clones). A dependency that has since merged is no
+/// longer an open-PR candidate, so it drops out and the ticket builds from the
+/// default branch as before. Best-effort: a query failure is logged and yields no
+/// dependencies rather than failing the turn.
+async fn resolve_dependency_branches(
+    state: &AppState,
+    task: &Task,
+) -> Vec<prompt::DependencyBranch> {
+    let references = dependencies::parse_dependency_refs(&task.body_snapshot);
+    if references.is_empty() {
+        return Vec::new();
+    }
+    let candidates =
+        match queries::list_open_dependency_candidates(&state.db, task.railway_id, task.id).await {
+            Ok(candidates) => candidates,
+            Err(error) => {
+                warn!(error = %error, task_id = %task.id, "could not list dependency candidates");
+                return Vec::new();
+            }
+        };
+
+    let mut resolved = Vec::new();
+    for candidate in candidates {
+        let is_github = candidate.source_kind == SourceKind::Github;
+        let matched = references.iter().any(|reference| {
+            dependencies::reference_matches(
+                reference,
+                &candidate.title,
+                &candidate.external_id,
+                is_github,
+            )
+        });
+        if !matched {
+            continue;
+        }
+        // The repos where this dependency has an open PR, so the agent merges its
+        // branch into the right clones. Skip a candidate whose PRs can't be read,
+        // or that has no open PR left (it merged between the two queries).
+        let repos = match queries::list_task_prs(&state.db, candidate.id).await {
+            Ok(prs) => prs
+                .into_iter()
+                .filter(|pr| pr.pr_state == "open")
+                .map(|pr| pr.repo_full_name)
+                .collect::<Vec<_>>(),
+            Err(error) => {
+                warn!(error = %error, dep_task_id = %candidate.id, "could not list a dependency's PRs");
+                continue;
+            }
+        };
+        if repos.is_empty() {
+            continue;
+        }
+        info!(
+            task_id = %task.id,
+            dependency = %candidate.branch,
+            "stacking fresh ticket on an open dependency branch"
+        );
+        resolved.push(prompt::DependencyBranch {
+            title: candidate.title,
+            branch: candidate.branch,
+            repos,
+        });
+    }
+    resolved
+}
+
 /// Runs a fresh issue end to end: prepare repo, drive Claude, detect PR. All execs
 /// target `handle`'s railway (its container + session).
 async fn work_fresh(
@@ -1471,7 +1544,19 @@ async fn work_fresh(
     } else {
         let comments = fetch_issue_comments(state, &repo, &task).await;
         let target_repos = load_target_repos(state, &task).await;
-        prompt::build(&settings, &repo, &task, &branch, &comments, &target_repos)
+        // Stack the ticket on any open (unmerged) dependency PR branches it names,
+        // so the agent merges them in rather than rediscovering and re-implementing
+        // them (issue #256).
+        let dependencies = resolve_dependency_branches(state, &task).await;
+        prompt::build(
+            &settings,
+            &repo,
+            &task,
+            &branch,
+            &comments,
+            &target_repos,
+            &dependencies,
+        )
     };
     let outcome = run_agent_turn(state, handle, &settings, &task, prompt).await?;
     persist_session(state, handle, &outcome).await?;

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -10,6 +10,18 @@ use crate::git::IssueComment;
 
 use super::provision::repo_dir_name;
 
+/// An open (unmerged) dependency PR branch this ticket should build on top of.
+///
+/// `branch` is the dependency's branch name, `title` its ticket title (for the
+/// brief), and `repos` the full names of the repos where it has an open PR (so
+/// the agent merges it into the right clones). See [`build`] and issue #256.
+#[derive(Debug, Clone)]
+pub struct DependencyBranch {
+    pub title: String,
+    pub branch: String,
+    pub repos: Vec<String>,
+}
+
 /// Builds the instruction text for working `task` fresh on a new `branch`.
 ///
 /// `comments` is the issue's discussion thread (empty when there is none or it
@@ -19,6 +31,9 @@ use super::provision::repo_dir_name;
 /// the first being `repo`, the focus repo). For a multi-repo ticket they are all
 /// named in the working agreement so the agent has the full context up front,
 /// even though it may end up opening a PR in only some of them.
+/// `dependencies` are open dependency PR branches the ticket builds on top of
+/// (issue #256); when present, the agent is told to merge them in first rather
+/// than discovering and re-implementing them.
 pub fn build(
     settings: &Settings,
     repo: &Repository,
@@ -26,6 +41,7 @@ pub fn build(
     branch: &str,
     comments: &[IssueComment],
     target_repos: &[Repository],
+    dependencies: &[DependencyBranch],
 ) -> String {
     let repo_path = format!("/workspace/{}", repo_dir_name(&repo.full_name));
     let mut prompt = context_header(settings, repo, task, comments);
@@ -85,8 +101,44 @@ pub fn build(
         ));
     }
 
+    prompt.push_str(&render_dependencies(dependencies, branch));
     prompt.push_str(ASKING_FOR_HELP);
     prompt
+}
+
+/// Renders the stacked-dependency section: each open dependency PR branch the
+/// ticket builds on, and the merge the agent should run before implementing.
+/// Returns an empty string when there are no open dependencies, so a standalone
+/// ticket's brief is unchanged.
+fn render_dependencies(dependencies: &[DependencyBranch], branch: &str) -> String {
+    if dependencies.is_empty() {
+        return String::new();
+    }
+
+    let mut section = String::from(
+        "# Stacked on unmerged dependencies\n\
+         - This ticket depends on other tickets whose pull requests are still OPEN, so their work \
+         is NOT yet on the default branch your branch was cut from. Before implementing, bring each \
+         dependency branch into your branch so you build on top of it, and do not re-implement work \
+         that already exists on it.\n",
+    );
+    for dependency in dependencies {
+        section.push_str(&format!(
+            "- `{dep_branch}` (from \"{title}\") has an open PR in: {repos}. In each of those \
+             repos, merge it into `{branch}` before you build: \
+             `git fetch origin && git merge origin/{dep_branch}`.\n",
+            dep_branch = dependency.branch,
+            title = dependency.title,
+            repos = dependency.repos.join(", "),
+            branch = branch,
+        ));
+    }
+    section.push_str(
+        "- Resolve any merge conflicts, and keep database migrations and lockfiles linear \
+         (renumber yours onto the dependency's if they collide). Then build and test on top of the \
+         merged result. The dependency's PR will merge on its own; you do not need to merge it.\n",
+    );
+    section
 }
 
 /// Builds the instruction text to re-engage `task` on its PR's failing CI.
@@ -598,6 +650,7 @@ mod tests {
             "seraphim/task-3",
             &[],
             &[],
+            &[],
         );
 
         // An internal ticket has no upstream issue, so the brief and the PR step
@@ -617,6 +670,7 @@ mod tests {
             &sample_repo(),
             &sample_task(),
             "seraphim/issue-57",
+            &[],
             &[],
             &[],
         );
@@ -642,6 +696,7 @@ mod tests {
             "seraphim/task-57",
             &[],
             &targets,
+            &[],
         );
 
         assert!(prompt.contains("This ticket targets multiple repositories"));
@@ -658,8 +713,50 @@ mod tests {
             "seraphim/issue-57",
             &[],
             &[sample_repo()],
+            &[],
         );
         assert!(!prompt.contains("targets multiple repositories"));
+    }
+
+    #[test]
+    fn dependency_branches_are_surfaced_with_a_merge_instruction() {
+        let dependencies = [DependencyBranch {
+            title: "A1: Package scaffold".to_string(),
+            branch: "seraphim/issue-4-package-scaffold".to_string(),
+            repos: vec!["mooreslabaiv1/frontend-core".to_string()],
+        }];
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &dependencies,
+        );
+
+        assert!(prompt.contains("Stacked on unmerged dependencies"));
+        // It names the dependency branch, its ticket, the repo, and the exact merge.
+        assert!(prompt.contains("seraphim/issue-4-package-scaffold"));
+        assert!(prompt.contains("A1: Package scaffold"));
+        assert!(prompt.contains("mooreslabaiv1/frontend-core"));
+        assert!(prompt.contains("git merge origin/seraphim/issue-4-package-scaffold"));
+        // And it tells the agent not to re-implement the dependency's work.
+        assert!(prompt.contains("do not re-implement"));
+    }
+
+    #[test]
+    fn no_dependencies_leaves_the_brief_unchanged() {
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &[],
+        );
+        assert!(!prompt.contains("Stacked on unmerged dependencies"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #256.

## Problem

When the agent works a dependency chain (A1 -> A2 -> A3), each new ticket branch is cut from the repo default branch. If the dependency's PR has not merged yet, the default branch is missing that work, so the new ticket cannot build until the agent manually discovers and merges the dependency branch in, wasting an exploration cycle and risking re-implementing the dependency.

## Approach (issue #256 option 2)

Keep cutting the branch from the default branch, but surface the open (unmerged) dependency PR branch in the working agreement so the agent merges it in first and is told not to re-implement it. This is the smaller change and is robust across multiple stacked dependencies.

## What changed

- **New pure module `orchestrator::dependencies`** (unit-tested, I/O-free): parses a `Depends on:` marker in the ticket body (tolerant of list bullets, Markdown emphasis, and the `Depends` / `Dependency` / `Dependencies` variants) and matches each reference against a task by GitHub issue number (`#N`) or a normalized title word-set match. So `A1 (package scaffold)` matches a task titled `A1: Package scaffold`, a bare `A1` matches it too, and `A1` does not match `A10`.
- **`queries::list_open_dependency_candidates`** lists the railway's in-flight tasks that have an open PR and a branch (the only resolvable, still-unmerged dependencies), backed by a new `DependencyCandidate` projection. No schema migration needed.
- **`work_fresh`** resolves matched dependencies to their PR branch + the repos they have an open PR in, and passes them to **`prompt::build`**, which renders a "Stacked on unmerged dependencies" section: merge `origin/<dep-branch>` into your branch first, keep migrations/lockfiles linear, build on top, and do not re-implement the dependency's work.

## Acceptance criteria

- A ticket whose dependency PR is open builds without the agent discovering/merging the branch by hand (the prompt names the branch + the exact merge). ✅
- The agent is told not to re-implement code on an unmerged dependency branch. ✅
- Works for a chain deeper than one: A2's branch already carries A1 (it merged A1 in when it was worked), so merging A2 into A3 brings the whole stack; if A3 names both, both are surfaced. ✅
- No regression when the dependency is already merged: a merged dependency has no open PR, so it is not a candidate and the ticket builds from the default branch as before. ✅
- Documented in `CLAUDE.md`. ✅

## Testing

- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets` (no new warnings), `cargo +1.88 test` (138 passed, incl. 8 new `dependencies`/`prompt` tests).

Branched off `develop`. The interim mitigation (frontend-core repo instructions) can be retired once this lands.