### PR TITLE
Card context menu: lifecycle actions (prioritize, hold, reset, ignore, delete) (#235)

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -4,14 +4,19 @@
   import { goto } from '$app/navigation'
   import {
     Pause,
+    Play,
     Ban,
     TrainFront,
     SquareArrowOutUpRight,
     Link as LinkIcon,
     GitPullRequestArrow,
     ArrowRightLeft,
+    ArrowUpToLine,
     Columns2,
-    Check
+    Check,
+    CircleSlash,
+    RotateCcw,
+    Trash2
   } from '@lucide/svelte'
 
   import { STATUS_BADGE, STATUS_LABELS, ticketStateBadge } from '../types'
@@ -31,7 +36,10 @@
     onselect,
     railways = [],
     onMoveToRailway,
-    onMoveToColumn
+    onMoveToColumn,
+    onToggleHold,
+    onReset,
+    onDelete
   }: {
     task: Task
     onchange: () => void
@@ -53,7 +61,23 @@
     // placement so the agent's "do this next" (top) vs "later" (bottom) intent is
     // expressible; the board computes the rank and calls moveTask.
     onMoveToColumn?: (column: TaskColumn, placement: 'top' | 'bottom') => void
+    // Lifecycle actions (issue #235). The board owns the API call, toast, and (for
+    // the destructive ones) the confirmation dialog; the card just signals intent.
+    onToggleHold?: () => void
+    onReset?: () => void
+    onDelete?: () => void
   } = $props()
+
+  // Whether this task has actually started an attempt: it has a branch or PR, or
+  // it has moved past the queue. A task that never started has nothing to reset,
+  // so the destructive "Reset" action is disabled for it (issue #235).
+  const hasStarted = $derived(
+    !!task.branch ||
+      !!task.pr_url ||
+      task.board_column === 'in_progress' ||
+      task.board_column === 'in_review' ||
+      task.board_column === 'done'
+  )
 
   // The board columns the context menu offers as move targets (issue #233). In
   // Progress is omitted (the agent owns it); To Do is split into top/bottom of the
@@ -380,5 +404,56 @@
       <LinkIcon class="size-4" />
       Copy link
     </ContextMenu.Item>
+
+    <ContextMenu.Separator />
+
+    <!--
+      Lifecycle actions (issue #235). "Work this now" / "Send to Ignored" are just
+      column moves, so they reuse onMoveToColumn; Hold toggles the flag (the label
+      shows the opposite of the current state).
+    -->
+    <ContextMenu.Item onclick={() => onMoveToColumn?.('todo', 'top')}>
+      <ArrowUpToLine class="size-4" />
+      Work this now
+    </ContextMenu.Item>
+    <ContextMenu.Item onclick={() => onToggleHold?.()}>
+      {#if task.hold}
+        <Play class="size-4" />
+        Release hold
+      {:else}
+        <Pause class="size-4" />
+        Hold
+      {/if}
+    </ContextMenu.Item>
+    <ContextMenu.Item
+      disabled={task.board_column === 'ignored'}
+      onclick={() => onMoveToColumn?.('ignored', 'top')}
+    >
+      <CircleSlash class="size-4" />
+      Send to Ignored
+    </ContextMenu.Item>
+
+    <ContextMenu.Separator />
+
+    <!--
+      Destructive actions: visually separated, styled destructive, and confirmed by
+      the board before they run. Reset is disabled when the task never started;
+      Delete is internal-only (source-driven tasks are managed from their source).
+    -->
+    <ContextMenu.Item
+      variant="destructive"
+      disabled={!hasStarted}
+      title={hasStarted ? undefined : "This task hasn't started yet, so there is nothing to reset"}
+      onclick={() => onReset?.()}
+    >
+      <RotateCcw class="size-4" />
+      Reset task…
+    </ContextMenu.Item>
+    {#if task.source_kind === 'internal'}
+      <ContextMenu.Item variant="destructive" onclick={() => onDelete?.()}>
+        <Trash2 class="size-4" />
+        Delete…
+      </ContextMenu.Item>
+    {/if}
   </ContextMenu.Content>
 </ContextMenu.Root>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -31,12 +31,14 @@
     extractApiError,
     getBoard,
     getNotepad,
+    hardResetTask,
     listRepos,
     moveTask,
     provisionWorkspace,
     setNotepad,
     setPaused,
     setRailwayPaused,
+    setTaskHold,
     syncNow
   } from '$lib/api'
   import { isWithinSchedule } from '$lib/schedule'
@@ -583,6 +585,77 @@
     }
   }
 
+  // --- Card lifecycle actions (issue #235) -----------------------------------
+  // Toggle a card's hold flag from its context menu. A reversible flag, so no
+  // confirmation (unlike the destructive actions below); just toast the result.
+  async function toggleHold(task: Task) {
+    try {
+      await setTaskHold(task.id, !task.hold)
+      await load()
+      toast.success(task.hold ? 'Hold released' : 'Task held — the agent will skip it')
+    } catch (error) {
+      const message = await extractApiError(error, 'Failed to update the hold.')
+      toast.error(message)
+    }
+  }
+
+  // A task awaiting a hard-reset / delete confirmation. Both are destructive, so
+  // they are confirmed before running (mirroring the task page's buttons).
+  let pendingReset = $state<Task | null>(null)
+  let resetBusy = $state(false)
+  let pendingDelete = $state<Task | null>(null)
+  let deleteBusy = $state(false)
+
+  // Hard reset: abandon the attempt, close the PR, delete the branch, reopen the
+  // source issue, and return the card to Available. Reports the side effects that
+  // actually ran via a toast, matching the task page.
+  async function confirmReset() {
+    const task = pendingReset
+    if (!task) {
+      return
+    }
+    resetBusy = true
+    try {
+      const summary = await hardResetTask(task.id)
+      const done = [
+        summary.interrupted_agent && 'stopped the agent',
+        summary.pr_closed && 'closed the PR',
+        summary.branch_deleted && 'deleted the branch',
+        summary.issue_reopened && 'reopened the issue'
+      ].filter(Boolean)
+      const detail = done.length ? ` (${done.join(', ')})` : ''
+      await load()
+      toast.success(`Task reset to Available${detail}`)
+    } catch (error) {
+      const message = await extractApiError(error, 'Hard reset failed. See the server logs.')
+      toast.error(message)
+    } finally {
+      resetBusy = false
+      pendingReset = null
+    }
+  }
+
+  // Delete an internal task (the card + its history). Source-driven tasks are not
+  // deletable here, so this only ever runs for internal tickets.
+  async function confirmDelete() {
+    const task = pendingDelete
+    if (!task) {
+      return
+    }
+    deleteBusy = true
+    try {
+      await bulkDeleteTasks([task.id])
+      await load()
+      toast.success('Task deleted')
+    } catch (error) {
+      const message = await extractApiError(error, 'Failed to delete the task.')
+      toast.error(message)
+    } finally {
+      deleteBusy = false
+      pendingDelete = null
+    }
+  }
+
   async function togglePause() {
     if (!settings) {
       return
@@ -925,6 +998,9 @@
                 {railways}
                 onMoveToColumn={(column, placement) => moveCardToColumn(task, column, placement)}
                 onMoveToRailway={(targetRailwayId) => requestLaneMove(task, targetRailwayId)}
+                onToggleHold={() => toggleHold(task)}
+                onReset={() => (pendingReset = task)}
+                onDelete={() => (pendingDelete = task)}
               />
             </div>
           {/each}
@@ -1051,6 +1127,59 @@
         <AlertDialog.Cancel disabled={laneMoveBusy}>Cancel</AlertDialog.Cancel>
         <Button onclick={confirmLaneMove} disabled={laneMoveBusy}>
           {laneMoveBusy ? 'Moving…' : 'Move repo'}
+        </Button>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+
+  <!--
+    Hard-reset confirmation (issue #235). Same copy as the task page's Hard reset
+    button. Closing (Cancel / Escape / outside) clears the pending reset.
+  -->
+  <AlertDialog.Root
+    open={pendingReset !== null}
+    onOpenChange={(open) => {
+      if (!open) pendingReset = null
+    }}
+  >
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Hard reset this task?</AlertDialog.Title>
+        <AlertDialog.Description>
+          This abandons the current attempt and starts the task over. It will: stop the agent if it
+          is working this task right now, close its pull request, delete its branch (from GitHub and
+          the workspace), reopen the source issue if it was closed, and move the card back to
+          Available. This cannot be undone.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel disabled={resetBusy}>Cancel</AlertDialog.Cancel>
+        <Button variant="destructive" onclick={confirmReset} disabled={resetBusy}>
+          {resetBusy ? 'Resetting…' : 'Hard reset'}
+        </Button>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog.Root>
+
+  <!-- Delete confirmation (issue #235), internal tasks only. -->
+  <AlertDialog.Root
+    open={pendingDelete !== null}
+    onOpenChange={(open) => {
+      if (!open) pendingDelete = null
+    }}
+  >
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Delete this task?</AlertDialog.Title>
+        <AlertDialog.Description>
+          This permanently removes the card and its activity history from Seraphim. This cannot be
+          undone.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel disabled={deleteBusy}>Cancel</AlertDialog.Cancel>
+        <Button variant="destructive" onclick={confirmDelete} disabled={deleteBusy}>
+          {deleteBusy ? 'Deleting…' : 'Delete'}
         </Button>
       </AlertDialog.Footer>
     </AlertDialog.Content>


### PR DESCRIPTION
Part of #231. Closes #235. Builds on #232 and the #233 "Move to" submenu (both on develop).

Adds the task lifecycle actions to the card right-click context menu so the operator can curate work without opening the task page.

## Actions

- **Work this now**: move the card to the top of To Do (reuses the existing column-move path with the top rank).
- **Hold / Release hold**: toggle the task's `hold` flag; the item shows the opposite of the current state. Reversible, so no confirmation, just a toast (`Task held — the agent will skip it` / `Hold released`).
- **Send to Ignored**: move the card to the Ignored column; disabled when it is already there.
- **Reset task...**: the per-task hard reset (`POST /api/v1/tasks/:id/reset`). Destructive styling + a confirmation dialog reusing the task page's copy; on success it surfaces the returned `ResetSummary` as a toast, identical to the task-page button (`Task reset to Available (stopped the agent, closed the PR, ...)`). Disabled (with a tooltip) when the task never started (no branch/PR and not past the queue).
- **Delete...**: internal tasks only (hidden for GitHub/Jira-sourced tasks, which are driven by their source). Destructive styling + a confirmation; deletes via the existing bulk-delete endpoint.

## Details

- Destructive items (Reset, Delete) are visually separated, styled `destructive`, and confirmed via an AlertDialog before acting (mirroring the lane-move confirmation pattern already on the board).
- All actions run through the board, which calls the same endpoints as the task page and reloads, so the board updates via the existing SSE/reload path.
- State-gated items (Reset when never started, Send to Ignored when already ignored) are disabled; Delete is hidden for non-internal tasks.

## Acceptance criteria

- Each action performs the same operation as its task-page equivalent and the board updates. ✅
- Reset and Delete confirm first and are styled destructive. ✅
- Internal-only and state-gated items are hidden/disabled appropriately. ✅
- `yarn check` / `yarn build` pass. ✅

## Note for review

This stacks on the open siblings #234 (quick actions) — both edit the menu `Content` block, so a small merge conflict is expected when #234 lands; it resolves by keeping the quick/copy actions at the top and this lifecycle/destructive group at the bottom. "Work this now" and "Send to Ignored" intentionally reuse the column-move handler (DRY), so their success toast reads "Moved to To Do" / "Moved to Ignored".

## Testing

`yarn check` (0 errors), `yarn test` (13 passed), `yarn build` all pass. Frontend-only, single repo.