### PR TITLE
Agent eyes: opt-in per-repo visual regression baselines (#246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,18 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   command, base URL/port, and key routes there, e.g. "dev server: `npm run dev` on
   :5173; check /, /login, /dashboard". The loop degrades gracefully: a repo with no
   runnable UI is skipped with a noted reason, never failed.
+  - **Visual regression baselines (issue #246):** the long-game complement, for
+    locking a confirmed-good screen against future regressions. An **opt-in,
+    per-repo** recipe (`workspace/visual-regression.md`, baked at
+    `/usr/local/share/seraphim/visual-regression.md`) documents committed Playwright
+    `toHaveScreenshot()` baselines plus anti-flake guidance (fixed viewport,
+    disabled animations, masked dynamic regions, deterministic data, same
+    environment to generate and diff). It runs in the repo's own test suite via the
+    standalone `@playwright/test` runner, NOT the MCP (the MCP has no pixel
+    comparison). Baselines are committed in the repo under test, never in Seraphim;
+    `VISUAL_SELF_REVIEW` points at the recipe but the agent only uses it where a
+    repo's `CLAUDE.md` opts in. An unexpected diff is a regression to investigate,
+    not a baseline to bump.
 - **Two-tier setup:** environment setup (`settings.base_setup_script`) runs once
   per provision/recreate (install CLIs/toolchains); per-repo setup
   (`repositories.setup_script`) runs after each clone (e.g. `yarn install`).

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -567,7 +567,9 @@ const ENVIRONMENT_SUGGESTIONS: &str = "\n\
 /// operator's global instructions. It uses the Playwright MCP baked into the
 /// workspace (issue #243); computed-style checks are the workhorse, so it points at
 /// the reusable check library baked into the image (issue #245) and treats a
-/// screenshot as final confirmation only, to keep token cost down. It reads the
+/// screenshot as final confirmation only, to keep token cost down. It also points
+/// at the opt-in, per-repo visual-regression baseline recipe (issue #246) for
+/// locking a confirmed-good screen against future regressions. It reads the
 /// per-repo dev-server facts from the repo's `CLAUDE.md`, and degrades gracefully:
 /// a repo with no runnable UI is skipped cleanly rather than failing the task.
 const VISUAL_SELF_REVIEW: &str = "\n\
@@ -590,6 +592,13 @@ const VISUAL_SELF_REVIEW: &str = "\n\
     the final result.\n\
     - Confirm it renders correctly at both mobile (375px) and desktop (1280px) \
     widths.\n\
+    - To lock a confirmed-good screen against FUTURE regressions, a repo may opt into \
+    committed Playwright visual-regression baselines (a standalone test in the repo's \
+    own suite, not the MCP); the recipe is at \
+    `/usr/local/share/seraphim/visual-regression.md`. This is opt-in per repo: only \
+    establish or run baselines where the repo's `CLAUDE.md` says it is enabled, or the \
+    task is to add it. Treat an unexpected screenshot diff as a regression to \
+    investigate, never reflexively re-baseline to make the check green.\n\
     - If the repo has no runnable UI (a backend-only or non-web repo, no dev server, \
     or the browser tools are unavailable), SKIP this review: do not fail the task or \
     hold the PR for it, just note in your summary that you skipped visual review and \
@@ -998,6 +1007,23 @@ mod tests {
         assert!(prompt.contains("375px"));
         assert!(prompt.contains("1280px"));
         assert!(prompt.contains("SKIP this review"));
+    }
+
+    #[test]
+    fn task_prompt_points_at_the_opt_in_visual_regression_recipe() {
+        // Issue #246: the default instructions surface the opt-in, per-repo visual
+        // regression baseline recipe as the way to lock a confirmed-good screen.
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &[],
+        );
+        assert!(prompt.contains("/usr/local/share/seraphim/visual-regression.md"));
+        assert!(prompt.contains("opt-in per repo"));
     }
 
     #[test]

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -159,6 +159,14 @@ RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
 # agent's default instructions can point at it no matter which repo it is on.
 COPY visual-checks.md /usr/local/share/seraphim/visual-checks.md
 
+# --- Visual regression baseline recipe (issue #246) ---------------------------
+# The opt-in, per-repo recipe for committed Playwright `toHaveScreenshot()`
+# baselines (standalone runner, not the MCP) plus anti-flake guidance, so the
+# agent can lock a confirmed-good screen against future regressions. Baked at the
+# same fixed path the default instructions point at; baselines themselves live in
+# each opted-in repo, never here.
+COPY visual-regression.md /usr/local/share/seraphim/visual-regression.md
+
 # --- Throwaway PostgreSQL 17 helper (boots a local cluster for DB validation) -
 COPY pg-ephemeral /usr/local/bin/pg-ephemeral
 RUN chmod +x /usr/local/bin/pg-ephemeral

--- a/workspace/visual-regression.md
+++ b/workspace/visual-regression.md
@@ -1,0 +1,165 @@
+# Visual regression baselines (opt-in, per repo)
+
+This is the long-game complement to the per-change visual self-review (see
+`visual-checks.md`). Once a screen looks right, lock it in with a committed
+**baseline screenshot** so a later, unrelated change can't silently break it. The
+per-change loop catches "is this change right?"; baselines catch "did this change
+break something that was already right?".
+
+It is **opt-in per repo** and runs in the repo's own test suite, NOT through the
+Playwright MCP: pixel comparison needs the standalone `@playwright/test` runner
+(`toHaveScreenshot()`), which the MCP does not provide. Only set this up, or run
+it, in a repo that has opted in (its `CLAUDE.md` says so, or the task is to add
+it). Do not add baselines to a repo that has not asked for them.
+
+**Baselines live in the repo under test, committed alongside its tests, never in
+Seraphim.**
+
+## Where baselines live
+
+`toHaveScreenshot()` writes PNGs next to the spec, under
+`<spec>.ts-snapshots/<name>-<project>-<platform>.png` by default. Commit that
+directory. Because rendering differs across OS and font stacks, a baseline is only
+valid on the platform that generated it, so the golden rule is:
+
+> Generate and compare baselines in the SAME environment CI uses.
+
+Pin the Playwright version (it pins the browser build) and run both the
+baseline-generation and the CI diff inside the same container, e.g. the official
+`mcr.microsoft.com/playwright:vX.Y.Z-jammy` image (or whatever image CI runs).
+Generating a baseline on your host and diffing it in CI is the most common source
+of "works locally, fails in CI" noise. The `{platform}` token in the path keeps
+per-OS baselines separate when a repo genuinely needs more than one.
+
+## Setup (once, in the opted-in repo)
+
+1. Add the runner: `yarn add -D @playwright/test` (then `yarn playwright install
+   --with-deps chromium`, already baked into this workspace image).
+2. Add a `playwright.config.ts` tuned against flakiness:
+
+```ts
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/visual',
+  // Fail CI if a baseline is missing rather than silently creating one: a new
+  // baseline must be a deliberate, reviewed commit, never a side effect of CI.
+  forbidOnly: !!process.env.CI,
+  use: {
+    baseURL: 'http://localhost:5173',
+    viewport: { width: 1280, height: 800 }, // fixed, never the window size
+    deviceScaleFactor: 1,
+    reducedMotion: 'reduce',
+    colorScheme: 'light',
+    timezoneId: 'UTC', // freeze locale-dependent rendering
+    locale: 'en-US',
+  },
+  expect: {
+    toHaveScreenshot: {
+      // Disable animations and hide the blinking caret so timing can't flip a pixel.
+      animations: 'disabled',
+      caret: 'hide',
+      scale: 'css',
+      // A tiny tolerance absorbs sub-pixel anti-aliasing without hiding real diffs.
+      maxDiffPixelRatio: 0.01,
+    },
+  },
+})
+```
+
+## The spec
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test('dashboard looks right', async ({ page }) => {
+  await page.goto('/dashboard')
+  // Wait for the real "settled" signal, not a fixed sleep: fonts loaded and the
+  // content present. A hard timeout is itself a flake source.
+  await page.locator('[data-testid="dashboard-ready"]').waitFor()
+  await page.evaluate(() => document.fonts.ready)
+
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    // Mask regions whose content legitimately changes run to run, so they never
+    // trip the diff: clocks, relative times, avatars, random ids, live counts.
+    mask: [page.locator('.timestamp'), page.locator('[data-dynamic]')],
+  })
+})
+```
+
+## Controlling flakiness (do all of these)
+
+A flaky baseline is worse than none: it trains everyone to ignore the diff. Pin
+down every source of nondeterminism:
+
+- **Fixed viewport + `deviceScaleFactor: 1`** so the canvas size never varies.
+- **Animations disabled, caret hidden** (set above) so timing can't change a pixel.
+- **Deterministic data:** point the dev server at seeded/fixture data or mock the
+  network (`page.route(...)`), and freeze the clock (`timezoneId: 'UTC'`, and stub
+  `Date`/`Math.random` if the UI shows them). Never baseline live/production data.
+- **Mask dynamic regions** (above) instead of widening the global threshold.
+- **Wait on a real readiness signal** (a test id, `document.fonts.ready`, a
+  network-idle for the relevant requests), never `waitForTimeout`.
+- **Same environment for generate and compare** (see "Where baselines live").
+- Keep the diff tolerance small (`maxDiffPixelRatio` ~0.01); if a screen needs
+  more, mask the noisy part rather than blinding the whole shot.
+
+## Workflow
+
+1. **Establish** a baseline only when the screen is confirmed good (you have just
+   reviewed it via the per-change loop): `yarn playwright test --update-snapshots`,
+   then **commit** the generated `*-snapshots/` PNGs. Review the committed images
+   like any other artifact, a wrong baseline locks in a bug.
+2. **Diff on later changes:** `yarn playwright test`. CI runs the same. A pass
+   means the rendered pixels match the committed baseline.
+3. **React to a regression:** an unexpected diff is a **failure to investigate**,
+   not a baseline to bump. Open the report (`playwright-report/`, with
+   expected/actual/diff images) and decide:
+   - The change was NOT meant to alter this screen → it is a real regression; fix
+     the code until the diff is clean.
+   - The change WAS meant to alter this screen → the new rendering is correct;
+     re-run with `--update-snapshots`, eyeball the new image, and commit it with a
+     message saying why it changed. Updating the baseline is a deliberate act.
+
+Never reflexively `--update-snapshots` to make a red check green: that is how a
+fixed bug gets re-introduced. That re-introduction is exactly what baselines exist
+to stop.
+
+## Opting a repo in
+
+Add the dependency, the `playwright.config.ts`, the specs under `tests/visual/`,
+the committed baselines, and a `"test:visual": "playwright test"` script. Wire it
+into CI in the same container that generated the baselines. Record in the repo's
+own `CLAUDE.md` that visual regression is enabled, where the specs and baselines
+live, and the command to update a baseline, so the next run knows it is opt-in and
+how to use it.
+
+## Heavier alternative: Storybook + Chromatic
+
+For a component-library-driven codebase, Storybook + Chromatic does per-component
+visual regression as a hosted service (automatic baselines, a review UI, parallel
+cross-browser snapshots) instead of committed PNGs. It is more setup and a paid
+dependency, so treat it as an option for repos already invested in Storybook, not
+the default. The committed-baseline recipe above is the lightweight default.
+
+## Worked example: catching a regression
+
+A baseline exists for `dashboard.png` (committed). A later task tweaks a shared
+button's padding, not meant to touch the dashboard. CI runs `playwright test`:
+
+```
+  1) dashboard.spec.ts:3:1 › dashboard looks right ─────────────────────────────
+
+    Error: Screenshot comparison failed:
+
+      1248 pixels (ratio 0.02 of all image pixels) are different.
+
+    Expected: dashboard-linux.png
+    Received: dashboard-actual.png
+    Diff:     dashboard-diff.png
+```
+
+The diff image shows the dashboard's action button shifted, the shared-padding
+change leaked here. Because it was unintended, this is a regression: revert/correct
+the padding until `playwright test` is green again. The baseline is left untouched,
+and a bug that would have shipped silently was caught instead.


### PR DESCRIPTION
Closes #246. Part of epic #242 (agent eyes), the long-game complement to the per-change visual self-review (#244, #245).

## What

Once a screen looks right, lock it in with a committed baseline screenshot so a later, unrelated change can't silently re-break it.

- **`workspace/visual-regression.md`** (new): a documented, **opt-in, per-repo** recipe for committed Playwright `toHaveScreenshot()` baselines. It uses the standalone `@playwright/test` runner in the repo's own suite, NOT the Playwright MCP (the MCP has no pixel-comparison step). It covers:
  - a tuned **anti-flake** `playwright.config.ts` (fixed viewport, `deviceScaleFactor: 1`, disabled animations, hidden caret, `maxDiffPixelRatio`, `reducedMotion`, frozen timezone/locale) plus masking dynamic regions, deterministic/seeded data, and waiting on a real readiness signal;
  - **where baselines live** (committed in the repo under test, never in Seraphim) and the platform-sensitivity rule (generate and diff in the same container CI uses);
  - the **establish -> diff -> react** workflow: an unexpected diff is a regression to investigate, and you re-baseline (`--update-snapshots`) only when the change is intended;
  - **Storybook + Chromatic** mentioned as a heavier optional alternative, not required;
  - a **worked example** catching a regression.
- **`workspace/Dockerfile`**: bakes the recipe at `/usr/local/share/seraphim/visual-regression.md`, next to the #245 computed-style library.
- **`api/src/orchestrator/prompt.rs`**: `VISUAL_SELF_REVIEW` now points at the recipe as an explicitly opt-in step ("only where the repo's `CLAUDE.md` enables it"), with a new test.
- **`CLAUDE.md`**: documents the opt-in baseline workflow under the visual self-review section.

## Acceptance criteria

- Documented, opt-in per-repo baseline + diff recipe with anti-flake guidance. ✓
- The agent can create a baseline for a confirmed-good screen and detect a regression. ✓ (recipe + worked example; verified live below)
- Baselines stored in the repo under test, not in Seraphim. ✓

## Verification

- Backend: `cargo +1.88 fmt --check` clean, full suite 147/147 pass (new test `task_prompt_points_at_the_opt_in_visual_regression_recipe`), no new clippy warnings.
- Ran the recipe end to end in headless Chromium: established a baseline of a blue page, then navigated a red page; the diff run failed as intended (`80000 pixels (ratio 1.00 of all image pixels) are different`, `1 failed`), and an intentional `--update-snapshots` cleared it.

## Notes

- Per-repo tooling + guidance; depends on Playwright being available (baked into the workspace image, #243). Deliberately not forced onto any repo's CI: it is opt-in, and the recipe says baselines must be generated and diffed in the same container to avoid cross-platform flakiness. Deploying the baked recipe needs a workspace image rebuild.