### PR TITLE
Card context menu: foundation (component + right-click/keyboard/touch wiring) (#232)

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -2,11 +2,19 @@
   import type { Railway, Task } from '../types'
 
   import { goto } from '$app/navigation'
-  import { Pause, Ban, TrainFront } from '@lucide/svelte'
+  import {
+    Pause,
+    Ban,
+    TrainFront,
+    SquareArrowOutUpRight,
+    Link as LinkIcon,
+    GitPullRequestArrow
+  } from '@lucide/svelte'
 
   import { STATUS_BADGE, STATUS_LABELS, ticketStateBadge } from '../types'
   import { Badge } from './ui/badge'
   import { buttonVariants } from './ui/button'
+  import * as ContextMenu from './ui/context-menu'
   import * as DropdownMenu from './ui/dropdown-menu'
   import SourceIcon from './SourceIcon.svelte'
 
@@ -59,116 +67,226 @@
     }
     goto(`/task/${task.id}`)
   }
+
+  // The "Open task" menu item always navigates, even in bulk-select mode (a left
+  // click there toggles selection instead, so the menu needs its own opener).
+  function openTask() {
+    goto(`/task/${task.id}`)
+  }
+
+  // Open the task's pull request in a new tab. Only shown when the task has one.
+  function openPullRequest() {
+    if (task.pr_url) {
+      window.open(task.pr_url, '_blank', 'noopener,noreferrer')
+    }
+  }
+
+  // Whether the card's right-click context menu is open. Bound to the bits-ui
+  // root so we can also close it on scroll (the board scrolls, and the menu is
+  // anchored to a fixed viewport point, so it would otherwise float orphaned).
+  let menuOpen = $state(false)
+
+  // Right-click and touch long-press are handled natively by the bits-ui
+  // ContextMenu trigger. This adds the keyboard path: the Menu/Apps key, or
+  // Shift+F10, opens the menu when the card is focused. We synthesize a
+  // `contextmenu` event near the card's top-left so the same trigger logic
+  // positions and opens the menu, with no pointer required.
+  function onCardKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      activate()
+      return
+    }
+    if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+      event.preventDefault()
+      const card = event.currentTarget as HTMLElement
+      const rect = card.getBoundingClientRect()
+      card.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.left + 16,
+          clientY: rect.top + 16
+        })
+      )
+    }
+  }
+
+  // Copy a link to the task. A placeholder menu action for this foundation;
+  // real card actions land in follow-up tickets.
+  async function copyTaskLink() {
+    const url = `${window.location.origin}/task/${task.id}`
+    try {
+      await navigator.clipboard.writeText(url)
+    }
+    catch (error) {
+      console.debug('failed to copy task link', error)
+    }
+  }
+
+  // Close the menu when anything other than the menu itself scrolls. The menu is
+  // anchored to a fixed viewport point, so a board scroll would leave it floating
+  // over the wrong card; closing is simpler and clearer than repositioning.
+  // Scroll events do not bubble, so we listen in the capture phase.
+  $effect(() => {
+    if (!menuOpen) {
+      return
+    }
+    function onScroll(event: Event) {
+      const target = event.target
+      if (target instanceof Element && target.closest('[data-slot="context-menu-content"]')) {
+        return
+      }
+      menuOpen = false
+    }
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true })
+    return () => window.removeEventListener('scroll', onScroll, { capture: true })
+  })
 </script>
 
-<div
-  role="button"
-  tabindex="0"
-  aria-pressed={selectionMode ? selected : undefined}
-  onclick={activate}
-  onkeydown={(event) => event.key === 'Enter' && activate()}
-  class="rounded-lg border bg-secondary p-3 transition-all {selectionMode
-    ? 'cursor-pointer'
-    : 'cursor-grab'} {selected
-    ? 'border-primary ring-2 ring-primary bg-primary/10'
-    : selectionMode
-      ? 'border-border opacity-50 hover:opacity-100 hover:border-primary'
-      : task.hold
-        ? 'border-dashed border-border opacity-60 hover:border-primary'
-        : task.blocking
-          ? 'border-warning hover:border-primary'
-          : 'border-border hover:border-primary'}"
->
-  <div class="flex items-center justify-between gap-2">
-    <span class="flex min-w-0 items-center gap-1 text-xs tabular-nums text-muted-foreground">
-      {#if task.hold}<Pause class="size-3 flex-none" aria-label="On hold" />{/if}
-      {#if task.blocking}<Ban
-          class="size-3 flex-none text-warning"
-          aria-label="Blocking: holds the queue until finished"
-        />{/if}
-      <SourceIcon source={task.source_kind} class="size-3.5 flex-none" />
-      {#if repoShort}<span class="truncate font-semibold text-primary" title={repoName}>{repoShort}</span>{/if}
-      <span class="flex-none">{#if repoShort} · {/if}#{task.external_id}</span>
-      {#if ticketState}
-        <Badge variant="outline" class="flex-none px-1.5 py-0 text-[10px] {ticketState.class}">
-          {ticketState.label}
-        </Badge>
-      {/if}
-    </span>
-    <Badge variant="outline" class={STATUS_BADGE[task.status]}>
-      {STATUS_LABELS[task.status] ?? task.status}
-    </Badge>
-  </div>
+<!--
+  The whole card is the context-menu trigger: right-click opens the menu at the
+  cursor, touch long-press opens it (both handled natively by bits-ui), and the
+  keyboard Menu key / Shift+F10 open it via `onCardKeydown`. The trigger renders
+  this div itself (not a wrapper), so it stays the focusable card and focus
+  returns here when the menu closes. right-click and a stationary long-press do
+  not start a `svelte-dnd-action` drag (it ignores non-left buttons and only
+  drags on movement).
+-->
+<ContextMenu.Root bind:open={menuOpen}>
+  <ContextMenu.Trigger
+    role="button"
+    tabindex={0}
+    aria-pressed={selectionMode ? selected : undefined}
+    onclick={activate}
+    onkeydown={onCardKeydown}
+    class="rounded-lg border bg-secondary p-3 transition-all {selectionMode
+      ? 'cursor-pointer'
+      : 'cursor-grab'} {selected
+      ? 'border-primary ring-2 ring-primary bg-primary/10'
+      : selectionMode
+        ? 'border-border opacity-50 hover:opacity-100 hover:border-primary'
+        : task.hold
+          ? 'border-dashed border-border opacity-60 hover:border-primary'
+          : task.blocking
+            ? 'border-warning hover:border-primary'
+            : 'border-border hover:border-primary'}"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <span class="flex min-w-0 items-center gap-1 text-xs tabular-nums text-muted-foreground">
+        {#if task.hold}<Pause class="size-3 flex-none" aria-label="On hold" />{/if}
+        {#if task.blocking}<Ban
+            class="size-3 flex-none text-warning"
+            aria-label="Blocking: holds the queue until finished"
+          />{/if}
+        <SourceIcon source={task.source_kind} class="size-3.5 flex-none" />
+        {#if repoShort}<span class="truncate font-semibold text-primary" title={repoName}>{repoShort}</span>{/if}
+        <span class="flex-none">{#if repoShort} · {/if}#{task.external_id}</span>
+        {#if ticketState}
+          <Badge variant="outline" class="flex-none px-1.5 py-0 text-[10px] {ticketState.class}">
+            {ticketState.label}
+          </Badge>
+        {/if}
+      </span>
+      <Badge variant="outline" class={STATUS_BADGE[task.status]}>
+        {STATUS_LABELS[task.status] ?? task.status}
+      </Badge>
+    </div>
 
-  <div class="mt-2 flex items-start gap-2">
-    {#if task.author_avatar_url}
-      <img
-        src={task.author_avatar_url}
-        alt={task.author_login ?? 'issue author'}
-        title={task.author_login ? `Opened by ${task.author_login}` : 'Issue author'}
-        class="mt-0.5 size-5 flex-none rounded-full"
-        onerror={(event) => ((event.currentTarget as HTMLImageElement).style.display = 'none')}
-      />
+    <div class="mt-2 flex items-start gap-2">
+      {#if task.author_avatar_url}
+        <img
+          src={task.author_avatar_url}
+          alt={task.author_login ?? 'issue author'}
+          title={task.author_login ? `Opened by ${task.author_login}` : 'Issue author'}
+          class="mt-0.5 size-5 flex-none rounded-full"
+          onerror={(event) => ((event.currentTarget as HTMLImageElement).style.display = 'none')}
+        />
+      {/if}
+      <div class="min-w-0 text-sm leading-snug">{task.title}</div>
+    </div>
+
+    <!-- Loud on purpose: pulses until the user acknowledges the suggestions on the task. -->
+    {#if suggestionCount > 0}
+      <div
+        class="mt-2 animate-pulse rounded-md bg-warning px-2 py-1 text-center text-xs font-bold text-background motion-reduce:animate-none"
+        title="The agent recommended environment changes"
+      >
+        💡 {suggestionCount} setup {suggestionCount === 1 ? 'suggestion' : 'suggestions'}
+      </div>
     {/if}
-    <div class="min-w-0 text-sm leading-snug">{task.title}</div>
-  </div>
 
-  <!-- Loud on purpose: pulses until the user acknowledges the suggestions on the task. -->
-  {#if suggestionCount > 0}
-    <div
-      class="mt-2 animate-pulse rounded-md bg-warning px-2 py-1 text-center text-xs font-bold text-background motion-reduce:animate-none"
-      title="The agent recommended environment changes"
-    >
-      💡 {suggestionCount} setup {suggestionCount === 1 ? 'suggestion' : 'suggestions'}
-    </div>
-  {/if}
-
-  {#if (otherRailways.length > 0 && !selectionMode) || task.pr_url}
-    <div class="mt-2 flex items-center justify-end gap-3">
-      {#if otherRailways.length > 0 && !selectionMode}
-        <!-- Reassign the card's repo to another swimlane. This moves the repo (and
-             all its tasks), so it is a repo action, not a single-card drag. The
-             backend blocks it while a live turn is working the repo. -->
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger
-            onclick={(event: MouseEvent) => event.stopPropagation()}
-            class={buttonVariants({ variant: 'ghost', size: 'sm' }) +
-              ' h-6 gap-1 px-1.5 text-xs text-muted-foreground'}
-            title="Move this repo to another railway"
+    {#if (otherRailways.length > 0 && !selectionMode) || task.pr_url}
+      <div class="mt-2 flex items-center justify-end gap-3">
+        {#if otherRailways.length > 0 && !selectionMode}
+          <!-- Reassign the card's repo to another swimlane. This moves the repo (and
+               all its tasks), so it is a repo action, not a single-card drag. The
+               backend blocks it while a live turn is working the repo. -->
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger
+              onclick={(event: MouseEvent) => event.stopPropagation()}
+              class={buttonVariants({ variant: 'ghost', size: 'sm' }) +
+                ' h-6 gap-1 px-1.5 text-xs text-muted-foreground'}
+              title="Move this repo to another railway"
+            >
+              <TrainFront class="size-3.5" />
+              Move lane
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end" class="min-w-44">
+              <DropdownMenu.Label class="text-xs">Move repo to railway</DropdownMenu.Label>
+              {#each otherRailways as railway (railway.id)}
+                <DropdownMenu.Item
+                  onclick={(event: MouseEvent) => {
+                    event.stopPropagation()
+                    onMoveToRailway?.(railway.id)
+                  }}
+                >
+                  {railway.name}
+                </DropdownMenu.Item>
+              {/each}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        {/if}
+        {#if task.pr_url}
+          <a
+            href={task.pr_url}
+            target="_blank"
+            rel="noreferrer"
+            onclick={(event) => event.stopPropagation()}
+            class="text-xs text-primary hover:underline"
           >
-            <TrainFront class="size-3.5" />
-            Move lane
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content align="end" class="min-w-44">
-            <DropdownMenu.Label class="text-xs">Move repo to railway</DropdownMenu.Label>
-            {#each otherRailways as railway (railway.id)}
-              <DropdownMenu.Item
-                onclick={(event: MouseEvent) => {
-                  event.stopPropagation()
-                  onMoveToRailway?.(railway.id)
-                }}
-              >
-                {railway.name}
-              </DropdownMenu.Item>
-            {/each}
-          </DropdownMenu.Content>
-        </DropdownMenu.Root>
-      {/if}
-      {#if task.pr_url}
-        <a
-          href={task.pr_url}
-          target="_blank"
-          rel="noreferrer"
-          onclick={(event) => event.stopPropagation()}
-          class="text-xs text-primary hover:underline"
-        >
-          PR ↗
-        </a>
-      {/if}
-    </div>
-  {/if}
+            PR ↗
+          </a>
+        {/if}
+      </div>
+    {/if}
 
-  {#if task.error}
-    <div class="mt-2 border-t border-border pt-1.5 text-xs text-destructive">{task.error}</div>
-  {/if}
-</div>
+    {#if task.error}
+      <div class="mt-2 border-t border-border pt-1.5 text-xs text-destructive">{task.error}</div>
+    {/if}
+  </ContextMenu.Trigger>
+
+  <!--
+    Placeholder menu for this foundation ticket: "Open task" is the working item;
+    real card actions (move column, hold, reset, etc.) land in follow-up tickets.
+    Closing on Escape / outside click / item select is handled by bits-ui; scroll
+    close is wired in this component (see the `$effect` above).
+  -->
+  <ContextMenu.Content class="min-w-44">
+    <ContextMenu.Label class="text-xs">#{task.external_id}</ContextMenu.Label>
+    <ContextMenu.Item onclick={openTask}>
+      <SquareArrowOutUpRight class="size-4" />
+      Open task
+    </ContextMenu.Item>
+    {#if task.pr_url}
+      <ContextMenu.Item onclick={openPullRequest}>
+        <GitPullRequestArrow class="size-4" />
+        Open pull request
+      </ContextMenu.Item>
+    {/if}
+    <ContextMenu.Separator />
+    <ContextMenu.Item onclick={copyTaskLink}>
+      <LinkIcon class="size-4" />
+      Copy link
+    </ContextMenu.Item>
+  </ContextMenu.Content>
+</ContextMenu.Root>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-content.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import ContextMenuPortal from "./context-menu-portal.svelte";
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		portalProps,
+		...restProps
+	}: ContextMenuPrimitive.ContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof ContextMenuPortal>>;
+	} = $props();
+</script>
+
+<ContextMenuPortal {...portalProps}>
+	<ContextMenuPrimitive.Content
+		bind:ref
+		data-slot="context-menu-content"
+		class={cn(
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 max-h-(--bits-floating-available-height) origin-(--bits-floating-transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden motion-reduce:animate-none motion-reduce:transition-none",
+			className
+		)}
+		{...restProps}
+	/>
+</ContextMenuPortal>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-group-heading.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-group-heading.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		...restProps
+	}: ComponentProps<typeof ContextMenuPrimitive.GroupHeading> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.GroupHeading
+	bind:ref
+	data-slot="context-menu-group-heading"
+	data-inset={inset}
+	class={cn("px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8", className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-group.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-group.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: ContextMenuPrimitive.GroupProps = $props();
+</script>
+
+<ContextMenuPrimitive.Group bind:ref data-slot="context-menu-group" {...restProps} />

--- a/frontend/src/lib/components/ui/context-menu/context-menu-item.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		variant = "default",
+		...restProps
+	}: ContextMenuPrimitive.ItemProps & {
+		inset?: boolean;
+		variant?: "default" | "destructive";
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.Item
+	bind:ref
+	data-slot="context-menu-item"
+	data-inset={inset}
+	data-variant={variant}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-label.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-label.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="context-menu-label"
+	data-inset={inset}
+	class={cn("text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7 data-[inset]:pl-8", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-portal.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { ...restProps }: ContextMenuPrimitive.PortalProps = $props();
+</script>
+
+<ContextMenuPrimitive.Portal {...restProps} />

--- a/frontend/src/lib/components/ui/context-menu/context-menu-separator.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.SeparatorProps = $props();
+</script>
+
+<ContextMenuPrimitive.Separator
+	bind:ref
+	data-slot="context-menu-separator"
+	class={cn("bg-border -mx-1 my-1 h-px", className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-shortcut.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-shortcut.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="context-menu-shortcut"
+	class={cn("text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-sub-content.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-sub-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.SubContentProps = $props();
+</script>
+
+<ContextMenuPrimitive.SubContent
+	bind:ref
+	data-slot="context-menu-sub-content"
+	class={cn(
+		"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 origin-(--bits-floating-transform-origin) rounded-lg p-1 shadow-lg ring-1 duration-100 z-50 w-auto outline-none motion-reduce:animate-none motion-reduce:transition-none",
+		className
+	)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+	import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: ContextMenuPrimitive.SubTriggerProps & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.SubTrigger
+	bind:ref
+	data-slot="context-menu-sub-trigger"
+	data-inset={inset}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ChevronRightIcon class="ml-auto" />
+</ContextMenuPrimitive.SubTrigger>

--- a/frontend/src/lib/components/ui/context-menu/context-menu-sub.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-sub.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: ContextMenuPrimitive.SubProps = $props();
+</script>
+
+<ContextMenuPrimitive.Sub bind:open {...restProps} />

--- a/frontend/src/lib/components/ui/context-menu/context-menu-trigger.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: ContextMenuPrimitive.TriggerProps = $props();
+</script>
+
+<ContextMenuPrimitive.Trigger bind:ref data-slot="context-menu-trigger" {...restProps} />

--- a/frontend/src/lib/components/ui/context-menu/context-menu.svelte
+++ b/frontend/src/lib/components/ui/context-menu/context-menu.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: ContextMenuPrimitive.RootProps = $props();
+</script>
+
+<ContextMenuPrimitive.Root bind:open {...restProps} />

--- a/frontend/src/lib/components/ui/context-menu/index.ts
+++ b/frontend/src/lib/components/ui/context-menu/index.ts
@@ -1,0 +1,43 @@
+import Root from "./context-menu.svelte";
+import Trigger from "./context-menu-trigger.svelte";
+import Portal from "./context-menu-portal.svelte";
+import Content from "./context-menu-content.svelte";
+import Item from "./context-menu-item.svelte";
+import Separator from "./context-menu-separator.svelte";
+import Shortcut from "./context-menu-shortcut.svelte";
+import Label from "./context-menu-label.svelte";
+import Group from "./context-menu-group.svelte";
+import GroupHeading from "./context-menu-group-heading.svelte";
+import Sub from "./context-menu-sub.svelte";
+import SubTrigger from "./context-menu-sub-trigger.svelte";
+import SubContent from "./context-menu-sub-content.svelte";
+
+export {
+	Root,
+	Trigger,
+	Portal,
+	Content,
+	Item,
+	Separator,
+	Shortcut,
+	Label,
+	Group,
+	GroupHeading,
+	Sub,
+	SubTrigger,
+	SubContent,
+	//
+	Root as ContextMenu,
+	Trigger as ContextMenuTrigger,
+	Portal as ContextMenuPortal,
+	Content as ContextMenuContent,
+	Item as ContextMenuItem,
+	Separator as ContextMenuSeparator,
+	Shortcut as ContextMenuShortcut,
+	Label as ContextMenuLabel,
+	Group as ContextMenuGroup,
+	GroupHeading as ContextMenuGroupHeading,
+	Sub as ContextMenuSub,
+	SubTrigger as ContextMenuSubTrigger,
+	SubContent as ContextMenuSubContent,
+};


### PR DESCRIPTION
Part of #231. Closes #232.

Builds the right-click context-menu foundation: a reusable menu component and the wiring that opens it on a kanban card via right-click, the keyboard Menu key / Shift+F10, and touch long-press. Card actions beyond placeholders land in follow-up tickets.

## What changed

- **New `ui/context-menu` component** wrapping bits-ui's `ContextMenu`, styled to match the existing `dropdown-menu`: `Root`, `Trigger`, `Portal`, `Content`, `Item` (with `destructive` variant), `Separator`, `Shortcut` (keyboard-hint slot), `Label`, `Group`, `GroupHeading`, and submenu `Sub` / `SubTrigger` / `SubContent`. Icons work in items as in the dropdown. Generic, so the board is not the only possible consumer.
- **Wired onto `Card.svelte`.** The card itself is the context-menu trigger (rendered in place, not wrapped), so it stays the focusable element and focus returns to it when the menu closes.

## Open / close / position

- **Open:** right-click (opens at the cursor) and touch long-press are handled natively by bits-ui; the keyboard Menu key / Shift+F10 open it via a synthesized `contextmenu` event near the focused card.
- **Position:** opens at the pointer; bits-ui's Floating UI flips/clamps it into the viewport.
- **Close:** Escape, outside click, and item select (bits-ui), plus scroll. The board scrolls and the menu is anchored to a fixed viewport point, so a capture-phase scroll listener closes it (while leaving scrolling inside a long menu alone) rather than letting it float orphaned.
- **prefers-reduced-motion:** the content disables its open/close animation under `motion-reduce`.

## Drag safety

No drag is triggered by right-click or long-press: `svelte-dnd-action` already ignores non-left-click (`if (e.button) return`) and only starts a drag on pointer movement, so a right-click and a stationary long-press never begin a drag, and opening the menu never leaves a card mid-drag. No board changes were needed.

## Accessibility

`menu` / `menuitem` / `separator` roles, roving focus, arrow-key navigation, Home/End, and type-ahead come from bits-ui's menu. Focus returns to the card on close (the card is the trigger).

## Placeholder items

"Open task" (works), "Open pull request" (when the task has one), and "Copy link". These exercise items + icons + separator; substantive actions come in later #231 tickets.

## Testing

Frontend-only. `yarn check` (0 errors), `yarn test` (13 passed), and `yarn build` all pass.