### PR TITLE
Gate merge on resolved review threads, not approval (#270)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,8 +339,9 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    have all merged. The pure, unit-tested `orchestrator::review::decide` takes the
    tick's action from the set of PRs (`refresh_task_prs` updates each PR's CI +
    lifecycle first): any open PR failing → hand back to the agent; any pending →
-   wait; once every open PR is green, before merging or holding, address any
-   unresolved review comments (see below); then merge the green `auto_squash_merge`
+   wait; once every open PR is green, it must clear the review gate before merging
+   or holding (zero unresolved threads and no "changes requested" review, see
+   below); then merge the green `auto_squash_merge`
    PRs now; once all are settled and at
    least one merged → **Done** (and, for a GitHub-sourced task, close the linked
    issue with `state_reason: "completed"` when `close_issue_on_done` is set, the
@@ -353,25 +354,33 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    pushes nothing (genuinely unresolvable) or the budget is exhausted, it falls
    back to `ci_blocked` for a human. The single-PR case is just a one-row set, so
    its behavior is unchanged.
-   - **Review-comment addressing (issue #255):** a green, (auto-)approved PR can
-     still carry unresolved review threads from the org CI reviewer bots
-     (`mooreslabai-claude`, `mooreslabai-codex`) or humans, which auto-merge would
-     otherwise paper over. Before merging (auto policy) or holding (human-review
-     policy), `review::decide` checks each green open PR for unresolved review
-     threads (octocrab GraphQL `reviewThreads { isResolved }`, via
-     `git::list_unresolved_review_threads`; only inline review threads count, so
-     purely informational or approving comments never block). If any are
-     actionable and the task has attempts left, it flags `addressing_review`
-     (`queries::flag_review_addressing`) and emits a synthetic `ci`-style feed
-     note; the agent loop then picks it up (`pick_next_review_address`) and runs an
-     addressing turn (`build_address_review`) listing each comment tagged with
-     `repo#pr` + `file:line` + author + body, plus the handles to reply and
-     resolve. The turn is best-effort and never blocks on "nothing pushed" (a
-     comment may only warrant a reply or be declined): it always returns to review.
-     Bounded by `MAX_REVIEW_FIX_ATTEMPTS` (3) on a dedicated `review_fix_attempts`
-     counter (separate from `ci_fix_attempts`); once the threads are resolved the
-     loop merges, and once the budget is spent the threads no longer block the
-     merge, so the queue never stalls on a genuinely unresolvable thread.
+   - **Review-comment gate (issues #255, #270):** a green PR is NEVER squash-merged
+     while it carries review work, no matter its approval state. The merge gate is
+     exactly **CI green AND zero unresolved review threads AND no outstanding
+     "changes requested" review** (approval alone never merges). For each green open
+     PR, `git::pr_review_status` reads both signals in one GraphQL round trip
+     (`reviewThreads { isResolved }` for unresolved threads from the org CI reviewer
+     bots `mooreslabai-claude` / `mooreslabai-codex` or humans, plus `reviewDecision`
+     for a standing `CHANGES_REQUESTED`). That collapses to a per-PR `ReviewState`
+     (`Clean` / `Outstanding` / `Unknown`) which `review::decide` gates on before any
+     merge or hold:
+     - **Outstanding** (threads and/or changes-requested) with attempts left → flag
+       `addressing_review` (`queries::flag_review_addressing`), emit a `ci`-style
+       feed note; the agent loop picks it up (`pick_next_review_address`) and runs an
+       addressing turn (`build_address_review`) listing each comment tagged with
+       `repo#pr` + `file:line` + author + body, plus the handles to reply and
+       resolve. The agent implements what it agrees with and, for every thread
+       (including ones it declines, with a brief reason), replies and resolves it via
+       the GraphQL `resolveReviewThread` mutation. The turn is best-effort and never
+       blocks on "nothing pushed": it returns to review, where the loop waits for CI
+       to re-run and re-checks the threads, repeating until clean.
+     - **Outstanding with the budget spent** (`MAX_REVIEW_FIX_ATTEMPTS`, 3, on the
+       dedicated `review_fix_attempts` counter) → **park for a human** (`ReviewDecision::Block`
+       → `handle_review_blocked`, which reuses the `ci_blocked` park with a
+       review-specific note). It is **never merged over** open comments; an idle
+       revisit later resets `review_fix_attempts` and tries again.
+     - **Unknown** (the review lookup failed) → wait and re-check next tick, never
+       merge on a guess.
 4. **defibrillator** (dead-agent management) — recovers turns that die mid-flight,
    which we call a **"heart attack"**: the agent hangs with no output, its stream
    breaks, or the turn aborts internally, leaving the card stranded `in_progress`

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -2050,6 +2050,16 @@ pub async fn reset_ci_fix_attempts(pool: &PgPool, id: Uuid) -> sqlx::Result<()> 
     Ok(())
 }
 
+/// Resets a task's review-address counter, so an idle revisit of a review-blocked
+/// PR gets the full addressing budget again rather than re-parking immediately.
+pub async fn reset_review_fix_attempts(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
+    sqlx::query("UPDATE tasks SET review_fix_attempts = 0, updated_at = now() WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 /// The oldest blocked PR worth revisiting while the agent is otherwise idle: in
 /// review, `ci_blocked`, not on hold, and untouched for at least `cooldown_secs`
 /// (so a genuinely stuck PR is retried periodically, not in a tight loop).

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -262,30 +262,48 @@ pub struct ReviewThread {
     pub body: String,
 }
 
-/// Lists a pull request's unresolved review threads (inline review comments not
-/// marked resolved), from reviewer bots and humans alike, via the GraphQL API.
+/// A pull request's review gate inputs: its unresolved review threads and whether
+/// a reviewer's standing review currently requests changes.
 ///
-/// REST has no notion of thread resolution, so this uses GraphQL `reviewThreads`.
-/// Only each thread's first (originating) comment is returned, the actionable
-/// item; replies are omitted to keep the brief focused. Resolved threads and
-/// threads with no comment are skipped. Capped at the first 100 threads, which
-/// comfortably covers any real PR.
+/// Both are read together because the merge gate needs them together: a PR may be
+/// squash-merged only with zero unresolved threads AND no outstanding "changes
+/// requested" review. An approval alone is never sufficient.
+#[derive(Debug)]
+pub struct PrReviewStatus {
+    /// Unresolved review threads (inline comments not marked resolved), reduced to
+    /// each thread's originating comment, from reviewer bots and humans alike.
+    pub unresolved_threads: Vec<ReviewThread>,
+    /// Whether GitHub's computed review decision is `CHANGES_REQUESTED`, i.e. a
+    /// reviewer asked for changes and has neither dismissed nor re-approved it.
+    pub changes_requested: bool,
+}
+
+/// Reads a pull request's review gate inputs (its unresolved review threads and
+/// whether a standing review requests changes), from bots and humans alike, in a
+/// single GraphQL round trip.
+///
+/// REST has no notion of thread resolution, so this uses GraphQL `reviewThreads`
+/// plus `reviewDecision`. Only each thread's first (originating) comment is
+/// returned, the actionable item; replies are omitted to keep the brief focused.
+/// Resolved threads and threads with no comment are skipped. Capped at the first
+/// 100 threads, which comfortably covers any real PR.
 ///
 /// # Errors
 /// If the GraphQL request fails or the response can't be parsed.
-pub async fn list_unresolved_review_threads(
+pub async fn pr_review_status(
     octo: &Octocrab,
     owner: &str,
     repo: &str,
     number: u64,
-) -> Result<Vec<ReviewThread>> {
+) -> Result<PrReviewStatus> {
     // First 100 threads, first comment of each: the originating comment carries
     // the file/line/author/body the agent needs to act, plus the handles to reply
-    // and resolve.
+    // and resolve. `reviewDecision` is GitHub's own roll-up of reviewer states.
     const QUERY: &str = "\
         query($owner:String!,$repo:String!,$number:Int!){\
           repository(owner:$owner,name:$repo){\
             pullRequest(number:$number){\
+              reviewDecision\
               reviewThreads(first:100){\
                 nodes{\
                   id isResolved\
@@ -304,16 +322,26 @@ pub async fn list_unresolved_review_threads(
             "variables": { "owner": owner, "repo": repo, "number": number },
         }))
         .await
-        .wrap_err("failed to query pull request review threads")?;
+        .wrap_err("failed to query pull request review status")?;
 
-    let nodes = response
+    let pull = response
         .data
         .and_then(|data| data.repository)
-        .and_then(|repository| repository.pull_request)
+        .and_then(|repository| repository.pull_request);
+
+    // Gate only on an outstanding "changes requested". "Approved" and the
+    // "review required" approval gate are deliberately not merge blockers here:
+    // resolution state, not approval, is what the gate enforces.
+    let changes_requested = pull
+        .as_ref()
+        .and_then(|pull| pull.review_decision.as_deref())
+        == Some("CHANGES_REQUESTED");
+
+    let nodes = pull
         .map(|pull| pull.review_threads.nodes)
         .unwrap_or_default();
 
-    let mut threads = Vec::new();
+    let mut unresolved_threads = Vec::new();
     for node in nodes {
         if node.is_resolved {
             continue;
@@ -321,7 +349,7 @@ pub async fn list_unresolved_review_threads(
         let Some(comment) = node.comments.nodes.into_iter().next() else {
             continue; // A thread with no comment has nothing to address.
         };
-        threads.push(ReviewThread {
+        unresolved_threads.push(ReviewThread {
             repo_full_name: format!("{owner}/{repo}"),
             pr_number: i64::try_from(number).unwrap_or_default(),
             thread_id: node.id,
@@ -336,7 +364,10 @@ pub async fn list_unresolved_review_threads(
             body: comment.body,
         });
     }
-    Ok(threads)
+    Ok(PrReviewStatus {
+        unresolved_threads,
+        changes_requested,
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -357,6 +388,8 @@ struct ReviewRepositoryNode {
 
 #[derive(Debug, Deserialize)]
 struct ReviewPullRequestNode {
+    #[serde(rename = "reviewDecision")]
+    review_decision: Option<String>,
     #[serde(rename = "reviewThreads")]
     review_threads: ReviewThreadConnection,
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -56,7 +56,7 @@ use crate::git;
 use crate::secrets::Scrubber;
 use crate::state::AppState;
 use railway::RailwayHandle;
-use review::{PrCi, PrReview, ReviewDecision};
+use review::{PrCi, PrReview, ReviewDecision, ReviewState};
 
 /// Pid file the main agent's `claude` records to, so a reset/defibrillation kills
 /// exactly it and never the compose assistant, which shares the workspace (#181).
@@ -1673,10 +1673,12 @@ async fn work_pr_fix(
 
     let settings = queries::get_settings(&state.db).await?;
 
-    // A revisit is a fresh effort: clear the exhausted counter so the renewed
-    // fix cycle gets the full retry budget again.
+    // A revisit is a fresh effort: clear the exhausted counters so the renewed
+    // fix cycle gets the full retry budget again, for CI fixes and for review
+    // addressing alike (a review-blocked PR parks as `ci_blocked` too).
     if mode == WorkMode::Revisit {
         queries::reset_ci_fix_attempts(&state.db, task.id).await?;
+        queries::reset_review_fix_attempts(&state.db, task.id).await?;
     }
 
     // While the turn runs the card sits in In Progress, like any actively-worked
@@ -2284,19 +2286,20 @@ async fn review_task(
     for pr in &prs {
         let auto_merge =
             pr_repo_policy(state, settings, pr).await? == ReviewPolicy::AutoSquashMerge;
-        // Only a green, open PR is a candidate for addressing review comments. For
-        // any other state CI handling or the merge takes priority anyway, so skip
-        // the extra GraphQL lookup.
-        let unresolved_review = if pr.pr_state == "open" && pr.ci_state == "passing" {
-            pr_has_unresolved_review_threads(github, pr).await
+        // Only a green, open PR is a candidate for the review gate. For any other
+        // state CI handling or the merge takes priority anyway, so skip the extra
+        // GraphQL lookup and treat the review as clean (it is never consulted).
+        let review = if pr.pr_state == "open" && pr.ci_state == "passing" {
+            pr_review_state(github, pr).await
         } else {
-            false
+            ReviewState::Clean
         };
-        views.push(pr_review_of(pr, auto_merge, unresolved_review));
+        views.push(pr_review_of(pr, auto_merge, review));
     }
 
-    // Once the attempt budget is spent, unresolved threads no longer block the
-    // merge, so a thread the agent can't resolve can't stall the task forever.
+    // Once the addressing budget is spent, an unresolved PR is parked for a human
+    // (never merged over), so a thread the agent can't resolve can't stall the
+    // queue yet can't slip through unaddressed either.
     let review_attempts_remaining = task.review_fix_attempts < MAX_REVIEW_FIX_ATTEMPTS;
     match review::decide(&views, review_attempts_remaining) {
         // Still settling (CI pending, or no actionable PR this tick): re-check next.
@@ -2312,9 +2315,12 @@ async fn review_task(
         }
         // A failing PR: hand back to the agent (or block once the cap is hit).
         ReviewDecision::Fix => handle_ci_failing(state, github, task, &prs).await?,
-        // A green PR with unresolved review threads: hand back to the agent to
-        // address the comments before the merge.
+        // A green PR with unresolved review threads (or a changes-requested
+        // review): hand back to the agent to address them before the merge.
         ReviewDecision::AddressReview => handle_review_addressing(state, task).await?,
+        // Review work is still outstanding after the addressing budget is spent:
+        // park the task for a human rather than merge over unresolved comments.
+        ReviewDecision::Block => handle_review_blocked(state, github, task).await?,
         // Merge the green, auto-merge PRs now; the next tick finishes once all are.
         ReviewDecision::Merge(indices) => {
             merge_task_prs(state, github, task, &prs, &indices).await?;
@@ -2670,10 +2676,9 @@ async fn pr_repo_policy(
     Ok(policy.unwrap_or(settings.default_review_policy))
 }
 
-/// Maps a stored PR row to the pure review view. `unresolved_review` is whether
-/// the open PR still carries unresolved review threads to address (only computed,
-/// and only meaningful, for a green open PR).
-fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool, unresolved_review: bool) -> PrReview {
+/// Maps a stored PR row to the pure review view. `review` is the PR's review-gate
+/// state (only computed, and only meaningful, for a green open PR).
+fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool, review: ReviewState) -> PrReview {
     match pr.pr_state.as_str() {
         "merged" => PrReview::Merged,
         "closed" => PrReview::Closed,
@@ -2684,27 +2689,36 @@ fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool, unresolved_review: bool)
                 _ => PrCi::Pending,
             },
             auto_merge,
-            unresolved_review,
+            review,
         },
     }
 }
 
-/// Whether a tracked PR has any unresolved review threads (reviewer-bot or human).
-/// Best-effort: a malformed repo name or a GraphQL failure is logged and treated
-/// as "none", so a transient lookup error never blocks an otherwise-ready merge.
-async fn pr_has_unresolved_review_threads(
-    github: &octocrab::Octocrab,
-    pr: &TaskPullRequest,
-) -> bool {
+/// A tracked PR's review-gate state: `Outstanding` if it has unresolved review
+/// threads or a "changes requested" review (bot or human), else `Clean`.
+///
+/// A malformed repo name or a GraphQL failure yields `Unknown`, NOT `Clean`: the
+/// gate must never merge over comments it simply failed to read, so an unreadable
+/// state re-checks next tick rather than waving the PR through.
+async fn pr_review_state(github: &octocrab::Octocrab, pr: &TaskPullRequest) -> ReviewState {
     let Some((owner, name)) = pr.repo_full_name.split_once('/') else {
-        return false;
+        // A name we can't parse can't be re-read into a different answer, so this
+        // is a permanent miss, not a transient one; treat it as nothing to address.
+        warn!(pr = %pr.pr_url, "malformed repo name for review lookup; treating as clean");
+        return ReviewState::Clean;
     };
     let number = u64::try_from(pr.pr_number).unwrap_or_default();
-    match git::list_unresolved_review_threads(github, owner, name, number).await {
-        Ok(threads) => !threads.is_empty(),
+    match git::pr_review_status(github, owner, name, number).await {
+        Ok(status) => {
+            if status.unresolved_threads.is_empty() && !status.changes_requested {
+                ReviewState::Clean
+            } else {
+                ReviewState::Outstanding
+            }
+        }
         Err(error) => {
-            warn!(error = %error, pr = %pr.pr_url, "could not list review threads; treating as none");
-            false
+            warn!(error = %error, pr = %pr.pr_url, "could not read review status; will re-check before merging");
+            ReviewState::Unknown
         }
     }
 }
@@ -2733,8 +2747,8 @@ async fn collect_unresolved_review_threads(
             continue;
         };
         let number = u64::try_from(pr.pr_number).unwrap_or_default();
-        match git::list_unresolved_review_threads(github, owner, name, number).await {
-            Ok(mut found) => threads.append(&mut found),
+        match git::pr_review_status(github, owner, name, number).await {
+            Ok(mut status) => threads.append(&mut status.unresolved_threads),
             Err(error) => {
                 warn!(error = %error, pr = %pr.pr_url, "could not list review threads for the prompt");
             }
@@ -2760,6 +2774,48 @@ async fn handle_review_addressing(state: &AppState, task: &Task) -> Result<()> {
         state.notify_board();
         info!(task_id = %task.id, "green PR has unresolved review comments; handing back to the agent");
     }
+    Ok(())
+}
+
+/// Parks a task for a human when its PR still has unresolved review threads (or a
+/// changes-requested review) after the addressing budget is spent. The PR is NEVER
+/// merged over open comments; a human resolves the stuck thread (or merges
+/// deliberately). Mirrors the `ci_blocked` park, so the idle revisit loop circles
+/// back to it later, just with a review-specific note instead of a CI one.
+async fn handle_review_blocked(
+    state: &AppState,
+    github: &octocrab::Octocrab,
+    task: &Task,
+) -> Result<()> {
+    // Only act on the transition; a steady-state re-detect each tick stays quiet.
+    if task.status == TaskStatus::CiBlocked {
+        return Ok(());
+    }
+
+    // Name the still-open repos so the note points a human at the right PR(s).
+    let threads = collect_unresolved_review_threads(state, github, task).await;
+    let repos: Vec<&str> = {
+        let mut seen: Vec<&str> = Vec::new();
+        for thread in &threads {
+            if !seen.contains(&thread.repo_full_name.as_str()) {
+                seen.push(&thread.repo_full_name);
+            }
+        }
+        seen
+    };
+    let where_ = if repos.is_empty() {
+        String::new()
+    } else {
+        format!(" on: {}", repos.join(", "))
+    };
+    let note = format!(
+        "Review comments still unresolved after {MAX_REVIEW_FIX_ATTEMPTS} addressing attempts{where_}. \
+         Not merging over open review threads; needs a human to resolve them or merge deliberately.",
+    );
+    queries::block_task_ci(&state.db, task.id, &note).await?;
+    emit_ci_note(state, task.id, &note, "review-blocked").await?;
+    state.notify_board();
+    warn!(task_id = %task.id, "review comments unresolved after the budget; parked for a human");
     Ok(())
 }
 

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -318,9 +318,10 @@ pub fn build_address_review(
 
     prompt.push_str(&format!(
         "# Addressing pull request review comments\n\
-         - Your pull request for this issue passed CI and was (auto-)approved, but reviewers \
-         (the org CI reviewer bots and/or humans) left review comments that have not been \
-         addressed. Make a best-effort pass to address them before the merge.\n\
+         - Your pull request for this issue passed CI, but reviewers (the org CI reviewer bots \
+         and/or humans) left review comments, or requested changes, that have not been addressed. \
+         The merge is gated on this: it will NOT merge while any review thread is unresolved or a \
+         reviewer's \"changes requested\" stands, no matter the approval state. Address them now.\n\
          - Your cwd is `/workspace`. The focus repo `{repo}` is at `{repo_path}`, already checked \
          out on branch `{branch}` with your earlier commits. If this issue spans several repos, \
          each one with a PR is also checked out on `{branch}` as a sibling directory; each comment \
@@ -338,8 +339,9 @@ pub fn build_address_review(
          automatically. It is fine if a comment needs no code change (a reply and resolve is \
          enough).\n\
          - Do not get stuck: if a thread needs a decision you can't make or is genuinely \
-         unresolvable, leave a brief reply explaining why and move on. The merge proceeds once the \
-         threads are handled or the attempt budget is spent.\n\
+         unresolvable, leave a brief reply explaining why and resolve it anyway, then move on. The \
+         merge proceeds once every thread is resolved; if some are still unresolved after several \
+         attempts the PR is parked for a human rather than merged over open comments.\n\
          - After pushing (or replying where no code change was needed), stop and finish with a short \
          summary. Do not watch or wait for CI; Seraphim re-checks the PR and merges it (or brings \
          you back) automatically.\n\n",

--- a/api/src/orchestrator/review.rs
+++ b/api/src/orchestrator/review.rs
@@ -13,16 +13,30 @@ pub enum PrCi {
     Failing,
 }
 
+/// A green PR's review-gate state: whether it still needs the agent's attention
+/// before it may merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewState {
+    /// No unresolved review threads and no outstanding "changes requested" review.
+    Clean,
+    /// Unresolved review threads and/or a "changes requested" review (from reviewer
+    /// bots or humans) the agent must address and resolve before the merge.
+    Outstanding,
+    /// The review state could not be determined this tick (a lookup error). The
+    /// gate never merges on a guess, so this re-checks next tick rather than risk
+    /// merging over threads we simply failed to read.
+    Unknown,
+}
+
 /// A pull request as the review decision sees it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrReview {
     /// Still open, with its current CI verdict; `auto_merge` is its repo's policy.
-    /// `unresolved_review` is whether it still carries unresolved review threads
-    /// (reviewer-bot or human) the agent should address before the merge.
+    /// `review` is the PR's review-gate state, meaningful once CI is green.
     Open {
         ci: PrCi,
         auto_merge: bool,
-        unresolved_review: bool,
+        review: ReviewState,
     },
     Merged,
     /// Closed without merging (the agent or a human abandoned this repo's PR).
@@ -34,10 +48,14 @@ pub enum PrReview {
 pub enum ReviewDecision {
     /// At least one open PR's CI failed: hand the task back to the agent to fix.
     Fix,
-    /// A green PR carries unresolved review threads: hand the task back to the
-    /// agent to address the comments before merging.
+    /// A green PR has unresolved review threads or a "changes requested" review:
+    /// hand the task back to the agent to address and resolve them before merging.
     AddressReview,
-    /// Something is still running (CI pending, or no PR detected yet); wait.
+    /// Review work is still outstanding but the addressing budget is spent: park
+    /// the task for a human rather than merge over unresolved comments.
+    Block,
+    /// Something is still running (CI pending, a review lookup failed, or no PR
+    /// detected yet); wait and re-check.
     Wait,
     /// These open, passing, auto-merge PRs (by index) should be squash-merged now.
     Merge(Vec<usize>),
@@ -48,13 +66,17 @@ pub enum ReviewDecision {
 }
 
 /// Decides the next action for a task given its PRs. Order matters: a failing PR
-/// is fixed first; then we wait on any pending CI; then, once everything is green,
-/// unresolved review comments are addressed (while the budget lasts) before we
-/// merge what we can; then, once nothing is open, finish if anything merged.
+/// is fixed first; then we wait on any pending CI; then the review gate, which a
+/// PR must clear (zero unresolved threads, no "changes requested" review) before
+/// it may merge; then, once nothing is open, finish if anything merged.
 ///
-/// `review_attempts_remaining` is whether the task still has addressing turns left
-/// in its budget. Once it is exhausted, unresolved review threads no longer block
-/// the merge, so a genuinely unresolvable thread can't stall the queue forever.
+/// The review gate is strict: a green PR with outstanding review work is never
+/// merged. While the addressing budget lasts the agent is handed it; once the
+/// budget is spent the task parks for a human (`Block`) instead of merging, so a
+/// genuinely unresolvable thread can't slip an unaddressed PR through. Approval is
+/// not consulted: resolution state is the gate, not approval.
+///
+/// `review_attempts_remaining` is whether the task still has addressing turns left.
 pub fn decide(prs: &[PrReview], review_attempts_remaining: bool) -> ReviewDecision {
     if prs.is_empty() {
         // Detection hasn't found a PR yet (e.g. GitHub indexing lag); re-check.
@@ -85,21 +107,37 @@ pub fn decide(prs: &[PrReview], review_attempts_remaining: bool) -> ReviewDecisi
         return ReviewDecision::Wait;
     }
 
-    // Everything open is green. Before merging (auto policy) or holding for a human
-    // (human-review policy), address any unresolved review threads on a green PR,
-    // for either policy, as long as the attempt budget lasts.
-    if review_attempts_remaining
-        && prs.iter().any(|pr| {
-            matches!(
-                pr,
-                PrReview::Open {
-                    unresolved_review: true,
-                    ..
-                }
-            )
-        })
-    {
-        return ReviewDecision::AddressReview;
+    // Everything open is green. The review gate comes before any merge or hold: a
+    // PR with outstanding review work is addressed while the budget lasts, and
+    // parked for a human once it is spent, but it is never merged over.
+    if prs.iter().any(|pr| {
+        matches!(
+            pr,
+            PrReview::Open {
+                review: ReviewState::Outstanding,
+                ..
+            }
+        )
+    }) {
+        return if review_attempts_remaining {
+            ReviewDecision::AddressReview
+        } else {
+            ReviewDecision::Block
+        };
+    }
+
+    // No known-outstanding review, but if any green PR's review state could not be
+    // read this tick, never merge on that guess; re-check once it is known.
+    if prs.iter().any(|pr| {
+        matches!(
+            pr,
+            PrReview::Open {
+                review: ReviewState::Unknown,
+                ..
+            }
+        )
+    }) {
+        return ReviewDecision::Wait;
     }
 
     let to_merge: Vec<usize> = prs
@@ -143,7 +181,7 @@ mod tests {
         PrReview::Open {
             ci,
             auto_merge,
-            unresolved_review: false,
+            review: ReviewState::Clean,
         }
     }
 
@@ -151,7 +189,15 @@ mod tests {
         PrReview::Open {
             ci,
             auto_merge,
-            unresolved_review: true,
+            review: ReviewState::Outstanding,
+        }
+    }
+
+    fn open_unknown_review(ci: PrCi, auto_merge: bool) -> PrReview {
+        PrReview::Open {
+            ci,
+            auto_merge,
+            review: ReviewState::Unknown,
         }
     }
 
@@ -244,17 +290,34 @@ mod tests {
     }
 
     #[test]
-    fn exhausted_budget_merges_over_unresolved_comments() {
-        // With no addressing turns left, the comments no longer block the merge,
-        // so the queue can't stall on a genuinely unresolvable thread.
+    fn exhausted_budget_parks_for_a_human_over_unresolved_comments() {
+        // With no addressing turns left, an unresolved PR is NEVER merged over: it
+        // parks for a human instead, for either merge policy.
         assert_eq!(
             decide(&[open_with_comments(PrCi::Passing, true)], false),
-            ReviewDecision::Merge(vec![0])
+            ReviewDecision::Block
         );
-        // And a human-review PR just holds for a human.
         assert_eq!(
             decide(&[open_with_comments(PrCi::Passing, false)], false),
-            ReviewDecision::Hold
+            ReviewDecision::Block
+        );
+    }
+
+    #[test]
+    fn an_unreadable_review_state_waits_rather_than_merging() {
+        // A review lookup that failed leaves the state unknown; the gate must not
+        // merge on a guess, so it waits and re-checks instead.
+        assert_eq!(
+            decide_ready(&[open_unknown_review(PrCi::Passing, true)]),
+            ReviewDecision::Wait
+        );
+        // A known-outstanding PR still takes priority over an unknown one.
+        assert_eq!(
+            decide_ready(&[
+                open_unknown_review(PrCi::Passing, true),
+                open_with_comments(PrCi::Passing, true),
+            ]),
+            ReviewDecision::AddressReview
         );
     }
 


### PR DESCRIPTION
Closes #270.

## The bug

A PR (`mooreslabaiv1/frontend-core` #17) was squash-merged with 10 unresolved review comments. The gate #255 introduced fetched unresolved threads but still had three holes:

1. Once the addressing budget ran out, it **merged over** the unresolved comments.
2. It never considered a reviewer's **"changes requested"** review.
3. A thread-lookup error **failed open** (treated as "no threads" → merge).

## The fix

The merge gate is now exactly: **CI green AND zero unresolved review threads AND no outstanding "changes requested" review.** Approval alone never merges; resolution state is the gate.

- **`review::decide`** models a green PR's review as a tri-state `ReviewState` (`Clean` / `Outstanding` / `Unknown`):
  - `Outstanding` with budget left → hand back to the agent (`AddressReview`).
  - `Outstanding` with the budget spent (`MAX_REVIEW_FIX_ATTEMPTS`) → **park for a human** via the new `ReviewDecision::Block` (was: merge over the comments).
  - `Unknown` (lookup failed) → **wait and re-check**, never merge on a guess.
- **`git::pr_review_status`** reads unresolved threads (`reviewThreads.isResolved`) AND `reviewDecision` in one GraphQL round trip, so a standing `CHANGES_REQUESTED` from a bot or human blocks too. Replaces `list_unresolved_review_threads`.
- **`mod.rs`**: thread-lookup errors now yield `Unknown` (fail closed); `handle_review_blocked` parks the task `ci_blocked`-style with a review-specific note; an idle revisit resets the review budget so a parked PR is retried.
- **`prompt::build_address_review`**: states the gate plainly (unresolved threads or changes-requested block the merge regardless of approval) and that an unresolvable PR parks for a human. It already instructs the agent to reply to and resolve every thread (including declined ones) via the `resolveReviewThread` mutation.
- **`CLAUDE.md`**: documents the strict gate, the addressing path, and the park-on-exhaustion behavior.

## Acceptance criteria

- A PR with unresolved threads is never squash-merged; the agent addresses + resolves them first. ✓
- Gate is exactly CI green AND zero unresolved threads AND no changes-requested; approval never merges. ✓
- Agent replies to + resolves every thread, including declined ones (prompt). ✓
- After each push the loop waits for CI to re-run and re-checks threads, repeating until clean. ✓ (unchanged loop)
- For `auto_squash_merge` repos the loop waits only until CI finishes. ✓
- Bounded retries; a genuinely unresolvable PR parks for a human rather than merging. ✓
- Works with the CI auto-reviewers (`mooreslabai-claude`, `mooreslabai-codex`) and humans. ✓

## Verification

- `cargo +1.88 fmt --check` clean; `cargo +1.88 build` clean; full suite 145/145 pass.
- New `review::decide` tests: `exhausted_budget_parks_for_a_human_over_unresolved_comments` and `an_unreadable_review_state_waits_rather_than_merging`.
- clippy adds no new warnings from these changes.

No DB migration: the park reuses the existing `ci_blocked` status (as the issue suggested), so no `task_status` enum change and no frontend churn.