### PR TITLE
Card context menu: 'Move to' columns and lanes (#233)

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Railway, Task } from '../types'
+  import type { Railway, Task, TaskColumn } from '../types'
 
   import { goto } from '$app/navigation'
   import {
@@ -8,7 +8,10 @@
     TrainFront,
     SquareArrowOutUpRight,
     Link as LinkIcon,
-    GitPullRequestArrow
+    GitPullRequestArrow,
+    ArrowRightLeft,
+    Columns2,
+    Check
   } from '@lucide/svelte'
 
   import { STATUS_BADGE, STATUS_LABELS, ticketStateBadge } from '../types'
@@ -27,7 +30,8 @@
     selected = false,
     onselect,
     railways = [],
-    onMoveToRailway
+    onMoveToRailway,
+    onMoveToColumn
   }: {
     task: Task
     onchange: () => void
@@ -45,7 +49,23 @@
     // the single `main` lane, where the control is meaningless.
     railways?: Railway[]
     onMoveToRailway?: (railwayId: string) => void
+    // Move this card to another board column (context menu). "To Do" carries a
+    // placement so the agent's "do this next" (top) vs "later" (bottom) intent is
+    // expressible; the board computes the rank and calls moveTask.
+    onMoveToColumn?: (column: TaskColumn, placement: 'top' | 'bottom') => void
   } = $props()
+
+  // The board columns the context menu offers as move targets (issue #233). In
+  // Progress is omitted (the agent owns it); To Do is split into top/bottom of the
+  // queue, mirroring the server-side automation rank.
+  const COLUMN_MOVES: { column: TaskColumn; placement: 'top' | 'bottom'; label: string }[] = [
+    { column: 'available', placement: 'top', label: 'Available' },
+    { column: 'todo', placement: 'top', label: 'To Do (top)' },
+    { column: 'todo', placement: 'bottom', label: 'To Do (bottom)' },
+    { column: 'in_review', placement: 'top', label: 'In Review' },
+    { column: 'done', placement: 'top', label: 'Done' },
+    { column: 'ignored', placement: 'top', label: 'Ignored' }
+  ]
 
   // The other lanes this card's repo can move to. Empty for a tracking-only card
   // (no repo) or when `main` is the only lane, which hides the control entirely.
@@ -266,10 +286,8 @@
   </ContextMenu.Trigger>
 
   <!--
-    Placeholder menu for this foundation ticket: "Open task" is the working item;
-    real card actions (move column, hold, reset, etc.) land in follow-up tickets.
-    Closing on Escape / outside click / item select is handled by bits-ui; scroll
-    close is wired in this component (see the `$effect` above).
+    Card actions. Closing on Escape / outside click / item select is handled by
+    bits-ui; scroll close is wired in this component (see the `$effect` above).
   -->
   <ContextMenu.Content class="min-w-44">
     <ContextMenu.Label class="text-xs">#{task.external_id}</ContextMenu.Label>
@@ -283,7 +301,81 @@
         Open pull request
       </ContextMenu.Item>
     {/if}
+
     <ContextMenu.Separator />
+
+    <!--
+      Move to > Column / Lane (issue #233). A column move re-ranks/relocates just
+      this card; a lane move reassigns the card's REPO (and all its tasks), so it
+      is confirmed and toasted by the board. The current column/lane is checked,
+      and a no-op destination is disabled.
+    -->
+    <ContextMenu.Sub>
+      <ContextMenu.SubTrigger>
+        <ArrowRightLeft class="size-4" />
+        Move to
+      </ContextMenu.SubTrigger>
+      <ContextMenu.SubContent class="min-w-40">
+        <ContextMenu.Sub>
+          <ContextMenu.SubTrigger>
+            <Columns2 class="size-4" />
+            Column
+          </ContextMenu.SubTrigger>
+          <ContextMenu.SubContent class="min-w-40">
+            {#each COLUMN_MOVES as move (move.label)}
+              {@const isCurrent = move.column === task.board_column}
+              <ContextMenu.Item
+                disabled={isCurrent && move.column !== 'todo'}
+                onclick={() => onMoveToColumn?.(move.column, move.placement)}
+              >
+                {#if isCurrent}
+                  <Check class="size-4" />
+                {:else}
+                  <span class="size-4"></span>
+                {/if}
+                {move.label}
+              </ContextMenu.Item>
+            {/each}
+          </ContextMenu.SubContent>
+        </ContextMenu.Sub>
+
+        {#if railways.length > 1}
+          {#if task.repo_id}
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger>
+                <TrainFront class="size-4" />
+                Lane
+              </ContextMenu.SubTrigger>
+              <ContextMenu.SubContent class="min-w-40">
+                {#each railways as railway (railway.id)}
+                  {@const isCurrent = railway.id === task.railway_id}
+                  <ContextMenu.Item
+                    disabled={isCurrent}
+                    onclick={() => onMoveToRailway?.(railway.id)}
+                  >
+                    {#if isCurrent}
+                      <Check class="size-4" />
+                    {:else}
+                      <span class="size-4"></span>
+                    {/if}
+                    {railway.name}
+                  </ContextMenu.Item>
+                {/each}
+              </ContextMenu.SubContent>
+            </ContextMenu.Sub>
+          {:else}
+            <!-- An internal task has no repo to follow between lanes. -->
+            <ContextMenu.Item disabled title="Internal tasks have no repo to move between lanes">
+              <TrainFront class="size-4" />
+              Lane
+            </ContextMenu.Item>
+          {/if}
+        {/if}
+      </ContextMenu.SubContent>
+    </ContextMenu.Sub>
+
+    <ContextMenu.Separator />
+
     <ContextMenu.Item onclick={copyTaskLink}>
       <LinkIcon class="size-4" />
       Copy link

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -53,6 +53,7 @@
   import { Label } from '$lib/components/ui/label'
   import { Textarea } from '$lib/components/ui/textarea'
   import * as Alert from '$lib/components/ui/alert'
+  import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import * as Resizable from '$lib/components/ui/resizable'
 
   const FLIP_MS = 150
@@ -486,22 +487,99 @@
     return 1
   }
 
-  // Reassign a card's repo (and all its tasks) to another railway. Cross-lane is a
-  // repo move, not a card drag, so this is the explicit control behind the card's
-  // "move lane" menu. The backend blocks it while a live turn is working the repo
-  // on its current lane and returns the reason, which we surface in a toast.
-  async function moveTaskToRailway(task: Task, railwayId: string) {
-    if (!task.repo_id) {
+  // Move a single card to another column via its context menu (issue #233). "To Do
+  // (top/bottom)" mirrors the server-side automation rank: just above the column's
+  // current minimum, or just below its maximum, within the card's own lane (the
+  // card itself is excluded so re-ranking within To Do works). Other columns place
+  // the card at the top. Reuses the same `moveTask` the drag-and-drop path uses, so
+  // the board reflects it via the existing optimistic/SSE reload.
+  async function moveCardToColumn(task: Task, column: TaskColumn, placement: 'top' | 'bottom') {
+    const positions = (columnsByRailway[task.railway_id]?.[column] ?? [])
+      .filter((other) => other.id !== task.id)
+      .map((other) => other.position)
+    const position =
+      placement === 'bottom'
+        ? positions.length
+          ? Math.max(...positions) + 1
+          : 1
+        : positions.length
+          ? Math.min(...positions) - 1
+          : -1
+    try {
+      await moveTask(task.id, column, position)
+      await load()
+      toast.success(`Moved to ${columnLabel(column)}`)
+    } catch (error) {
+      const message = await extractApiError(error, 'Failed to move the card.')
+      toast.error(message)
+    }
+  }
+
+  function columnLabel(column: TaskColumn): string {
+    return COLUMNS.find((entry) => entry.key === column)?.label ?? column
+  }
+
+  // A lane move awaiting confirmation. Because a railway follows its repo, moving a
+  // card to another lane reassigns the whole REPO (and every one of its tasks), not
+  // just this card, so it is confirmed before it runs.
+  let pendingLaneMove = $state<{ task: Task; railwayId: string } | null>(null)
+  let laneMoveBusy = $state(false)
+
+  // The repo, task count, and target lane behind the pending move, for the
+  // confirmation copy. Null when there is nothing pending or the task has no repo.
+  const pendingLaneDetails = $derived.by(() => {
+    const repoId = pendingLaneMove?.task.repo_id
+    if (!repoId) {
+      return null
+    }
+    return {
+      repoLabel: repoNames[repoId] ?? 'this repo',
+      count: repoTaskCount(repoId),
+      laneName: railwayName(pendingLaneMove?.railwayId)
+    }
+  })
+
+  // How many of a repo's tasks are on the board, to spell out the blast radius of a
+  // lane move (the backend reassigns the repo and ALL its tasks).
+  function repoTaskCount(repoId: string): number {
+    let count = 0
+    for (const buckets of Object.values(columnsByRailway)) {
+      for (const column of COLUMNS) {
+        count += buckets[column.key].filter((task) => task.repo_id === repoId).length
+      }
+    }
+    return count
+  }
+
+  // Open the confirmation for moving a card's repo to another lane. A no-op (no
+  // repo, or already on that lane) is ignored.
+  function requestLaneMove(task: Task, railwayId: string) {
+    if (!task.repo_id || railwayId === task.railway_id) {
       return
     }
-    const repoLabel = repoNames[task.repo_id] ?? 'repo'
+    pendingLaneMove = { task, railwayId }
+  }
+
+  // Reassign the repo (and all its tasks) to the chosen lane. The backend blocks it
+  // while a live turn is working the repo on its current lane and returns the
+  // reason, which we surface as a toast.
+  async function confirmLaneMove() {
+    const move = pendingLaneMove
+    if (!move?.task.repo_id) {
+      return
+    }
+    const repoLabel = repoNames[move.task.repo_id] ?? 'repo'
+    laneMoveBusy = true
     try {
-      await assignRepoToRailway(railwayId, task.repo_id)
+      await assignRepoToRailway(move.railwayId, move.task.repo_id)
       await load()
-      toast.success(`Moved ${repoLabel} to ${railwayName(railwayId)}`)
+      toast.success(`Moved ${repoLabel} to ${railwayName(move.railwayId)}`)
     } catch (error) {
       const message = await extractApiError(error, 'Failed to move the repo to that railway.')
       toast.error(message)
+    } finally {
+      laneMoveBusy = false
+      pendingLaneMove = null
     }
   }
 
@@ -845,7 +923,8 @@
                 selected={selected.has(task.id)}
                 onselect={() => toggleSelected(task.id)}
                 {railways}
-                onMoveToRailway={(targetRailwayId) => moveTaskToRailway(task, targetRailwayId)}
+                onMoveToColumn={(column, placement) => moveCardToColumn(task, column, placement)}
+                onMoveToRailway={(targetRailwayId) => requestLaneMove(task, targetRailwayId)}
               />
             </div>
           {/each}
@@ -943,6 +1022,39 @@
       onDelete={applyBulkDelete}
     />
   {/if}
+
+  <!--
+    Lane-move confirmation (issue #233). A railway follows its repo, so moving a
+    card to another lane reassigns the whole repo and every one of its tasks. The
+    copy names the repo, the task count, and the target lane so the blast radius is
+    explicit. Closing (Cancel / Escape / outside) clears the pending move.
+  -->
+  <AlertDialog.Root
+    open={pendingLaneMove !== null}
+    onOpenChange={(open) => {
+      if (!open) pendingLaneMove = null
+    }}
+  >
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Move repo to the {pendingLaneDetails?.laneName} lane?</AlertDialog.Title>
+        <AlertDialog.Description>
+          A lane follows its repo, so this moves <span class="font-semibold"
+            >{pendingLaneDetails?.repoLabel}</span
+          >
+          and all {pendingLaneDetails?.count}
+          {pendingLaneDetails?.count === 1 ? 'task' : 'tasks'} of it to the
+          {pendingLaneDetails?.laneName} lane, not just this card.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel disabled={laneMoveBusy}>Cancel</AlertDialog.Cancel>
+        <Button onclick={confirmLaneMove} disabled={laneMoveBusy}>
+          {laneMoveBusy ? 'Moving…' : 'Move repo'}
+        </Button>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
 
   {#if filtersOpen}
     <!-- Filters drawer: a right-side modal over a dimmed backdrop. View-only;


### PR DESCRIPTION
Part of #231. Closes #233. Builds on the #232 context-menu foundation.

Adds the **Move to** submenu to the card right-click context menu.

## Move to > Column

- Lists Available, To Do (top), To Do (bottom), In Review, Done, Ignored (In Progress is omitted as agent-owned).
- Reuses the existing `moveTask(taskId, column, position)` (the same call the drag-and-drop path uses), so the board reflects it immediately via the existing reload/SSE path.
- "To Do (top)" / "To Do (bottom)" compute the rank the same way the server-side automation does: just above the column's current minimum (`min - 1`) or below its maximum (`max + 1`), within the card's own lane and excluding the card itself (so re-ranking a To Do card to top/bottom works).
- The current column is checked; a no-op destination column is disabled. To Do (top/bottom) stay actionable even when the card is already in To Do, since they re-rank the queue.

## Move to > Lane

- Lists every railway (main first), with the current lane checked and disabled.
- A railway follows its repo, so picking a lane reassigns the **whole repo and all of its tasks** via `assignRepoToRailway`, not just this card. The board now shows a confirmation dialog that names the repo, the number of tasks that will move, and the target lane before running it.
- On success it toasts `Moved <repo> to <lane>`; on a blocked reassignment (e.g. a live turn is running on that repo's current lane) it surfaces the backend's refusal reason as an error toast.
- Internal tasks with no repo show the Lane option disabled (they have no repo to follow); the Lane submenu is hidden entirely when there is only one lane.
- The existing card-footer "Move lane" control now routes through the same confirmation, so both entry points behave consistently.

## Acceptance criteria

- Move to > Column moves the card and the board reflects it immediately. ✅
- Move to > Lane reassigns the repo (with confirmation), moves the repo's cards, and toasts on success or on a blocked move. ✅
- Current column and lane are indicated (checked) and not actionable where the move would be a no-op. ✅
- `yarn check` / `yarn build` pass. ✅

## Note for review

The issue's explicit column list includes **In Review**, while its parenthetical "mirror the bulk-move bar" aside would exclude it (the bulk bar treats In Review as agent-owned). I followed the explicit list and included In Review; happy to drop it if you'd rather keep In Review agent-only. The card-footer "Move lane" button is left in place (now confirmed); it could be retired in favor of the context menu in a follow-up.

## Testing

`yarn check` (0 errors), `yarn test` (13 passed), `yarn build` all pass. Frontend-only.