### PR TITLE
Bake the visual self-review loop into the agent's default instructions (#244)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,18 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   after `/`), so cross-repo work is natural. The task names a focus repo + branch.
 - **Instructions become files:** global → `/workspace/AGENTS.md`; per-repo →
   `/workspace/{repo}/CLAUDE.md` (Claude auto-loads them).
+- **Visual self-review (issue #244):** every task prompt carries a standing
+  instruction (`prompt::VISUAL_SELF_REVIEW`, in the shared header so it applies on
+  fresh work and fix/revisit turns alike) to look at any UI change in a real
+  browser before declaring it done, via the Playwright MCP baked into the workspace
+  (issue #243): start the dev server (test data only), open the affected route(s),
+  check layout with computed styles (cheaper than screenshots; screenshot only to
+  confirm), at mobile (375px) and desktop (1280px). The per-repo dev-server
+  facts live in that repo's `CLAUDE.md` (i.e. `repositories.instructions`): record
+  the dev command, base URL/port, and key routes there, e.g. "dev server:
+  `npm run dev` on :5173; check /, /login, /dashboard". The loop degrades
+  gracefully: a repo with no runnable UI is skipped with a noted reason, never
+  failed.
 - **Two-tier setup:** environment setup (`settings.base_setup_script`) runs once
   per provision/recreate (install CLIs/toolchains); per-repo setup
   (`repositories.setup_script`) runs after each clone (e.g. `yarn install`).
@@ -435,6 +447,13 @@ cd frontend && npm run check && npm run build
 
 CI (`.github/workflows/ci.yml`) runs these three jobs independently (no
 fail-fast) on every PR and on `main`/`develop`.
+
+**Frontend dev server (for the agent's visual self-review, issue #244):**
+`cd frontend && npm run dev` serves the UI on `:5173` (`vite dev`, which proxies
+`/api` to the backend). Key routes to eyeball after a UI change: `/` (the kanban
+board), `/settings`, `/railways`, and `/task/<id>`. After any change to this
+frontend, follow the visual self-review loop (open the affected route(s) with the
+Playwright MCP, check layout via computed styles at 375px and 1280px).
 
 ## Conventions & gotchas
 

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -474,6 +474,10 @@ fn context_header(
     // Shared by every mode: noticing missing tooling can happen on any run, so
     // the recommend-improvements guidance lives in the common header.
     prompt.push_str(ENVIRONMENT_SUGGESTIONS);
+    // Likewise the visual self-review loop: any turn that touches the UI must look
+    // at it before declaring done, so the standing instruction lives in the header
+    // too (fresh work, CI fixes, revisits all alike).
+    prompt.push_str(VISUAL_SELF_REVIEW);
     prompt
 }
 
@@ -553,6 +557,38 @@ const ENVIRONMENT_SUGGESTIONS: &str = "\n\
     \x20 JSON\n\n\
     Only suggest things that genuinely help; if nothing comes to mind, skip it. \
     This does not replace opening the pull request.\n";
+
+/// Standing instruction (issue #244) to visually self-review any UI change.
+///
+/// Capability without a standing instruction does nothing, so this bakes the
+/// loop into every task prompt (via the shared header) rather than relying on the
+/// operator's global instructions. It uses the Playwright MCP baked into the
+/// workspace (issue #243), prefers cheap computed-style checks over screenshots to
+/// keep token cost down, reads the per-repo dev-server facts from the repo's
+/// `CLAUDE.md`, and degrades gracefully: a repo with no runnable UI is skipped
+/// cleanly rather than failing the task.
+const VISUAL_SELF_REVIEW: &str = "\n\
+    # Visual self-review (UI changes)\n\
+    If your change affects the UI, you are NOT done until you have looked at it in a \
+    real browser, not just reasoned about the code:\n\
+    - Find how to run the repo's UI in its `CLAUDE.md`: the dev-server command, the \
+    base URL/port, and the key routes (e.g. \"dev server: `npm run dev` on :5173; \
+    check /, /login, /dashboard\"). If that is not recorded there, infer it (e.g. \
+    the `dev` script in `package.json`) and add a short note to the repo's \
+    `CLAUDE.md` so the next run has it.\n\
+    - Start the dev server with test/dev data only (never production data) and open \
+    the affected route(s) with the Playwright MCP browser tools (navigate, snapshot, \
+    evaluate, screenshot), headless.\n\
+    - Check layout (centering, spacing, alignment) using computed styles via \
+    `evaluate` and the accessibility snapshot. Prefer these computed-style checks \
+    over screenshots to keep cost down; take a screenshot only to confirm the final \
+    result.\n\
+    - Confirm it renders correctly at both mobile (375px) and desktop (1280px) \
+    widths.\n\
+    - If the repo has no runnable UI (a backend-only or non-web repo, no dev server, \
+    or the browser tools are unavailable), SKIP this review: do not fail the task or \
+    hold the PR for it, just note in your summary that you skipped visual review and \
+    why.\n";
 
 /// Guidance, appended to every fresh task prompt, on escalating to the user.
 const ASKING_FOR_HELP: &str = "\n\
@@ -810,6 +846,29 @@ mod tests {
         );
         assert!(prompt.contains("Work issue #57"));
         assert!(prompt.contains("referencing issue #57"));
+    }
+
+    #[test]
+    fn fresh_prompt_bakes_in_the_visual_self_review_loop() {
+        // The visual self-review (issue #244) is a standing instruction, so a plain
+        // fresh task carries it without the user asking, including the cost-saving
+        // computed-style preference, the responsive widths, and the clean skip.
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[],
+            &[],
+        );
+        assert!(prompt.contains("Visual self-review"));
+        assert!(prompt.contains("Playwright MCP"));
+        assert!(prompt.contains("computed styles"));
+        assert!(prompt.contains("375px") && prompt.contains("1280px"));
+        // It reads per-repo dev facts from the repo's CLAUDE.md and skips cleanly.
+        assert!(prompt.contains("CLAUDE.md"));
+        assert!(prompt.contains("SKIP this review"));
     }
 
     #[test]


### PR DESCRIPTION
Part of #242 (give the agent eyes). Closes #244.

A browser capability does nothing unless the agent invokes it unprompted, so this bakes the visual self-review loop into the agent's prompt rather than relying on the operator's (editable, often-empty) global instructions.

## What changed

- **`prompt::VISUAL_SELF_REVIEW`** standing instruction, appended in the shared `context_header` so it rides on **every** turn type (fresh work and CI-fix / conflict / revisit / address-review turns alike), not just fresh tasks. It says: after any change that affects the UI, you are not done until you have launched the dev server, opened the affected route(s) in a real browser via the Playwright MCP (#243), verified centering/spacing/alignment via **computed styles**, screenshotted to confirm, and checked **mobile (375px)** and **desktop (1280px)** widths.
- **Cost + safety** (per the epic): prefer cheap computed-style checks over screenshots (screenshot only to confirm), and use a dev server with **test data only**.
- **Per-repo "how to run the UI" has a home:** the loop reads the dev command, base URL/port, and key routes from the repo's `CLAUDE.md`, and is told to record them there if missing (e.g. "dev server: `npm run dev` on :5173; check /, /login, /dashboard"). Documented the convention in `CLAUDE.md`, with Seraphim's own frontend (`npm run dev` on :5173; routes `/`, `/settings`, `/railways`, `/task/<id>`) recorded as a concrete example so this very repo is review-ready.
- **Graceful degradation:** a repo with no runnable UI (backend-only/non-web, no dev server, or the browser tools not yet available) is **skipped with a noted reason**, never failed.

## Acceptance criteria

- Default instructions include the loop; a frontend task triggers it without the user asking. ✅ (a prompt test asserts a plain fresh task carries the loop)
- A documented, per-repo place for the dev command/port/routes, and the loop uses it. ✅
- No runnable UI → skip cleanly and say so. ✅
- Checks pass. ✅ (`cargo +1.88 fmt --check` / `clippy --all-targets` / `test` = 144 passed)

## Notes for review

- **Depends on #243 (Playwright MCP).** That PR is still in flight; until it lands, the MCP browser tools aren't present, but the instruction degrades gracefully (it says to skip if the browser tools are unavailable), so this is safe to merge in either order and "switches on" once #243 ships.
- Backend/config change only (`prompt.rs` + `CLAUDE.md`); the frontend is untouched, so `npm run check`/`build` are unaffected.
- Per the epic notes, end-to-end validation with a real frontend task in a repo that has a dev server should be done once #243 is merged and the workspace is rebuilt.