### PR TITLE
Symlink ~/.claude to the config dir so documented home-dir paths resolve (#259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,14 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   failure it records `settings.config_repo_error`, the board shows a red banner,
   and `next_actionable_task` **halts the agent** (refuses to pull work) until it
   succeeds. A blank `config_repo_url` bypasses the halt (agent runs unconfigured).
+  The workspace entrypoint also symlinks the agent's `~/.claude`
+  (`/home/codespace/.claude`) at `CLAUDE_CONFIG_DIR` so the global instructions'
+  documented home-dir paths (`~/.claude/orgs/*.md`, `~/.claude/docs/*.md`)
+  resolve, since the agent's `$HOME` is `/home/codespace`, not `/workspace`
+  (issue #259). `$HOME` is deliberately **not** moved to `/workspace`: SSH keys
+  (`~/.ssh`) and `gh auth setup-git` credentials live under `/home/codespace`, so
+  relocating `$HOME` would break SSH cloning and git/gh auth; the symlink fixes
+  the path resolution with no such side effects.
 - **Claude invocation** (`api/src/claude/exec.rs`):
   `claude -p <prompt> --output-format stream-json --verbose --permission-mode bypassPermissions --model <model> [--resume <session>]`,
   exec'd as user `codespace`, cwd `/workspace`. All tasks resume the one shared

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -17,6 +17,35 @@ mkdir -p /workspace "${CLAUDE_CONFIG_DIR}/projects"
 chown "${AGENT_USER}:${AGENT_USER}" /workspace
 chown -R "${AGENT_USER}:${AGENT_USER}" "${CLAUDE_CONFIG_DIR}" 2>/dev/null || true
 
+# --- Make documented ~/.claude/... paths resolve (issue #259) ----------------
+# The global instructions tell the agent to read ~/.claude/orgs/*.md and every
+# applicable ~/.claude/docs/*.md before its first edit (and to HALT if the org
+# file is missing). But the config repo lives under CLAUDE_CONFIG_DIR
+# (/workspace/.claude) while the agent's $HOME is /home/codespace, so those
+# literal home-dir paths don't resolve and can trigger a false halt that wastes a
+# run. Symlink the agent's ~/.claude at the real config dir so the documented
+# paths resolve, with no other effect.
+#
+# We deliberately do NOT move $HOME to /workspace (the alternative considered in
+# the issue): SSH keys are copied to ${AGENT_HOME}/.ssh below and `gh auth
+# setup-git` wires git credentials under ${AGENT_HOME}, so relocating $HOME would
+# break SSH cloning and auth unless those were relocated too. The symlink has no
+# such side effects.
+#
+# If a real (non-symlink) ~/.claude already exists, link only the two documented
+# subdirs so we never clobber other Claude state the home dir may hold. A symlink
+# to a target that the API clones later (orgs/, docs/) is fine: it dangles until
+# the config repo lands, then resolves.
+if [ "${CLAUDE_CONFIG_DIR}" != "${AGENT_HOME}/.claude" ]; then
+  if [ ! -e "${AGENT_HOME}/.claude" ] || [ -L "${AGENT_HOME}/.claude" ]; then
+    ln -sfn "${CLAUDE_CONFIG_DIR}" "${AGENT_HOME}/.claude"
+  else
+    ln -sfn "${CLAUDE_CONFIG_DIR}/orgs" "${AGENT_HOME}/.claude/orgs"
+    ln -sfn "${CLAUDE_CONFIG_DIR}/docs" "${AGENT_HOME}/.claude/docs"
+  fi
+  chown -h "${AGENT_USER}:${AGENT_USER}" "${AGENT_HOME}/.claude" 2>/dev/null || true
+fi
+
 # --- SSH: copy the host's keys so git@github.com clones work -----------------
 if [ -d /host-ssh ]; then
   mkdir -p "${AGENT_HOME}/.ssh"


### PR DESCRIPTION
Closes #259.

## Problem

The global instructions tell the agent to read `~/.claude/orgs/*.md` (and **halt** if the org file is missing) and every applicable `~/.claude/docs/*.md` before its first edit. But the config repo is cloned into `CLAUDE_CONFIG_DIR=/workspace/.claude`, while the agent's `$HOME` is `/home/codespace`, so those literal home-dir paths don't resolve. That can trigger the false "halt" the issue describes and waste a run locating the real paths.

## Fix

The workspace entrypoint now symlinks the agent's `~/.claude` (`/home/codespace/.claude`) at `CLAUDE_CONFIG_DIR`, so `~/.claude/orgs/...` and `~/.claude/docs/...` resolve. If a real (non-symlink) `~/.claude` already exists, it links only the `orgs/` and `docs/` subdirs, so other Claude state in the home dir is never clobbered. A symlink to a target the API clones later (orgs/docs arrive with the config repo) just dangles until the clone lands, then resolves.

## Why not `HOME=/workspace`

The issue and a maintainer comment floated setting `$HOME=/workspace` instead. I verified the side effects and that approach has a real blocker: the entrypoint copies the host SSH keys to `/home/codespace/.ssh` and `gh auth setup-git` wires git credentials under `/home/codespace`, and repos clone over SSH (`git@github.com:...`). Moving `$HOME` would break SSH cloning and git/gh auth unless `~/.ssh`, `known_hosts`, and the git/gh config were all relocated too, a much larger and riskier change to the workspace image. The symlink fixes the path resolution with **zero** auth side effects.

I asked the maintainer to confirm the direction before committing (the question is still open). Proceeding with the symlink because it is the surgical, verified, side-effect-free fix that resolves the reported bug and is additive: it does not preclude a later `HOME=/workspace` + relocate change if preferred. Happy to switch to that approach in review.

## Testing

- `bash -n workspace/entrypoint.sh` passes.
- Simulated the symlink logic for all four cases: fresh home (whole-dir symlink), dangling target that resolves once the config repo lands, a pre-existing real `~/.claude` (subdir-only links), and an idempotent re-run. All read the linked files correctly.

Documented the behavior and the `$HOME` decision in `CLAUDE.md` (source-of-truth policy). Workspace-image-only change; no Rust/frontend code touched.