### PR TITLE
Reject malformed agent JSON instead of posting it as a garbled question (#260)

### DIFF
--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -545,9 +545,12 @@ const ENVIRONMENT_SUGGESTIONS: &str = "\n\
     If during the task you noticed tooling or setup that was missing or would \
     make future runs on a fresh workstation go smoother (a toolchain you had to \
     install, a CLI that was absent, a slow step that a cached tool would fix), \
-    record it before you finish so it is not buried in your output. Run:\n\n\
-    \x20 seraphim-suggest '{\"suggestions\":[{\"title\":\"<short recommendation>\",\
-    \"detail\":\"<why it helps and how to apply it, e.g. a setup-script snippet>\"}]}'\n\n\
+    record it before you finish so it is not buried in your output. Pass valid \
+    JSON to `seraphim-suggest` on stdin via a heredoc, so quotes and apostrophes \
+    in your text never need shell-escaping:\n\n\
+    \x20 seraphim-suggest <<'JSON'\n\
+    \x20 {\"suggestions\":[{\"title\":\"<short recommendation>\",\"detail\":\"<why it helps, e.g. a setup-script snippet>\"}]}\n\
+    \x20 JSON\n\n\
     Only suggest things that genuinely help; if nothing comes to mind, skip it. \
     This does not replace opening the pull request.\n";
 
@@ -556,9 +559,13 @@ const ASKING_FOR_HELP: &str = "\n\
     # Asking the user for help\n\
     If you hit a decision you should not guess on (an ambiguous requirement, a \
     tradeoff with no clear winner, missing access, or anything where a wrong \
-    assumption would be costly), ask the user instead of guessing. Run:\n\n\
-    \x20 seraphim-ask '{\"questions\":[{\"prompt\":\"<your question>\",\
-    \"options\":[{\"title\":\"<short answer>\",\"description\":\"<why this>\"}]}]}'\n\n\
+    assumption would be costly), ask the user instead of guessing. Pass valid \
+    JSON to `seraphim-ask` on stdin via a heredoc, so quotes and apostrophes in \
+    your question never need shell-escaping (a malformed payload is rejected with \
+    an error, never shown to the user as a question):\n\n\
+    \x20 seraphim-ask <<'JSON'\n\
+    \x20 {\"questions\":[{\"prompt\":\"<your question>\",\"options\":[{\"title\":\"<short answer>\",\"description\":\"<why this>\"}]}]}\n\
+    \x20 JSON\n\n\
     Offer up to 3 suggested options per question, and you may ask several \
     questions at once. After running it, STOP and end your turn; you will be \
     automatically resumed once the user answers. Prefer asking over guessing \
@@ -884,6 +891,27 @@ mod tests {
             &[],
         );
         assert!(!prompt.contains("Stacked on unmerged dependencies"));
+    }
+
+    #[test]
+    fn help_guidance_uses_the_stdin_heredoc_form() {
+        // Issue #260: recommend the heredoc stdin form, which sidesteps the shell
+        // quoting of quotes/apostrophes that produced malformed payloads, and tell
+        // the agent a malformed payload is rejected rather than shown to the user.
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &[],
+        );
+        assert!(prompt.contains("seraphim-ask <<'JSON'"));
+        assert!(prompt.contains("seraphim-suggest <<'JSON'"));
+        assert!(prompt.contains("malformed payload is rejected"));
+        // The brittle single-quoted-argument example is gone.
+        assert!(!prompt.contains("seraphim-ask '{"));
     }
 
     #[test]

--- a/workspace/seraphim-ask
+++ b/workspace/seraphim-ask
@@ -67,11 +67,29 @@ async function main() {
   }
 
   let parsed
+  const trimmedInput = rawInput.trim()
   try {
-    parsed = JSON.parse(rawInput)
-  } catch {
-    // Allow a plain, unquoted question string as a convenience.
-    parsed = rawInput.trim()
+    parsed = JSON.parse(trimmedInput)
+  } catch (error) {
+    // Input that begins with `{` or `[` was meant to be JSON. If it does not
+    // parse, it is malformed (a common model slip: a missing closing brace, a
+    // trailing comma, an unescaped quote, or a truncated payload). Do NOT fall
+    // back to posting the whole blob as one question's text: that is the garbled
+    // "question" with no usable options that users have seen (issue #260). Fail
+    // loudly so the agent re-emits valid JSON instead of asking the user to read
+    // raw JSON.
+    if (trimmedInput.startsWith('{') || trimmedInput.startsWith('[')) {
+      fail(
+        `the input looks like JSON but could not be parsed (${error.message}). ` +
+          'Nothing was sent. Re-run with valid JSON. To avoid shell-quoting problems ' +
+          'with quotes and apostrophes inside the payload, pipe it on stdin via a heredoc:\n' +
+          "  seraphim-ask <<'JSON'\n" +
+          '  {"questions":[{"prompt":"...","options":[{"title":"...","description":"..."}]}]}\n' +
+          '  JSON'
+      )
+    }
+    // A genuinely plain, unquoted question string is still allowed as a shortcut.
+    parsed = trimmedInput
   }
 
   const questions = normalizeQuestions(parsed)

--- a/workspace/seraphim-suggest
+++ b/workspace/seraphim-suggest
@@ -62,11 +62,26 @@ async function main() {
   }
 
   let parsed
+  const trimmedInput = rawInput.trim()
   try {
-    parsed = JSON.parse(rawInput)
-  } catch {
-    // Allow a plain, unquoted recommendation string as a convenience.
-    parsed = rawInput.trim()
+    parsed = JSON.parse(trimmedInput)
+  } catch (error) {
+    // Input that begins with `{` or `[` was meant to be JSON. If it does not
+    // parse, it is malformed; do NOT fall back to recording the whole blob as one
+    // suggestion's title (the same garbled-input class as issue #260). Fail
+    // loudly so the agent re-emits valid JSON.
+    if (trimmedInput.startsWith('{') || trimmedInput.startsWith('[')) {
+      fail(
+        `the input looks like JSON but could not be parsed (${error.message}). ` +
+          'Nothing was sent. Re-run with valid JSON. To avoid shell-quoting problems ' +
+          'with quotes and apostrophes inside the payload, pipe it on stdin via a heredoc:\n' +
+          "  seraphim-suggest <<'JSON'\n" +
+          '  {"suggestions":[{"title":"...","detail":"..."}]}\n' +
+          '  JSON'
+      )
+    }
+    // A genuinely plain, unquoted recommendation string is still allowed.
+    parsed = trimmedInput
   }
 
   const suggestions = normalizeSuggestions(parsed)


### PR DESCRIPTION
Closes #260.

## Root cause

When the agent escalates with `seraphim-ask`, the helper did:

```js
try { parsed = JSON.parse(rawInput) }
catch { parsed = rawInput.trim() }   // fall back to a plain-string question
```

So when the agent emitted JSON that failed to parse (the reported case is a payload missing its final `}`; other common slips are trailing commas, unescaped quotes, or a truncated body), the whole raw blob became a single question whose `prompt` was the entire JSON string, with no options. The user saw a wall of JSON and could only "answer with your own response". `seraphim-suggest` had the same fallback.

## Fix

- **`workspace/seraphim-ask` and `workspace/seraphim-suggest`**: if the input begins with `{` or `[` (i.e. it was meant to be JSON) but does not parse, fail loudly. Nothing is sent, and the agent gets a clear, actionable error so it re-emits valid JSON, instead of the user seeing garbage. A genuinely plain, unquoted string is still accepted as a shortcut. This matches `seraphim-draft`, which already failed loudly on bad JSON.
- **Prompt guidance** (`prompt::ASKING_FOR_HELP` / `ENVIRONMENT_SUGGESTIONS`): recommend the heredoc stdin form, which passes the payload verbatim and removes the shell-quoting of quotes/apostrophes that itself produces malformed input, and notes a malformed payload is rejected rather than shown to the user:

  ```
  seraphim-ask <<'JSON'
  {"questions":[{"prompt":"...","options":[{"title":"...","description":"..."}]}]}
  JSON
  ```

## Testing

- Ran both helpers with node: malformed JSON-looking input is now rejected with the heredoc tip and a non-zero exit; valid JSON and plain strings still pass parsing (then hit the API as before). Verified the heredoc form carries apostrophes/quotes without escaping.
- `cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets`, `cargo +1.88 test` (143 passed) including a new prompt regression test that the guidance uses the stdin heredoc form.

Branched off `develop`.