### PR TITLE
Agent eyes: constrain the design space toward tokens/primitives (#247)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,17 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   command, base URL/port, and key routes there, e.g. "dev server: `npm run dev` on
   :5173; check /, /login, /dashboard". The loop degrades gracefully: a repo with no
   runnable UI is skipped with a noted reason, never failed.
+  - **Constrain the design space (issue #247):** a sibling build-time standing
+    instruction (`prompt::DESIGN_PRIMITIVES`, also in the shared header) steers UI
+    work to compose from the repo's existing layout primitives (`<Stack gap="md">`
+    and friends) and spacing-scale tokens, and to match neighboring components,
+    instead of hand-rolled `margin`/`padding` (fewer degrees of freedom, fewer ways
+    to be wrong). The fuller guidance plus the optional Figma-spec path (use the
+    Figma MCP to implement against real numbers, then validate with the
+    computed-style checks; opt-in, no Figma MCP is wired by default) lives in
+    `workspace/design-system.md`, baked at
+    `/usr/local/share/seraphim/design-system.md`. The concrete tokens and primitives
+    live in each repo under test, not here.
 - **Two-tier setup:** environment setup (`settings.base_setup_script`) runs once
   per provision/recreate (install CLIs/toolchains); per-repo setup
   (`repositories.setup_script`) runs after each clone (e.g. `yarn install`).

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -476,6 +476,10 @@ fn context_header(
     // Shared by every mode: noticing missing tooling can happen on any run, so
     // the recommend-improvements guidance lives in the common header.
     prompt.push_str(ENVIRONMENT_SUGGESTIONS);
+    // Build-then-verify for UI work: first steer toward the repo's design vocabulary
+    // (issue #247) so spacing is picked from a fixed set, then the self-review loop
+    // checks the result. Both are shared by every mode.
+    prompt.push_str(DESIGN_PRIMITIVES);
     // Likewise the visual self-review loop: any turn that touches the UI must look
     // at it before declaring done, so the standing instruction lives in the header
     // too (fresh work, CI fixes, revisits all alike).
@@ -559,6 +563,33 @@ const ENVIRONMENT_SUGGESTIONS: &str = "\n\
     \x20 JSON\n\n\
     Only suggest things that genuinely help; if nothing comes to mind, skip it. \
     This does not replace opening the pull request.\n";
+
+/// Standing instruction (issue #247) to build UI from the repo's design vocabulary
+/// rather than ad-hoc spacing.
+///
+/// Spacing/alignment go wrong most when every component re-decides them, so this
+/// steers the agent to compose from existing layout primitives and spacing-scale
+/// tokens and to match neighboring components, cutting the degrees of freedom at
+/// the source. The concrete primitives live in each repo, so this points at the
+/// baked `design-system.md` (which also documents the optional Figma-spec path) and
+/// defers the specifics to the repo's own `CLAUDE.md`.
+const DESIGN_PRIMITIVES: &str = "\n\
+    # Build UI from the design system, not ad-hoc spacing\n\
+    Spacing and alignment go wrong most often because every component re-decides them \
+    from scratch. Cut the degrees of freedom: build from the repo's existing \
+    vocabulary instead of inventing values.\n\
+    - Prefer the repo's layout primitives (e.g. a `<Stack gap=\"md\">`, `<Inline>`, \
+    `<Grid>`) and its spacing-scale tokens over hand-rolled `margin`/`padding` with \
+    magic pixel values, and compose from shared components (the repo's own primitives \
+    or its component library, e.g. shadcn/ui) rather than re-implementing one with \
+    bespoke spacing.\n\
+    - Match the surrounding components: before writing layout, look at the sibling \
+    code and reuse the same primitives, token names, and spacing steps it already \
+    uses. Consistency over novelty.\n\
+    - The tokens and primitives live in each repo (its `tailwind.config`, theme/token \
+    files, `components/ui` dir, ideally noted in its `CLAUDE.md`), not here. Fuller \
+    guidance, including the optional path for implementing against a Figma spec when a \
+    Figma MCP is configured, is at `/usr/local/share/seraphim/design-system.md`.\n";
 
 /// Standing instruction (issues #244, #245) to visually self-review any UI change.
 ///
@@ -999,6 +1030,26 @@ mod tests {
         assert!(prompt.contains("375px"));
         assert!(prompt.contains("1280px"));
         assert!(prompt.contains("SKIP this review"));
+    }
+
+    #[test]
+    fn task_prompt_steers_toward_design_primitives() {
+        // Issue #247: the default instructions steer the agent to compose from the
+        // repo's layout primitives and spacing tokens, match the neighbors, and away
+        // from ad-hoc margin/padding, pointing at the baked design-system guidance.
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &[],
+        );
+        assert!(prompt.contains("layout primitives"));
+        assert!(prompt.contains("spacing-scale tokens"));
+        assert!(prompt.contains("Match the surrounding components"));
+        assert!(prompt.contains("/usr/local/share/seraphim/design-system.md"));
     }
 
     #[test]

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -159,6 +159,14 @@ RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
 # agent's default instructions can point at it no matter which repo it is on.
 COPY visual-checks.md /usr/local/share/seraphim/visual-checks.md
 
+# --- Design-system guidance (issue #247) --------------------------------------
+# Build-time guidance to compose UI from the repo's existing tokens/primitives
+# instead of ad-hoc spacing (fewer degrees of freedom, fewer ways to be wrong),
+# plus the optional path for implementing against a Figma spec when a Figma MCP is
+# configured. Baked at the fixed path the default instructions point at; the
+# concrete tokens/primitives live in each repo under test, not here.
+COPY design-system.md /usr/local/share/seraphim/design-system.md
+
 # --- Throwaway PostgreSQL 17 helper (boots a local cluster for DB validation) -
 COPY pg-ephemeral /usr/local/bin/pg-ephemeral
 RUN chmod +x /usr/local/bin/pg-ephemeral

--- a/workspace/design-system.md
+++ b/workspace/design-system.md
@@ -1,0 +1,70 @@
+# Compose from the design system (constrain the spacing decision)
+
+The deepest reason spacing and alignment come out wrong is that they are a free
+decision on every single component: each new bit of UI re-invents its margins from
+scratch, so there are endless ways to be slightly off. The fix is to cut the
+degrees of freedom. Before you reach for a `margin`, reach for the vocabulary the
+repo already has.
+
+This is build-time guidance (how to write the UI). The per-change verification of
+the result lives in `visual-checks.md` (computed-style checks).
+
+## Prefer primitives and tokens over ad-hoc spacing
+
+- **Layout primitives.** If the repo has them, express spacing as a choice from a
+  fixed set: a `<Stack gap="md">`, `<Inline>`, `<Grid>`, `<Box p="4">`, etc. A
+  primitive with a `gap`/`p` prop drawn from the scale is far harder to get wrong
+  than a hand-written `margin-top: 13px`.
+- **Spacing-scale tokens.** Use the named steps the repo defines (`xs`/`sm`/`md`,
+  `1`/`2`/`3`/`4`, Tailwind's spacing scale, CSS `--space-*` vars) instead of
+  arbitrary pixel values. A value that is not on the scale is almost always a bug.
+- **Shared components.** Reuse the repo's own components or its component library
+  (shadcn/ui, Radix, MUI, the repo's `components/ui`) rather than re-implementing a
+  button / card / field with bespoke padding. Change spacing through a component's
+  props or variants, not by wrapping it in a one-off `div` with a margin.
+
+## Match the neighbors
+
+Before writing any layout, look at the sibling components around your change: which
+primitives, token names, and spacing steps do they use? Match them. Grep for the
+same element type elsewhere in the codebase and copy its conventions. The goal is
+to look like it was always there, not to introduce a new spacing dialect.
+
+## Discover the repo's vocabulary
+
+- **Tokens / scale:** `tailwind.config.*` (`theme.spacing`), a `theme.ts` /
+  `tokens.*`, or CSS custom properties (`--space-*`, `--radius-*`).
+- **Primitives:** a `components/ui/` or `lib/primitives/` directory, a design-system
+  package, or a UI library already in `package.json`.
+- If the repo records its design system in its own `CLAUDE.md`, follow it. If you
+  discover the vocabulary and it is not recorded, add a short note there (the tokens
+  file, the primitives dir, the spacing scale) so the next run starts informed.
+
+## Anti-patterns
+
+- Magic values: `margin: 13px`, `style={{ marginTop: 17 }}`, a `gap: 11px` that is
+  not on any scale.
+- A bespoke `display: flex; gap: ...` where a `<Stack>` / `<Inline>` primitive
+  already exists.
+- Re-implementing or wrapping a shared component just to nudge its spacing, instead
+  of using the prop/variant it already exposes.
+
+## Optional: implement against a Figma spec
+
+Only when a **Figma MCP is configured** for the repo (none is wired by default, so
+treat this as opt-in and skip it otherwise): use the Figma MCP to pull the actual
+spec, the real spacing, sizes, and token values, and implement against those exact
+numbers instead of eyeballing them. Then validate the implementation against that
+spec with the computed-style checks (`/usr/local/share/seraphim/visual-checks.md`)
+at mobile (375px) and desktop (1280px): the Figma numbers become the expected
+values your centering/spacing assertions check, so "matches the design" becomes a
+pass/fail measurement rather than a judgment call. With no Figma MCP and no spec,
+fall back to matching the neighbors and the repo's token scale.
+
+## Where the primitives live
+
+The concrete tokens, scale, and primitives live in each repo under test, not in
+Seraphim. This is guidance for picking from whatever vocabulary a repo already has.
+If a repo genuinely has none, still prefer a small consistent scale (a handful of
+spacing steps) over scattered magic numbers, and record what you chose in that
+repo's `CLAUDE.md` so it becomes the convention the next change matches.


### PR DESCRIPTION
Closes #247. Part of epic #242 (agent eyes). Supplementary to the higher-leverage browser/loop/computed-style tickets (#244, #245, #246), this lowers the UI error rate at the source.

## What

Spacing and alignment go wrong most often because they are a free decision on every component. Fewer degrees of freedom means fewer ways to be wrong, so steer the agent to compose from the repo's existing design vocabulary instead of improvising.

- **`prompt::DESIGN_PRIMITIVES`** (new standing instruction in the shared header, build-time sibling to the verify-time `VISUAL_SELF_REVIEW`): prefer the repo's layout primitives (`<Stack gap="md">`, `<Inline>`, `<Grid>`) and spacing-scale tokens over hand-rolled `margin`/`padding` with magic pixel values; compose from shared components (the repo's own or its library, e.g. shadcn/ui) rather than re-implementing them; and match the surrounding components' conventions. Applies on fresh work and fix/revisit turns alike.
- **`workspace/design-system.md`** (new, baked at `/usr/local/share/seraphim/design-system.md`): the fuller guidance, how to discover a repo's tokens/primitives, anti-patterns, and the **optional Figma-spec path**, when a Figma MCP is configured (none is wired by default, so it is explicitly opt-in), pull the real spec and implement against those exact numbers, then validate with the computed-style checks (`visual-checks.md`) at 375px and 1280px so "matches the design" becomes a pass/fail measurement.
- **`CLAUDE.md`**: documented under the visual self-review section.

## Acceptance criteria

- The default instructions steer toward existing tokens/primitives and away from ad-hoc spacing. ✓
- Where a repo has a component system, the agent composes from it rather than re-inventing spacing (instruction + doc: match the neighbors, reuse shared components). ✓
- (Optional) A documented path for validating an implementation against a Figma spec via the Figma MCP + computed-style checks. ✓ (clearly marked opt-in; no Figma MCP wired by default)

## Verification

- `cargo +1.88 fmt --check` clean; full suite 147/147 pass (new test `task_prompt_steers_toward_design_primitives`); no new clippy warnings.

## Notes

- Mostly guidance; the concrete tokens/primitives live in each repo under test, not in Seraphim. Deploying the baked doc needs a workspace image rebuild. The Figma path is documented as conditional only, this PR wires no Figma MCP.