### PR TITLE
Bump runewood to ^0.1.1 (Gource port + scale fix)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "ky": "^1.7.0",
     "marked": "^18.0.5",
     "paneforge": "^1.0.2",
-    "runewood": "^0.0.2",
+    "runewood": "^0.1.1",
     "svelte-dnd-action": "^0.9.50",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2202,13 +2202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"runewood@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "runewood@npm:0.0.2"
+"runewood@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "runewood@npm:0.1.1"
   dependencies:
     pixi-filters: "npm:^6.1.5"
     pixi.js: "npm:^8.19.0"
-  checksum: 10c0/abd626796fb3d37d383b6130333a317a3acd33d72968bb748752f7f3f1c9f46eb4935b67b6bfb9703e1fd02fc9d401f4d6984b908028ccce82c5b3f6a1ea6659
+  checksum: 10c0/05c560b985f7f70876176596edbfaa8abea7ac68b369b30a615d35514b098791d5d8756146523037937e2819487f97ce35c87f88cab7697bc970157cebed526a
   languageName: node
   linkType: hard
 
@@ -2251,7 +2251,7 @@ __metadata:
     marked: "npm:^18.0.5"
     mode-watcher: "npm:^1.1.0"
     paneforge: "npm:^1.0.2"
-    runewood: "npm:^0.0.2"
+    runewood: "npm:^0.1.1"
     svelte: "npm:^5.1.0"
     svelte-check: "npm:^4.0.0"
     svelte-dnd-action: "npm:^0.9.50"


### PR DESCRIPTION
## What

Bumps the `runewood` dependency in the frontend from `^0.0.2` to `^0.1.1`.

## Why

The watch page's activity forest pinned `runewood: ^0.0.2`. A caret on a `0.0.x`
version is locked below `0.1.0`, so the watch page could never resolve up to the
`0.1.x` line no matter how many times it was installed, it was stuck on the old
build. This bumps it to `^0.1.1`.

`0.1.x` brings:
- **The faithful Gource port** (`0.1.0`): directory force-graph + file satellites,
  Gource-style users (fly to file / brake / friction / separation / idle-fade),
  the Gource laser beam, actor avatar images, and click-to-follow a contributor.
- **The scale + first-load fix** (`0.1.1`): deterministic radial initial placement
  so a large multi-repo tree lays out organized instead of piling and flailing,
  cooling + node sleeping so it settles to a true stop and the framerate recovers
  (no more perpetual spinning), and auto-disabling the per-node glow above ~1200
  nodes. This is the fix for the 18-repo / 3000+ node workspace churning for
  minutes on load.

## Notes

- runewood's public API (`createRunewood`, `ingest`, `seed`, `on`, `highlight`,
  etc.) is unchanged across the bump, so no integration code changes are needed.
- The new SDK surface available to wire in later if wanted: `resolveAvatar` /
  `setAvatar` (agent icons), `followActor` (click-to-follow), and the `cameraMode`
  / `rootLabel` / `exclude` options.

## Validation

- `cd frontend && yarn check` -> 0 errors, 0 warnings.
- `cd frontend && yarn build` -> success (adapter-node).
- Only `frontend/package.json` and `frontend/yarn.lock` change; no source edits.
