### PR TITLE
Card context menu: multi-select awareness and polish (#236)

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -19,7 +19,8 @@
     Check,
     CircleSlash,
     RotateCcw,
-    Trash2
+    Trash2,
+    Search
   } from '@lucide/svelte'
   import { toast } from 'svelte-sonner'
 
@@ -37,8 +38,10 @@
     suggestionCount = 0,
     selectionMode = false,
     selected = false,
+    selectedCount = 0,
     onselect,
     railways = [],
+    recentLaneIds = [],
     onMoveToRailway,
     onMoveToColumn,
     onToggleHold,
@@ -54,12 +57,18 @@
     // cards dim so it is obvious which are picked.
     selectionMode?: boolean
     selected?: boolean
+    // How many cards are currently selected board-wide. When this card is part of a
+    // multi-selection (issue #236) the context menu acts on the whole selection.
+    selectedCount?: number
     onselect?: () => void
     // The full set of railways (swimlanes). When more than one exists and the card
     // has a repo, a "move to lane" control reassigns the card's repo's railway
     // (cross-lane is a repo move, never a card drag). Omitted when there is only
     // the single `main` lane, where the control is meaningless.
     railways?: Railway[]
+    // Recently used lane move targets (railway ids), newest first, for the lane
+    // submenu's shortlist (issue #236). The board owns this and persists it.
+    recentLaneIds?: string[]
     onMoveToRailway?: (railwayId: string) => void
     // Move this card to another board column (context menu). "To Do" carries a
     // placement so the agent's "do this next" (top) vs "later" (bottom) intent is
@@ -71,6 +80,36 @@
     onReset?: () => void
     onDelete?: () => void
   } = $props()
+
+  // Multi-select awareness (issue #236): when this card is part of a multi-card
+  // selection, the menu acts on the whole selection. The board routes each action
+  // to all selected cards; here it drives the header and which items are shown
+  // (per-card-only actions are hidden in multi mode; bulk-capable ones stay).
+  const multi = $derived(selected && selectedCount > 1)
+
+  // Above this many lanes, the lane submenu shows a filter box (issue #236). Below
+  // it the list is short enough to scan, and bits-ui's type-ahead already covers
+  // keyboard jumping.
+  const LANE_FILTER_THRESHOLD = 7
+  let laneFilter = $state('')
+
+  // Recently used lanes still on the board, excluding the card's current lane in
+  // single-card mode (in multi mode the selection may span lanes, so keep them).
+  const recentRailways = $derived(
+    recentLaneIds
+      .map((id) => railways.find((railway) => railway.id === id))
+      .filter((railway): railway is Railway => !!railway)
+      .filter((railway) => multi || railway.id !== task.railway_id)
+  )
+
+  // The lane list narrowed by the filter box (case-insensitive name match).
+  const filteredRailways = $derived(
+    laneFilter.trim()
+      ? railways.filter((railway) =>
+          railway.name.toLowerCase().includes(laneFilter.trim().toLowerCase())
+        )
+      : railways
+  )
 
   // Whether this task has actually started an attempt: it has a branch or PR, or
   // it has moved past the queue. A task that never started has nothing to reset,
@@ -208,7 +247,31 @@
           clientY: rect.top + 16
         })
       )
+      return
     }
+    // Power-user shortcuts on a focused card (issue #236): W = work this now,
+    // H = toggle hold. The menu shows these hints. Skipped when a modifier is held
+    // so a browser/OS shortcut is never clobbered. (When the menu is open, focus is
+    // in the menu, not the card, so these never fire there.)
+    if (event.ctrlKey || event.metaKey || event.altKey) {
+      return
+    }
+    if (event.key === 'w' || event.key === 'W') {
+      event.preventDefault()
+      onMoveToColumn?.('todo', 'top')
+    } else if (event.key === 'h' || event.key === 'H') {
+      event.preventDefault()
+      onToggleHold?.()
+    }
+  }
+
+  // Keep typing in the lane filter box from triggering the menu's type-ahead, while
+  // still letting the menu's own navigation/dismiss keys through.
+  function onLaneFilterKeydown(event: KeyboardEvent) {
+    if (['Escape', 'ArrowDown', 'ArrowUp', 'Enter', 'Tab'].includes(event.key)) {
+      return
+    }
+    event.stopPropagation()
   }
 
   // Close the menu when anything other than the menu itself scrolls. The menu is
@@ -217,6 +280,8 @@
   // Scroll events do not bubble, so we listen in the capture phase.
   $effect(() => {
     if (!menuOpen) {
+      // Reset the lane filter so the next open starts fresh.
+      laneFilter = ''
       return
     }
     function onScroll(event: Event) {
@@ -360,56 +425,71 @@
     `$effect` above). An action that does not apply (no external URL, no PR, no
     branch) is disabled or hidden, never shown broken.
   -->
-  <ContextMenu.Content class="min-w-48">
-    <ContextMenu.Label class="text-xs">#{task.external_id}</ContextMenu.Label>
-
-    <ContextMenu.Item onclick={openTask}>
-      <SquareArrowOutUpRight class="size-4" />
-      Open task
-    </ContextMenu.Item>
-    <ContextMenu.Item
-      disabled={!task.url}
-      title={task.url ? undefined : 'This task has no linked external issue'}
-      onclick={openExternalIssue}
-    >
-      <SourceIcon source={task.source_kind} class="size-4" />
-      {EXTERNAL_OPEN_LABELS[task.source_kind]}
-    </ContextMenu.Item>
-    {#if task.pr_url}
-      <ContextMenu.Item onclick={openPullRequest}>
-        <GitPullRequestArrow class="size-4" />
-        Open pull request
-      </ContextMenu.Item>
+  <ContextMenu.Content class="min-w-52">
+    <!--
+      Header: the single card's issue ref, or the selection count when the menu
+      acts on a multi-selection (issue #236).
+    -->
+    {#if multi}
+      <ContextMenu.Label class="text-xs">{selectedCount} cards selected</ContextMenu.Label>
+    {:else}
+      <ContextMenu.Label class="text-xs">#{task.external_id}</ContextMenu.Label>
     {/if}
-
-    <ContextMenu.Separator />
-
-    <ContextMenu.Item onclick={copyLink}>
-      <LinkIcon class="size-4" />
-      Copy link
-    </ContextMenu.Item>
-    <ContextMenu.Item onclick={copyIssueReference}>
-      <Hash class="size-4" />
-      Copy issue reference
-    </ContextMenu.Item>
-    {#if task.branch}
-      <ContextMenu.Item onclick={copyBranch}>
-        <GitBranch class="size-4" />
-        Copy branch name
-      </ContextMenu.Item>
-    {/if}
-    <ContextMenu.Item onclick={copyTitle}>
-      <Type class="size-4" />
-      Copy title
-    </ContextMenu.Item>
-
-    <ContextMenu.Separator />
 
     <!--
-      Move to > Column / Lane (issue #233). A column move re-ranks/relocates just
-      this card; a lane move reassigns the card's REPO (and all its tasks), so it
-      is confirmed and toasted by the board. The current column/lane is checked,
-      and a no-op destination is disabled.
+      Per-card-only actions (open / copy): meaningless across a selection, so they
+      are hidden in multi mode (issue #236).
+    -->
+    {#if !multi}
+      <ContextMenu.Item onclick={openTask}>
+        <SquareArrowOutUpRight class="size-4" />
+        Open task
+      </ContextMenu.Item>
+      <ContextMenu.Item
+        disabled={!task.url}
+        title={task.url ? undefined : 'This task has no linked external issue'}
+        onclick={openExternalIssue}
+      >
+        <SourceIcon source={task.source_kind} class="size-4" />
+        {EXTERNAL_OPEN_LABELS[task.source_kind]}
+      </ContextMenu.Item>
+      {#if task.pr_url}
+        <ContextMenu.Item onclick={openPullRequest}>
+          <GitPullRequestArrow class="size-4" />
+          Open pull request
+        </ContextMenu.Item>
+      {/if}
+
+      <ContextMenu.Separator />
+
+      <ContextMenu.Item onclick={copyLink}>
+        <LinkIcon class="size-4" />
+        Copy link
+      </ContextMenu.Item>
+      <ContextMenu.Item onclick={copyIssueReference}>
+        <Hash class="size-4" />
+        Copy issue reference
+      </ContextMenu.Item>
+      {#if task.branch}
+        <ContextMenu.Item onclick={copyBranch}>
+          <GitBranch class="size-4" />
+          Copy branch name
+        </ContextMenu.Item>
+      {/if}
+      <ContextMenu.Item onclick={copyTitle}>
+        <Type class="size-4" />
+        Copy title
+      </ContextMenu.Item>
+
+      <ContextMenu.Separator />
+    {/if}
+
+    <!--
+      Bulk-capable actions (issues #233/#235/#236): Move to column/lane, Work this
+      now, Hold/Unhold, Send to Ignored. The board applies each to the whole
+      selection when one is active, otherwise just this card. A column move
+      re-ranks/relocates; a lane move reassigns the REPO(s) (confirmed + toasted by
+      the board). Current column/lane is checked only in single-card mode.
     -->
     <ContextMenu.Sub>
       <ContextMenu.SubTrigger>
@@ -424,7 +504,7 @@
           </ContextMenu.SubTrigger>
           <ContextMenu.SubContent class="min-w-40">
             {#each COLUMN_MOVES as move (move.label)}
-              {@const isCurrent = move.column === task.board_column}
+              {@const isCurrent = !multi && move.column === task.board_column}
               <ContextMenu.Item
                 disabled={isCurrent && move.column !== 'todo'}
                 onclick={() => onMoveToColumn?.(move.column, move.placement)}
@@ -441,15 +521,42 @@
         </ContextMenu.Sub>
 
         {#if railways.length > 1}
-          {#if task.repo_id}
+          {#if multi || task.repo_id}
             <ContextMenu.Sub>
               <ContextMenu.SubTrigger>
                 <TrainFront class="size-4" />
                 Lane
               </ContextMenu.SubTrigger>
-              <ContextMenu.SubContent class="min-w-40">
-                {#each railways as railway (railway.id)}
-                  {@const isCurrent = railway.id === task.railway_id}
+              <ContextMenu.SubContent class="min-w-44">
+                {#if railways.length > LANE_FILTER_THRESHOLD}
+                  <!-- Filter box for boards with many lanes (issue #236). It keeps
+                       its own keystrokes from the menu's type-ahead. -->
+                  <div class="flex items-center gap-1.5 px-1.5 py-1">
+                    <Search class="size-3.5 flex-none text-muted-foreground" />
+                    <input
+                      type="text"
+                      placeholder="Filter lanes…"
+                      bind:value={laneFilter}
+                      onkeydown={onLaneFilterKeydown}
+                      class="h-6 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                    />
+                  </div>
+                  <ContextMenu.Separator />
+                {/if}
+
+                {#if recentRailways.length > 0 && !laneFilter.trim()}
+                  <ContextMenu.Label class="text-xs">Recent</ContextMenu.Label>
+                  {#each recentRailways as railway (railway.id)}
+                    <ContextMenu.Item onclick={() => onMoveToRailway?.(railway.id)}>
+                      <TrainFront class="size-4" />
+                      {railway.name}
+                    </ContextMenu.Item>
+                  {/each}
+                  <ContextMenu.Separator />
+                {/if}
+
+                {#each filteredRailways as railway (railway.id)}
+                  {@const isCurrent = !multi && railway.id === task.railway_id}
                   <ContextMenu.Item
                     disabled={isCurrent}
                     onclick={() => onMoveToRailway?.(railway.id)}
@@ -462,6 +569,11 @@
                     {railway.name}
                   </ContextMenu.Item>
                 {/each}
+                {#if filteredRailways.length === 0}
+                  <ContextMenu.Label class="text-xs text-muted-foreground">
+                    No lanes match
+                  </ContextMenu.Label>
+                {/if}
               </ContextMenu.SubContent>
             </ContextMenu.Sub>
           {:else}
@@ -477,14 +589,10 @@
 
     <ContextMenu.Separator />
 
-    <!--
-      Lifecycle actions (issue #235). "Work this now" / "Send to Ignored" are just
-      column moves, so they reuse onMoveToColumn; Hold toggles the flag (the label
-      shows the opposite of the current state).
-    -->
     <ContextMenu.Item onclick={() => onMoveToColumn?.('todo', 'top')}>
       <ArrowUpToLine class="size-4" />
       Work this now
+      <ContextMenu.Shortcut>W</ContextMenu.Shortcut>
     </ContextMenu.Item>
     <ContextMenu.Item onclick={() => onToggleHold?.()}>
       {#if task.hold}
@@ -494,36 +602,41 @@
         <Pause class="size-4" />
         Hold
       {/if}
+      <ContextMenu.Shortcut>H</ContextMenu.Shortcut>
     </ContextMenu.Item>
     <ContextMenu.Item
-      disabled={task.board_column === 'ignored'}
+      disabled={!multi && task.board_column === 'ignored'}
       onclick={() => onMoveToColumn?.('ignored', 'top')}
     >
       <CircleSlash class="size-4" />
       Send to Ignored
     </ContextMenu.Item>
 
-    <ContextMenu.Separator />
-
     <!--
-      Destructive actions: visually separated, styled destructive, and confirmed by
-      the board before they run. Reset is disabled when the task never started;
-      Delete is internal-only (source-driven tasks are managed from their source).
+      Destructive actions (issue #235): per-card only, so hidden in multi mode
+      (bulk reset/delete are not offered here). Visually separated, styled
+      destructive, confirmed by the board. Reset is disabled when the task never
+      started; Delete is internal-only (source-driven tasks are managed from their
+      source).
     -->
-    <ContextMenu.Item
-      variant="destructive"
-      disabled={!hasStarted}
-      title={hasStarted ? undefined : "This task hasn't started yet, so there is nothing to reset"}
-      onclick={() => onReset?.()}
-    >
-      <RotateCcw class="size-4" />
-      Reset task…
-    </ContextMenu.Item>
-    {#if task.source_kind === 'internal'}
-      <ContextMenu.Item variant="destructive" onclick={() => onDelete?.()}>
-        <Trash2 class="size-4" />
-        Delete…
+    {#if !multi}
+      <ContextMenu.Separator />
+
+      <ContextMenu.Item
+        variant="destructive"
+        disabled={!hasStarted}
+        title={hasStarted ? undefined : "This task hasn't started yet, so there is nothing to reset"}
+        onclick={() => onReset?.()}
+      >
+        <RotateCcw class="size-4" />
+        Reset task…
       </ContextMenu.Item>
+      {#if task.source_kind === 'internal'}
+        <ContextMenu.Item variant="destructive" onclick={() => onDelete?.()}>
+          <Trash2 class="size-4" />
+          Delete…
+        </ContextMenu.Item>
+      {/if}
     {/if}
   </ContextMenu.Content>
 </ContextMenu.Root>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -489,13 +489,50 @@
     return 1
   }
 
-  // Move a single card to another column via its context menu (issue #233). "To Do
-  // (top/bottom)" mirrors the server-side automation rank: just above the column's
-  // current minimum, or just below its maximum, within the card's own lane (the
-  // card itself is excluded so re-ranking within To Do works). Other columns place
-  // the card at the top. Reuses the same `moveTask` the drag-and-drop path uses, so
-  // the board reflects it via the existing optimistic/SSE reload.
+  // The tasks a context-menu action should apply to (issue #236): the whole
+  // multi-selection when the right-clicked card is part of it, otherwise just that
+  // card. Keeps single-card behavior identical while making the menu act on the
+  // selection when one is active.
+  function actionTasks(task: Task): Task[] {
+    if (!(selected.has(task.id) && selected.size > 1)) {
+      return [task]
+    }
+    const all: Task[] = []
+    for (const buckets of Object.values(columnsByRailway)) {
+      for (const column of COLUMNS) {
+        for (const candidate of buckets[column.key]) {
+          if (selected.has(candidate.id)) {
+            all.push(candidate)
+          }
+        }
+      }
+    }
+    return all
+  }
+
+  // Move a card (or the whole selection) to another column via the context menu
+  // (issues #233/#236). For a single card, "To Do (top/bottom)" mirrors the
+  // server-side automation rank: just above the column's current minimum, or just
+  // below its maximum, within the card's own lane (the card itself is excluded so
+  // re-ranking within To Do works). For a multi-selection, every selected card is
+  // moved to the column in one bulk call (precise top/bottom ranking is a
+  // single-card nicety). Both reuse the board's existing reload/SSE path.
   async function moveCardToColumn(task: Task, column: TaskColumn, placement: 'top' | 'bottom') {
+    const targets = actionTasks(task)
+    if (targets.length > 1) {
+      try {
+        await bulkSetTaskStatus(
+          targets.map((target) => target.id),
+          column
+        )
+        await load()
+        toast.success(`Moved ${targets.length} cards to ${columnLabel(column)}`)
+      } catch (error) {
+        toast.error(await extractApiError(error, 'Failed to move the cards.'))
+      }
+      return
+    }
+
     const positions = (columnsByRailway[task.railway_id]?.[column] ?? [])
       .filter((other) => other.id !== task.id)
       .map((other) => other.position)
@@ -521,23 +558,25 @@
     return COLUMNS.find((entry) => entry.key === column)?.label ?? column
   }
 
-  // A lane move awaiting confirmation. Because a railway follows its repo, moving a
-  // card to another lane reassigns the whole REPO (and every one of its tasks), not
-  // just this card, so it is confirmed before it runs.
-  let pendingLaneMove = $state<{ task: Task; railwayId: string } | null>(null)
+  // A lane move awaiting confirmation (issues #233/#236). Because a railway follows
+  // its repo, moving a card to another lane reassigns the whole REPO (and every one
+  // of its tasks). For a multi-selection we operate per unique repo across the
+  // selection, so the pending move carries the deduped repo ids, not a single task.
+  let pendingLaneMove = $state<{ railwayId: string; repoIds: string[] } | null>(null)
   let laneMoveBusy = $state(false)
 
-  // The repo, task count, and target lane behind the pending move, for the
-  // confirmation copy. Null when there is nothing pending or the task has no repo.
+  // The repo count, total task count, and target lane behind the pending move, for
+  // the confirmation copy. Null when nothing is pending.
   const pendingLaneDetails = $derived.by(() => {
-    const repoId = pendingLaneMove?.task.repo_id
-    if (!repoId) {
+    if (!pendingLaneMove) {
       return null
     }
+    const { railwayId, repoIds } = pendingLaneMove
     return {
-      repoLabel: repoNames[repoId] ?? 'this repo',
-      count: repoTaskCount(repoId),
-      laneName: railwayName(pendingLaneMove?.railwayId)
+      repoCount: repoIds.length,
+      repoLabel: repoIds.length === 1 ? (repoNames[repoIds[0]] ?? 'this repo') : `${repoIds.length} repos`,
+      taskCount: repoIds.reduce((sum, repoId) => sum + repoTaskCount(repoId), 0),
+      laneName: railwayName(railwayId)
     }
   })
 
@@ -553,46 +592,110 @@
     return count
   }
 
-  // Open the confirmation for moving a card's repo to another lane. A no-op (no
-  // repo, or already on that lane) is ignored.
+  // Open the confirmation for moving a card's (or the selection's) repo(s) to
+  // another lane. Dedupes the repos across the selection and drops tasks with no
+  // repo; a no-op (nothing to move) is ignored.
   function requestLaneMove(task: Task, railwayId: string) {
-    if (!task.repo_id || railwayId === task.railway_id) {
+    const repoIds = [
+      ...new Set(
+        actionTasks(task)
+          .map((target) => target.repo_id)
+          .filter((repoId): repoId is string => !!repoId)
+      )
+    ]
+    if (repoIds.length === 0) {
       return
     }
-    pendingLaneMove = { task, railwayId }
+    pendingLaneMove = { railwayId, repoIds }
   }
 
-  // Reassign the repo (and all its tasks) to the chosen lane. The backend blocks it
-  // while a live turn is working the repo on its current lane and returns the
-  // reason, which we surface as a toast.
+  // Reassign each repo (and all its tasks) to the chosen lane, then report a single
+  // summary toast. The backend blocks a repo while a live turn is working it on its
+  // current lane and returns the reason, which we fold into the summary.
   async function confirmLaneMove() {
     const move = pendingLaneMove
-    if (!move?.task.repo_id) {
+    if (!move) {
       return
     }
-    const repoLabel = repoNames[move.task.repo_id] ?? 'repo'
+    const laneName = railwayName(move.railwayId)
     laneMoveBusy = true
+    const moved: string[] = []
+    const blocked: string[] = []
+    for (const repoId of move.repoIds) {
+      const label = repoNames[repoId] ?? 'a repo'
+      try {
+        await assignRepoToRailway(move.railwayId, repoId)
+        moved.push(label)
+      } catch (error) {
+        blocked.push(`${label} (${await extractApiError(error, 'blocked')})`)
+      }
+    }
+    await load()
+    if (moved.length > 0) {
+      rememberLane(move.railwayId)
+    }
+    const movedLabel = moved.length === 1 ? moved[0] : `${moved.length} repos`
+    if (blocked.length === 0) {
+      toast.success(`Moved ${movedLabel} to ${laneName}`)
+    } else if (moved.length === 0) {
+      toast.error(`Could not move to ${laneName}: ${blocked.join('; ')}`)
+    } else {
+      toast.error(`Moved ${movedLabel} to ${laneName}; ${blocked.length} blocked: ${blocked.join('; ')}`)
+    }
+    laneMoveBusy = false
+    pendingLaneMove = null
+  }
+
+  // The most recently used lane move targets, newest first, persisted so repeat
+  // moves are one click (issue #236). Hydrated from localStorage on mount.
+  const RECENT_LANES_KEY = 'seraphim:recent-lane-moves'
+  const RECENT_LANES_MAX = 3
+  let recentLaneIds = $state<string[]>([])
+
+  function loadRecentLanes() {
     try {
-      await assignRepoToRailway(move.railwayId, move.task.repo_id)
-      await load()
-      toast.success(`Moved ${repoLabel} to ${railwayName(move.railwayId)}`)
+      const raw = localStorage.getItem(RECENT_LANES_KEY)
+      const parsed: unknown = raw ? JSON.parse(raw) : []
+      if (Array.isArray(parsed)) {
+        recentLaneIds = parsed.filter((id): id is string => typeof id === 'string')
+      }
     } catch (error) {
-      const message = await extractApiError(error, 'Failed to move the repo to that railway.')
-      toast.error(message)
-    } finally {
-      laneMoveBusy = false
-      pendingLaneMove = null
+      console.debug('failed to load recent lanes', error)
+    }
+  }
+
+  function rememberLane(railwayId: string) {
+    recentLaneIds = [railwayId, ...recentLaneIds.filter((id) => id !== railwayId)].slice(
+      0,
+      RECENT_LANES_MAX
+    )
+    try {
+      localStorage.setItem(RECENT_LANES_KEY, JSON.stringify(recentLaneIds))
+    } catch (error) {
+      console.debug('failed to save recent lanes', error)
     }
   }
 
   // --- Card lifecycle actions (issue #235) -----------------------------------
-  // Toggle a card's hold flag from its context menu. A reversible flag, so no
-  // confirmation (unlike the destructive actions below); just toast the result.
+  // Toggle the hold flag from the context menu, for one card or the whole selection
+  // (issue #236). The new value follows the right-clicked card's current state, and
+  // is applied to every target. A reversible flag, so no confirmation.
   async function toggleHold(task: Task) {
+    const targets = actionTasks(task)
+    const hold = !task.hold
     try {
-      await setTaskHold(task.id, !task.hold)
-      await load()
-      toast.success(task.hold ? 'Hold released' : 'Task held — the agent will skip it')
+      if (targets.length > 1) {
+        await bulkSetTaskFields(
+          targets.map((target) => target.id),
+          { hold }
+        )
+        await load()
+        toast.success(hold ? `Held ${targets.length} cards` : `Released ${targets.length} cards`)
+      } else {
+        await setTaskHold(task.id, hold)
+        await load()
+        toast.success(hold ? 'Task held — the agent will skip it' : 'Hold released')
+      }
     } catch (error) {
       const message = await extractApiError(error, 'Failed to update the hold.')
       toast.error(message)
@@ -713,6 +816,7 @@
     for (const column of COLUMNS) {
       sortState[column.key] = loadSort(column.key)
     }
+    loadRecentLanes()
     load()
     // The notepad loads once, separately from the board: the board stream below
     // reloads on every change, which must never clobber an in-progress edit.
@@ -994,8 +1098,10 @@
                 suggestionCount={suggestionCounts[task.id] ?? 0}
                 selectionMode={bulkMode}
                 selected={selected.has(task.id)}
+                selectedCount={selected.size}
                 onselect={() => toggleSelected(task.id)}
                 {railways}
+                {recentLaneIds}
                 onMoveToColumn={(column, placement) => moveCardToColumn(task, column, placement)}
                 onMoveToRailway={(targetRailwayId) => requestLaneMove(task, targetRailwayId)}
                 onToggleHold={() => toggleHold(task)}
@@ -1113,20 +1219,26 @@
   >
     <AlertDialog.Content>
       <AlertDialog.Header>
-        <AlertDialog.Title>Move repo to the {pendingLaneDetails?.laneName} lane?</AlertDialog.Title>
+        <AlertDialog.Title>
+          Move {pendingLaneDetails?.repoCount === 1 ? 'repo' : 'repos'} to the
+          {pendingLaneDetails?.laneName} lane?
+        </AlertDialog.Title>
         <AlertDialog.Description>
           A lane follows its repo, so this moves <span class="font-semibold"
             >{pendingLaneDetails?.repoLabel}</span
           >
-          and all {pendingLaneDetails?.count}
-          {pendingLaneDetails?.count === 1 ? 'task' : 'tasks'} of it to the
-          {pendingLaneDetails?.laneName} lane, not just this card.
+          and all {pendingLaneDetails?.taskCount}
+          {pendingLaneDetails?.taskCount === 1 ? 'task' : 'tasks'} of
+          {pendingLaneDetails?.repoCount === 1 ? 'it' : 'them'} to the
+          {pendingLaneDetails?.laneName} lane, not just the card{pendingLaneDetails?.repoCount === 1
+            ? ''
+            : 's'} you clicked.
         </AlertDialog.Description>
       </AlertDialog.Header>
       <AlertDialog.Footer>
         <AlertDialog.Cancel disabled={laneMoveBusy}>Cancel</AlertDialog.Cancel>
         <Button onclick={confirmLaneMove} disabled={laneMoveBusy}>
-          {laneMoveBusy ? 'Moving…' : 'Move repo'}
+          {laneMoveBusy ? 'Moving…' : pendingLaneDetails?.repoCount === 1 ? 'Move repo' : 'Move repos'}
         </Button>
       </AlertDialog.Footer>
     </AlertDialog.Content>


### PR DESCRIPTION
Part of #231. Closes #236. The final polish pass, built on the merged #232–#235.

## Multi-select awareness

- When the right-clicked card is part of the current multi-selection, the menu **acts on the whole selection** and its header reads "N cards selected". Right-clicking a card outside the selection acts on just that card. The board routes each action through a new `actionTasks()` helper that returns the whole selection when the clicked card is in it, else just that card, so single-card behavior is unchanged.
- **Bulk-capable** actions (Move to column, Move to lane, Work this now, Hold/Unhold, Send to Ignored) apply to every selected card. **Per-card-only** actions (Open task, Open on GitHub/Jira, Open pull request, the Copy items) and the destructive Reset/Delete are hidden in multi mode.
- Bulk column moves use `bulkSetTaskStatus`; bulk holds use `bulkSetTaskFields`; each reports a single summary toast.
- **Bulk lane moves dedupe the repos across the selection**, reassign each via `assignRepoToRailway`, and report **one summary toast** that folds in any repos whose reassignment was **blocked** (with the backend's reason, e.g. a live turn on that lane). The confirmation dialog spells out the repo count and total task count.

## Bells and whistles

- **Recent lanes** shortlist at the top of Move-to > Lane, persisted in `localStorage` (newest first, capped at 3) for fast repeat moves.
- **Filterable lane submenu**: a filter box appears when there are many lanes (> 7); its keystrokes are kept out of the menu's type-ahead so typing narrows the list.
- **Shortcut hints**: `W` (Work this now) and `H` (Hold) shown in the menu and wired as shortcuts on a focused card (skipped when a modifier is held; they route to the selection in multi mode).
- Icons on every item, section separators, and `prefers-reduced-motion` were already in place from the earlier sub-tickets (kept).

## Acceptance criteria

- Right-clicking within a multi-selection acts on all; outside acts on the single card. ✅
- Bulk actions apply to all selected cards and report a single result toast, including blocked reassignments. ✅
- Lane submenu is filterable when long; recent lanes appear and persist. ✅
- Icons, shortcut hints, separators, reduced-motion all in place. ✅
- `yarn check` / `yarn build` pass. ✅

## Notes for review

- **Columns**: only six fixed columns, so no column filter was added (the issue said "and the same for columns if useful" — it isn't for a short fixed list).
- I can't browser-test here (CI only type-checks + builds), so please sanity-check the in-menu keyboard interactions, specifically the **lane filter box** (only shown with > 7 lanes) and the type-ahead coexistence, in a real browser.

## Testing

`yarn check` (0 errors), `yarn test` (13 passed), `yarn build` all pass. Frontend-only, single repo.