### PR TITLE
Fail closed when review status can't be read, so unresolved threads block merge (#270)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,9 +391,13 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
      PR, `git::pr_review_status` reads both signals in one GraphQL round trip
      (`reviewThreads { isResolved }` for unresolved threads from the org CI reviewer
      bots `mooreslabai-claude` / `mooreslabai-codex` or humans, plus `reviewDecision`
-     for a standing `CHANGES_REQUESTED`). That collapses to a per-PR `ReviewState`
-     (`Clean` / `Outstanding` / `Unknown`) which `review::decide` gates on before any
-     merge or hold:
+     for a standing `CHANGES_REQUESTED`). It **fails closed** (`pr_review_status` ->
+     `Err` -> `Unknown`): GraphQL returns HTTP 200 even on field errors, so a body
+     carrying `errors` or a null `pullRequest` is treated as "could not read" and is
+     never read as "zero threads" (the hole that let an APPROVED PR with open threads
+     merge, issue #270, locked by unit tests on `review_status_from_response`). That
+     collapses to a per-PR `ReviewState` (`Clean` / `Outstanding` / `Unknown`) which
+     `review::decide` gates on before any merge or hold:
      - **Outstanding** (threads and/or changes-requested) with attempts left → flag
        `addressing_review` (`queries::flag_review_addressing`), emit a `ci`-style
        feed note; the agent loop picks it up (`pick_next_review_address`) and runs an
@@ -409,8 +413,12 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
        → `handle_review_blocked`, which reuses the `ci_blocked` park with a
        review-specific note). It is **never merged over** open comments; an idle
        revisit later resets `review_fix_attempts` and tries again.
-     - **Unknown** (the review lookup failed) → wait and re-check next tick, never
-       merge on a guess.
+     - **Unknown** (the review lookup failed: a transport error, GraphQL `errors`, or
+       a missing `pullRequest`) → wait and re-check next tick, never merge on a guess.
+       A persistent `Unknown` means the PR sits in review without merging (safe) and
+       the cause is logged (`could not read review status`), so a token/permission
+       gap on the GraphQL `reviewThreads` query surfaces as "stops merging" rather
+       than "merges unreviewed".
 4. **defibrillator** (dead-agent management) — recovers turns that die mid-flight,
    which we call a **"heart attack"**: the agent hangs with no output, its stream
    breaks, or the turn aborts internally, leaving the card stranded `in_progress`

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -5,7 +5,7 @@
 //! detects and acts on them deterministically here, rather than parsing the
 //! agent's prose.
 
-use eyre::{Context, Result};
+use eyre::{eyre, Context, Result};
 use octocrab::params::pulls::MergeMethod;
 use octocrab::params::State;
 use octocrab::Octocrab;
@@ -324,25 +324,61 @@ pub async fn pr_review_status(
         .await
         .wrap_err("failed to query pull request review status")?;
 
-    let pull = response
+    review_status_from_response(response, owner, repo, number)
+}
+
+/// Interprets the GraphQL review-status response into a [`PrReviewStatus`], failing
+/// CLOSED whenever it cannot positively confirm the PR's review state.
+///
+/// This is the merge gate's most safety-critical step, so it never assumes "zero
+/// unresolved threads" from a degenerate response. GraphQL returns HTTP 200 even on
+/// field errors, so a `{ "data": null, "errors": [...] }` body (e.g. a permission
+/// or transient error) or a `pullRequest: null` (PR not resolved for this token)
+/// would otherwise deserialize into an empty thread list and wave an unreviewed PR
+/// straight through to merge (issue #270). Both now return an error, which the
+/// caller maps to `ReviewState::Unknown` so the PR waits and re-checks rather than
+/// merging on a guess. Pure (no I/O) so the fail-closed logic is unit-tested.
+///
+/// # Errors
+/// If the response carries GraphQL `errors`, or does not contain the pull request.
+fn review_status_from_response(
+    response: ReviewThreadsResponse,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> Result<PrReviewStatus> {
+    if !response.errors.is_empty() {
+        let messages = response
+            .errors
+            .iter()
+            .map(|error| error.message.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(eyre!(
+            "review-status query for {owner}/{repo}#{number} returned GraphQL errors: {messages}"
+        ));
+    }
+
+    // A missing pull request means we could not read the review state, NOT that the
+    // PR is clean. Refuse to assume zero threads so the gate never merges blind.
+    let Some(pull) = response
         .data
         .and_then(|data| data.repository)
-        .and_then(|repository| repository.pull_request);
+        .and_then(|repository| repository.pull_request)
+    else {
+        return Err(eyre!(
+            "review-status query for {owner}/{repo}#{number} returned no pull request; \
+             refusing to assume zero unresolved threads"
+        ));
+    };
 
     // Gate only on an outstanding "changes requested". "Approved" and the
     // "review required" approval gate are deliberately not merge blockers here:
     // resolution state, not approval, is what the gate enforces.
-    let changes_requested = pull
-        .as_ref()
-        .and_then(|pull| pull.review_decision.as_deref())
-        == Some("CHANGES_REQUESTED");
-
-    let nodes = pull
-        .map(|pull| pull.review_threads.nodes)
-        .unwrap_or_default();
+    let changes_requested = pull.review_decision.as_deref() == Some("CHANGES_REQUESTED");
 
     let mut unresolved_threads = Vec::new();
-    for node in nodes {
+    for node in pull.review_threads.nodes {
         if node.is_resolved {
             continue;
         }
@@ -373,6 +409,17 @@ pub async fn pr_review_status(
 #[derive(Debug, Deserialize)]
 struct ReviewThreadsResponse {
     data: Option<ReviewThreadsData>,
+    /// GraphQL field-level errors. Present (with `data` null or partial) on a
+    /// permission/transient failure, which GitHub still returns as HTTP 200, so the
+    /// gate must inspect this rather than treat the absent data as "no threads".
+    #[serde(default)]
+    errors: Vec<GraphQlError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQlError {
+    #[serde(default)]
+    message: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -987,7 +1034,120 @@ pub async fn add_issue_comment(
 
 #[cfg(test)]
 mod tests {
-    use super::strip_log_timestamp;
+    use super::{review_status_from_response, strip_log_timestamp, ReviewThreadsResponse};
+    use serde_json::{from_value, json};
+
+    fn response(value: serde_json::Value) -> ReviewThreadsResponse {
+        from_value(value).expect("review-status payload should deserialize")
+    }
+
+    fn unresolved_thread(id: &str) -> serde_json::Value {
+        json!({
+            "id": id,
+            "isResolved": false,
+            "comments": { "nodes": [{
+                "databaseId": 111,
+                "path": "src/init.ts",
+                "line": 10,
+                "originalLine": 10,
+                "body": "Consider extracting this.",
+                "author": { "login": "mooreslabai-claude" }
+            }]}
+        })
+    }
+
+    // Issue #270: GraphQL returns HTTP 200 even on field errors, so a body carrying
+    // `errors` (with data null) must NOT be read as "zero unresolved threads". It
+    // must fail closed so the caller waits rather than merging blind.
+    #[test]
+    fn graphql_errors_fail_closed() {
+        let result = review_status_from_response(
+            response(json!({ "data": null, "errors": [{ "message": "Something went wrong" }] })),
+            "mooreslabaiv1",
+            "frontend-core",
+            21,
+        );
+        assert!(
+            result.is_err(),
+            "GraphQL errors must not be treated as a clean PR"
+        );
+    }
+
+    // A `pullRequest: null` means we could not read the review state, not that the
+    // PR is clean; refuse to assume zero threads.
+    #[test]
+    fn missing_pull_request_fails_closed() {
+        let result = review_status_from_response(
+            response(json!({ "data": { "repository": { "pullRequest": null } } })),
+            "mooreslabaiv1",
+            "frontend-core",
+            21,
+        );
+        assert!(
+            result.is_err(),
+            "a missing pull request must not be treated as clean"
+        );
+    }
+
+    // The exact PR #21 regression: the bot COMMENTED (creating unresolved threads)
+    // then APPROVED, so `reviewDecision` is APPROVED. Approval must NOT clear the
+    // unresolved threads; they are still reported so the gate blocks the merge.
+    #[test]
+    fn unresolved_threads_are_reported_even_when_approved() {
+        let status = review_status_from_response(
+            response(json!({ "data": { "repository": { "pullRequest": {
+                "reviewDecision": "APPROVED",
+                "reviewThreads": { "nodes": [
+                    unresolved_thread("T1"),
+                    unresolved_thread("T2"),
+                    unresolved_thread("T3"),
+                    unresolved_thread("T4"),
+                ]}
+            }}}})),
+            "mooreslabaiv1",
+            "frontend-core",
+            21,
+        )
+        .expect("a well-formed response should parse");
+        assert_eq!(status.unresolved_threads.len(), 4);
+        assert!(!status.changes_requested);
+    }
+
+    // Resolved threads under an approval are genuinely clean and may merge.
+    #[test]
+    fn all_resolved_threads_are_clean() {
+        let mut resolved = unresolved_thread("T1");
+        resolved["isResolved"] = json!(true);
+        let status = review_status_from_response(
+            response(json!({ "data": { "repository": { "pullRequest": {
+                "reviewDecision": "APPROVED",
+                "reviewThreads": { "nodes": [resolved] }
+            }}}})),
+            "mooreslabaiv1",
+            "frontend-core",
+            21,
+        )
+        .expect("a well-formed response should parse");
+        assert!(status.unresolved_threads.is_empty());
+        assert!(!status.changes_requested);
+    }
+
+    // A standing "changes requested" review blocks even with no inline threads.
+    #[test]
+    fn changes_requested_is_flagged() {
+        let status = review_status_from_response(
+            response(json!({ "data": { "repository": { "pullRequest": {
+                "reviewDecision": "CHANGES_REQUESTED",
+                "reviewThreads": { "nodes": [] }
+            }}}})),
+            "mooreslabaiv1",
+            "frontend-core",
+            21,
+        )
+        .expect("a well-formed response should parse");
+        assert!(status.unresolved_threads.is_empty());
+        assert!(status.changes_requested);
+    }
 
     #[test]
     fn strips_the_leading_iso_timestamp() {


### PR DESCRIPTION
Reopens/finishes #270. The earlier fix (PR #277) did not hold: `mooreslabaiv1/frontend-core` PR #21 merged again with 4 unresolved review threads after the bot COMMENTED then APPROVED.

## Root cause: the review fetch failed OPEN

`git::pr_review_status` calls `octocrab.graphql::<ReviewThreadsResponse>(...)`. In octocrab 0.41.2, `graphql<R>` just deserializes the HTTP response body into `R` with no inspection of the GraphQL `errors` array, and **GraphQL returns HTTP 200 even on field-level errors**. Our response struct only had `data: Option<...>`, so:

- a `{"data": null, "errors": [...]}` body (permission/transient error), or
- a `{"data": {"repository": {"pullRequest": null}}}` body (PR not resolved for this token),

both deserialized into an **empty thread list**. That read as "zero unresolved threads" → `ReviewState::Clean` → **merge**, no matter how many threads were actually open. Because the bot's APPROVAL set `reviewDecision: APPROVED` (not `CHANGES_REQUESTED`), nothing else blocked either. So approval was effectively trusted whenever the thread fetch silently came back empty.

This is why it merged "as soon as CI went green regardless of unresolved threads": the gate believed there were none.

## Fix: fail CLOSED

`pr_review_status` now refuses to assume a clean PR from a response it cannot positively read:

- Parse the GraphQL `errors` array; if present → return `Err`.
- If `data`/`repository`/`pullRequest` is absent → return `Err` (do not assume zero threads).

`pr_review_state` already maps `Err` → `ReviewState::Unknown`, and `review::decide` already treats `Unknown` as **wait and re-check, never merge**. So an unreadable review state can no longer wave a PR through.

The envelope interpretation is extracted into a pure `review_status_from_response(...)` and locked with unit tests, including the exact PR #21 regression:

- `graphql_errors_fail_closed` - `errors` present → `Err` (not "clean").
- `missing_pull_request_fails_closed` - null `pullRequest` → `Err`.
- `unresolved_threads_are_reported_even_when_approved` - `reviewDecision: APPROVED` + 4 unresolved threads → still 4 threads reported, so the gate blocks.
- `all_resolved_threads_are_clean`, `changes_requested_is_flagged`.

## Acceptance criteria

- A PR with unresolved threads is NEVER squash-merged; an unreadable status no longer counts as clean. ✓
- Gate is exactly CI green AND zero unresolved threads AND no changes-requested; approval alone never merges. ✓
- Bots that COMMENT-then-APPROVE no longer slip through (the regression test asserts this). ✓
- Bounded retries + park-for-human and the addressing loop are unchanged from #277. ✓

## Operational note

If a deployment's token genuinely cannot read the GraphQL `reviewThreads`/`reviewDecision` for a repo, PRs there will now **sit in review without merging** (the safe failure) rather than merging unreviewed, and the cause is logged (`could not read review status; will re-check before merging`). That surfaces a token/permission gap as "stops merging" instead of "merges unreviewed", which is the correct posture for #270. Documented in CLAUDE.md.

## Verification

- `cargo +1.88 fmt --check` clean; full suite **153/153 pass** (5 new git tests); no new clippy warnings. No DB migration.