### PR TITLE
Show the connected Claude account email on the kanban page (#269)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,11 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   `current_session_id` (the one shared Claude session), the secret columns
   `claude_oauth_token` / `github_token` (the API only ever exposes
   `*_token_set` booleans plus a masked `*_token_preview`, never the raw values;
-  write via `POST /settings/tokens`), and the optional **availability schedule**
+  write via `POST /settings/tokens`), the connected Claude account's
+  `claude_account_email` (captured from the subscription OAuth token-exchange /
+  refresh response and shown next to the environment name on the board, issue
+  #269; blank for a pasted setup-token or API key), and the optional
+  **availability schedule**
   (`availability_enabled`, `availability_timezone` (IANA), `availability_windows`
   JSONB, `availability_skip_dates` JSONB). When enabled, the agent only pulls new
   work during the configured weekly windows in the operator's time zone, skipping

--- a/api/migrations/0042_claude_account_email.sql
+++ b/api/migrations/0042_claude_account_email.sql
@@ -1,0 +1,10 @@
+-- The connected Claude account's email, shown next to the environment name on the
+-- kanban page (issue #269).
+--
+-- Captured from the OAuth token-exchange (and refresh) response, which identifies
+-- the authenticated account regardless of the granted scopes. Empty until a
+-- subscription OAuth login (or its next token refresh) populates it; a manually
+-- pasted setup-token or an API key leaves it blank, since no account identity is
+-- returned on those paths.
+ALTER TABLE settings
+    ADD COLUMN claude_account_email TEXT NOT NULL DEFAULT '';

--- a/api/src/claude/oauth.rs
+++ b/api/src/claude/oauth.rs
@@ -66,6 +66,9 @@ pub struct Tokens {
     /// Seconds until the access token expires.
     pub expires_in: i64,
     pub scopes: String,
+    /// The connected account's email, if the token response carried it (issue
+    /// #269). Empty when the response omitted the account block.
+    pub account_email: String,
 }
 
 /// A subscription usage snapshot (rolling-window utilization percentages).
@@ -175,6 +178,17 @@ async fn token_request(body: &Value) -> Result<Tokens> {
         expires_in: i64,
         #[serde(default)]
         scope: String,
+        /// The authenticated account, returned by the token endpoint on both the
+        /// authorization-code and refresh grants. Used only for its email (#269).
+        #[serde(default)]
+        account: Option<Account>,
+    }
+    #[derive(Deserialize)]
+    struct Account {
+        // The token endpoint returns the account email as `email_address`; accept a
+        // bare `email` too so a shape variation never silently drops the identity.
+        #[serde(default, alias = "email")]
+        email_address: String,
     }
     let client = reqwest::Client::new();
     let response = client
@@ -205,6 +219,10 @@ async fn token_request(body: &Value) -> Result<Tokens> {
             3600
         },
         scopes: parsed.scope,
+        account_email: parsed
+            .account
+            .map(|account| account.email_address)
+            .unwrap_or_default(),
     })
 }
 

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -207,6 +207,10 @@ pub struct Settings {
     pub claude_token_set: bool,
     /// How the agent authenticates to Claude (subscription token vs API key).
     pub claude_auth_mode: ClaudeAuthMode,
+    /// The connected Claude account's email, shown next to the environment name on
+    /// the board (issue #269). Captured from the OAuth token response; empty for a
+    /// manually pasted setup-token or API key, where no account identity is known.
+    pub claude_account_email: String,
     /// Whether subscription usage credentials are stored (the refreshing
     /// access/refresh pair used only to poll the usage gauge). Only meaningful in
     /// `subscription` mode; the tokens themselves are never sent.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -30,7 +30,7 @@ const SETTINGS_COLUMNS: &str =
      claude_model, workspace_image_tag, base_setup_script, config_repo_url, \
      default_branch_template, config_repo_error, current_session_id, updated_at, \
      (claude_oauth_token <> '') AS claude_token_set, \
-     claude_auth_mode, \
+     claude_auth_mode, claude_account_email, \
      (claude_usage_refresh_token <> '') AS claude_usage_token_set, \
      (github_token <> '') AS github_token_set, \
      availability_enabled, availability_timezone, availability_windows, \
@@ -308,18 +308,23 @@ pub async fn set_subscription_credentials(
     refresh_token: &str,
     expires_at: DateTime<Utc>,
     scopes: &str,
+    account_email: &str,
 ) -> sqlx::Result<()> {
+    // An empty `account_email` keeps the stored one rather than wiping it, so a
+    // response that happens to omit the account never blanks a known email.
     sqlx::query(
         "UPDATE settings SET claude_oauth_token = $1, claude_auth_mode = 'subscription', \
          claude_usage_access_token = $2, claude_usage_refresh_token = $3, \
-         claude_usage_expires_at = $4, claude_usage_scopes = $5, updated_at = now() \
-         WHERE id = 1",
+         claude_usage_expires_at = $4, claude_usage_scopes = $5, \
+         claude_account_email = COALESCE(NULLIF($6, ''), claude_account_email), \
+         updated_at = now() WHERE id = 1",
     )
     .bind(inference_token)
     .bind(access_token)
     .bind(refresh_token)
     .bind(expires_at)
     .bind(scopes)
+    .bind(account_email)
     .execute(pool)
     .await?;
     Ok(())
@@ -334,15 +339,23 @@ pub async fn set_oauth_tokens(
     access_token: &str,
     refresh_token: &str,
     expires_at: DateTime<Utc>,
+    account_email: &str,
 ) -> sqlx::Result<()> {
+    // Like the refresh token, an empty `account_email` keeps the existing value, so
+    // a refresh response that omits the account never blanks a known email. This is
+    // also how an install that connected before #269 backfills its email: the first
+    // refresh that returns an account populates it without a reconnect.
     sqlx::query(
         "UPDATE settings SET claude_oauth_token = $1, claude_usage_access_token = $1, \
          claude_usage_refresh_token = COALESCE(NULLIF($2, ''), claude_usage_refresh_token), \
-         claude_usage_expires_at = $3, updated_at = now() WHERE id = 1",
+         claude_usage_expires_at = $3, \
+         claude_account_email = COALESCE(NULLIF($4, ''), claude_account_email), \
+         updated_at = now() WHERE id = 1",
     )
     .bind(access_token)
     .bind(refresh_token)
     .bind(expires_at)
+    .bind(account_email)
     .execute(pool)
     .await?;
     Ok(())
@@ -354,7 +367,8 @@ pub async fn set_api_key(pool: &PgPool, api_key: &str) -> sqlx::Result<()> {
     sqlx::query(
         "UPDATE settings SET claude_oauth_token = $1, claude_auth_mode = 'api_key', \
          claude_usage_access_token = '', claude_usage_refresh_token = '', \
-         claude_usage_expires_at = NULL, claude_usage_scopes = '', updated_at = now() \
+         claude_usage_expires_at = NULL, claude_usage_scopes = '', \
+         claude_account_email = '', updated_at = now() \
          WHERE id = 1",
     )
     .bind(api_key)

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -194,6 +194,7 @@ pub async fn claude_oauth_finish(
         &tokens.refresh_token,
         expires_at,
         &tokens.scopes,
+        &tokens.account_email,
     )
     .await?;
     info!(

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -737,6 +737,7 @@ mod tests {
             updated_at: Utc::now(),
             claude_token_set: false,
             claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_account_email: String::new(),
             claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,

--- a/api/src/orchestrator/availability.rs
+++ b/api/src/orchestrator/availability.rs
@@ -99,6 +99,7 @@ mod tests {
             updated_at: Utc::now(),
             claude_token_set: false,
             claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_account_email: String::new(),
             claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: enabled,

--- a/api/src/orchestrator/network.rs
+++ b/api/src/orchestrator/network.rs
@@ -242,6 +242,7 @@ mod tests {
             updated_at: Utc::now(),
             claude_token_set: false,
             claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_account_email: String::new(),
             claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -715,6 +715,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             claude_token_set: false,
             claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
+            claude_account_email: String::new(),
             claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,

--- a/api/src/orchestrator/subscription.rs
+++ b/api/src/orchestrator/subscription.rs
@@ -99,6 +99,7 @@ async fn refresh_and_store(state: &AppState, refresh_token: &str) -> Result<Stri
         &tokens.access_token,
         &tokens.refresh_token,
         expires_at,
+        &tokens.account_email,
     )
     .await?;
     info!(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -183,6 +183,9 @@ export type Settings = {
   claude_token_set: boolean
   // How the agent authenticates to Claude (subscription token vs API key).
   claude_auth_mode: ClaudeAuthMode
+  // The connected Claude account's email (issue #269); empty when unknown
+  // (a manually pasted setup-token or API key returns no account identity).
+  claude_account_email: string
   // Whether subscription usage credentials are stored (powers the usage gauge).
   claude_usage_token_set: boolean
   github_token_set: boolean

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -944,6 +944,14 @@
     <div class="flex items-baseline gap-2">
       {#if settings}
         <strong class="text-base">{settings.org_name}</strong>
+        {#if settings.claude_account_email}
+          <span
+            class="text-sm text-muted-foreground"
+            title="Connected Claude account"
+          >
+            • ({settings.claude_account_email})
+          </span>
+        {/if}
         {#if outsideSchedule}
           <span
             class="rounded-full border border-warning/40 px-2 py-0.5 text-xs text-warning"


### PR DESCRIPTION
Closes #269.

Shows the connected Claude account next to the environment name on the board:

```
<Environment name> • (authorized@email.com)
```

## How the identity is obtained

The Claude OAuth token endpoint returns an `account` block (with the account's email) alongside the tokens, on both the authorization-code and refresh grants. It identifies the authenticated account regardless of the granted scopes, so this needs no extra scope or endpoint (the `/api/oauth/usage` profile gauge, by contrast, needs `user:profile` and is often skipped). The parser previously discarded everything but the tokens; now it captures `account.email_address` (also accepts a bare `email`).

## Changes

- **`api/src/claude/oauth.rs`**: parse the account block into a new `Tokens.account_email`.
- **Migration `0042` + `Settings.claude_account_email`**: a plain (non-secret) column, surfaced on the `GET /settings` payload. Persisted on OAuth connect (`set_subscription_credentials`) and on each token refresh (`set_oauth_tokens`), so an install that connected before this change backfills its email on the next refresh without a reconnect. Cleared when switching to API-key mode. An empty value never clobbers a known email.
- **`frontend`**: `types.ts` gains `claude_account_email`; the kanban header renders ` • (email)` after the org name when present.
- **`CLAUDE.md`**: documents the new field.

The email is blank for a manually pasted setup-token or an API key (no account identity is returned on those paths); the header simply shows the environment name alone, matching the issue's conditional ("if we have access").

## Verification

- Backend: `cargo +1.88 fmt --check` clean, `cargo +1.88 build` clean, `clippy --all-targets` no new warnings, full suite 145/145 pass (added the field to the four `Settings` test fixtures).
- Frontend: `svelte-check` 0 errors / 0 warnings; `vitest` 13/13 pass.

Docs read before editing: docker.md, rust.md, typescript.md, i18n.md. (The frontend is inline-English with no i18next wired up, and this adds no new translatable copy, only a "•" separator around a dynamic email, so it follows the existing inline convention.)