### PR TITLE
Bump runewood to 0.1.2 (spin fix + remove camera wobble)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "ky": "^1.7.0",
     "marked": "^18.0.5",
     "paneforge": "^1.0.2",
-    "runewood": "^0.1.1",
+    "runewood": "^0.1.2",
     "svelte-dnd-action": "^0.9.50",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2202,13 +2202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"runewood@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "runewood@npm:0.1.1"
+"runewood@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "runewood@npm:0.1.2"
   dependencies:
     pixi-filters: "npm:^6.1.5"
     pixi.js: "npm:^8.19.0"
-  checksum: 10c0/05c560b985f7f70876176596edbfaa8abea7ac68b369b30a615d35514b098791d5d8756146523037937e2819487f97ce35c87f88cab7697bc970157cebed526a
+  checksum: 10c0/02f6e8e6c2f470159922ba4a23c8647049ba7cafa507d9809b9420e1ac947742401b75bc9ea83754416e48ea28d537c25a18a4d33ea742302a0d1c0080d230a7
   languageName: node
   linkType: hard
 
@@ -2251,7 +2251,7 @@ __metadata:
     marked: "npm:^18.0.5"
     mode-watcher: "npm:^1.1.0"
     paneforge: "npm:^1.0.2"
-    runewood: "npm:^0.1.1"
+    runewood: "npm:^0.1.2"
     svelte: "npm:^5.1.0"
     svelte-check: "npm:^4.0.0"
     svelte-dnd-action: "npm:^0.9.50"


### PR DESCRIPTION
Updates the watch-page activity forest dependency from `^0.1.1` to `^0.1.2`.

## What 0.1.2 fixes
- **Pulse-spin / chaos-at-scale.** The force layout used to globally reheat the entire forest on every structural change, so on a busy instance it never cooled (chaos that never settled) and each event rotated the whole tree coherently for a second (the pulse-spin synced to updates). It now uses a per-directory temperature with the reheat scoped to just the changed node and its immediate neighbors, plus a per-step de-spin, so a node added in one repo only re-settles its own neighborhood and the tree stays still between updates.
- **Camera wobble removed.** Panning and zooming now move the camera only; the forest no longer drifts circularly in response to camera input.

## Notes
- No runewood API changes (the public surface is unchanged), so no Seraphim code edits are needed, just the version bump and a regenerated `frontend/yarn.lock` pinning 0.1.2.
- Verified locally: `yarn check` (0 errors) and `yarn build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)