### PR TITLE
Card context menu: quick actions (open / external links / copy) (#234)

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Railway, Task } from '../types'
+  import type { Railway, SourceKind, Task } from '../types'
 
   import { goto } from '$app/navigation'
   import {
@@ -8,8 +8,12 @@
     TrainFront,
     SquareArrowOutUpRight,
     Link as LinkIcon,
-    GitPullRequestArrow
+    GitPullRequestArrow,
+    Hash,
+    GitBranch,
+    Type
   } from '@lucide/svelte'
+  import { toast } from 'svelte-sonner'
 
   import { STATUS_BADGE, STATUS_LABELS, ticketStateBadge } from '../types'
   import { Badge } from './ui/badge'
@@ -59,6 +63,19 @@
   // The source ticket's open/closed (GitHub) or workflow (Jira) state, or null.
   const ticketState = $derived(ticketStateBadge(task))
 
+  // The label for the "open the external issue" action, per source. Internal
+  // tasks have no external issue, so the item is disabled regardless of label.
+  const EXTERNAL_OPEN_LABELS = {
+    github: 'Open on GitHub',
+    jira: 'Open in Jira',
+    internal: 'Open issue'
+  } as const satisfies Record<SourceKind, string>
+
+  // A pasteable reference to the source issue: `owner/repo#number` when the task
+  // has a repo (a cross-repo GitHub reference), else `#number`. Matches the card's
+  // own `#{external_id}` convention.
+  const issueReference = $derived(repoName ? `${repoName}#${task.external_id}` : `#${task.external_id}`)
+
   // A click opens the task normally, or toggles its selection in bulk mode.
   function activate() {
     if (selectionMode) {
@@ -79,6 +96,45 @@
     if (task.pr_url) {
       window.open(task.pr_url, '_blank', 'noopener,noreferrer')
     }
+  }
+
+  // Open the linked external issue (GitHub/Jira) in a new tab. Disabled when there
+  // is no external URL (an internal task), so `task.url` is always set here.
+  function openExternalIssue() {
+    if (task.url) {
+      window.open(task.url, '_blank', 'noopener,noreferrer')
+    }
+  }
+
+  // Write `text` to the clipboard and confirm with a small toast, or surface a
+  // failure (e.g. a denied clipboard permission) rather than failing silently.
+  async function copyToClipboard(text: string, confirmation: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success(confirmation)
+    }
+    catch (error) {
+      console.debug('clipboard write failed', error)
+      toast.error('Could not copy to the clipboard')
+    }
+  }
+
+  function copyLink() {
+    copyToClipboard(`${window.location.origin}/task/${task.id}`, 'Copied link')
+  }
+
+  function copyIssueReference() {
+    copyToClipboard(issueReference, `Copied ${issueReference}`)
+  }
+
+  function copyBranch() {
+    if (task.branch) {
+      copyToClipboard(task.branch, 'Copied branch name')
+    }
+  }
+
+  function copyTitle() {
+    copyToClipboard(task.title, 'Copied title')
   }
 
   // Whether the card's right-click context menu is open. Bound to the bits-ui
@@ -108,18 +164,6 @@
           clientY: rect.top + 16
         })
       )
-    }
-  }
-
-  // Copy a link to the task. A placeholder menu action for this foundation;
-  // real card actions land in follow-up tickets.
-  async function copyTaskLink() {
-    const url = `${window.location.origin}/task/${task.id}`
-    try {
-      await navigator.clipboard.writeText(url)
-    }
-    catch (error) {
-      console.debug('failed to copy task link', error)
     }
   }
 
@@ -266,16 +310,26 @@
   </ContextMenu.Trigger>
 
   <!--
-    Placeholder menu for this foundation ticket: "Open task" is the working item;
-    real card actions (move column, hold, reset, etc.) land in follow-up tickets.
-    Closing on Escape / outside click / item select is handled by bits-ui; scroll
-    close is wired in this component (see the `$effect` above).
+    Quick / navigation actions (issue #234). Closing on Escape / outside click /
+    item select is handled by bits-ui; scroll close is wired in this component
+    (see the `$effect` above). An action that does not apply (no external URL, no
+    PR, no branch) is disabled or hidden, never shown broken. Later tickets add a
+    "Move to..." section below this one.
   -->
-  <ContextMenu.Content class="min-w-44">
+  <ContextMenu.Content class="min-w-48">
     <ContextMenu.Label class="text-xs">#{task.external_id}</ContextMenu.Label>
+
     <ContextMenu.Item onclick={openTask}>
       <SquareArrowOutUpRight class="size-4" />
       Open task
+    </ContextMenu.Item>
+    <ContextMenu.Item
+      disabled={!task.url}
+      title={task.url ? undefined : 'This task has no linked external issue'}
+      onclick={openExternalIssue}
+    >
+      <SourceIcon source={task.source_kind} class="size-4" />
+      {EXTERNAL_OPEN_LABELS[task.source_kind]}
     </ContextMenu.Item>
     {#if task.pr_url}
       <ContextMenu.Item onclick={openPullRequest}>
@@ -283,10 +337,26 @@
         Open pull request
       </ContextMenu.Item>
     {/if}
+
     <ContextMenu.Separator />
-    <ContextMenu.Item onclick={copyTaskLink}>
+
+    <ContextMenu.Item onclick={copyLink}>
       <LinkIcon class="size-4" />
       Copy link
+    </ContextMenu.Item>
+    <ContextMenu.Item onclick={copyIssueReference}>
+      <Hash class="size-4" />
+      Copy issue reference
+    </ContextMenu.Item>
+    {#if task.branch}
+      <ContextMenu.Item onclick={copyBranch}>
+        <GitBranch class="size-4" />
+        Copy branch name
+      </ContextMenu.Item>
+    {/if}
+    <ContextMenu.Item onclick={copyTitle}>
+      <Type class="size-4" />
+      Copy title
     </ContextMenu.Item>
   </ContextMenu.Content>
 </ContextMenu.Root>


### PR DESCRIPTION
Part of #231. Closes #234. Builds on the #232 context-menu foundation.

Fills out the card context menu's top (quick / navigation) section.

## Actions

- **Open task**: navigate to `/task/:id`.
- **Open on GitHub** (or **Open in Jira**): open the linked external issue in a new tab, labeled and iconed per source (`SourceIcon`). Disabled for internal tasks with no external URL.
- **Open pull request**: open the PR in a new tab; shown only when the task has one.
- **Copy link**: the absolute task-page URL.
- **Copy issue reference**: `owner/repo#number` when the task has a repo (a pasteable cross-repo GitHub reference), else `#number`.
- **Copy branch name**: the task's branch; shown only when it has one.
- **Copy title**: the card title.

Copy actions use the clipboard API and confirm with a small toast (e.g. `Copied owner/repo#123`), and surface a failure rather than failing silently. Items that do not apply are hidden (PR, branch) or disabled (external open), never shown broken. The actions are grouped as the menu's top section; the "Move to..." section (#233) slots in below.

## Acceptance criteria

- Each action does the right thing and is hidden/disabled when not applicable. ✅
- Copy actions write the correct text and toast. ✅
- `yarn check` / `yarn build` pass. ✅

## Notes for review

- **Issue reference format:** I copy the full `owner/repo#number` instead of the literal short `repo#number` in the issue, because the full form is the pasteable GitHub cross-repo reference (short `repo#number` doesn't resolve on GitHub). The toast shows exactly what was copied. Trivial to switch to short if you prefer.
- This stacks on #232 (merged) and is a sibling of #233 (Move to, still open). When #233 lands there may be a small merge conflict in the menu `Content` block (both edit the same region); it resolves by keeping the quick actions on top and the "Move to" section below.

## Testing

`yarn check` (0 errors), `yarn test` (13 passed), `yarn build` all pass. Frontend-only, single repo.