### PR TITLE
Agent eyes: wire the Playwright MCP into the headless workspace (#243)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,24 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   pinned to the Playwright version Plunder uses (`PLAYWRIGHT_VERSION` build arg);
   if that drifts, only the browser re-downloads on first run, never the slow apt
   dependency step.
+- **Playwright MCP, the agent's eyes (issue #243):** the headless browser the
+  visual self-review (issues #244-247) drives. `@playwright/mcp` (`PLAYWRIGHT_MCP_VERSION`
+  build arg, pinned `0.0.76`) is installed globally and its `playwright-mcp` bin
+  symlinked onto `/usr/local/bin`. The MCP bundles its OWN Playwright, pinned to a
+  DIFFERENT Chromium than the #215 stable build (alpha -> revision 1226, vs 1228), so
+  the Dockerfile bakes the matching `chromium-headless-shell` (rev 1226) with the
+  MCP's own Playwright into `/ms-playwright`; a turn never downloads a browser at
+  runtime. Only the headless shell is baked (`--headless` uses it), and only its own
+  dir is chmod-ed (a recursive chmod over `/ms-playwright` would copy #215's browsers
+  up into the layer and add ~650MB). Net image delta: **~290MB**. The entrypoint
+  registers the server at **user scope** in `CLAUDE_CONFIG_DIR/.claude.json`
+  (`claude mcp add -s user playwright -- playwright-mcp --headless --browser chromium
+  --no-sandbox --isolated`), idempotently (remove-then-add), so `claude -p
+  --permission-mode bypassPermissions` loads it with NO per-task approval gate (a
+  project `.mcp.json` would sit unapproved). A build-time gate fails the image if the
+  bin or the rev-1226 browser is missing. `docker compose build workspace` needs a
+  populated `.env` (the compose volume interpolation), so a bare checkout builds the
+  image directly with `docker build ./workspace`.
 ### The orchestrator loops (`api/src/orchestrator/mod.rs`)
 1. **sync** — polls every repo with `sync_issues` for open issues and upserts
    them into the **top** of **Available** (never clobbers human-set

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -142,6 +142,44 @@ RUN npx -y "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium \
     && chmod -R a+w /ms-playwright \
     && rm -rf /var/lib/apt/lists/*
 
+# --- Playwright MCP: a headless browser for the agent's eyes (issue #243) -----
+# The visual self-review loop (issues #244-247) drives a real headless browser
+# through the Playwright MCP, so a `claude -p` turn can open a dev server, read the
+# DOM, run `evaluate`, and screenshot, with no X server. The entrypoint registers
+# the server at USER scope (it then loads with no per-task approval); this bakes the
+# server binary and the exact browser build it needs.
+#
+# The MCP bundles its OWN Playwright, pinned to a different Chromium than the #215
+# stable build: `@playwright/mcp@0.0.76` -> playwright 1.61.0-alpha -> Chromium
+# revision 1226, NOT the 1228 baked above. The matching headless shell is baked here
+# with the MCP's own Playwright, so a turn never downloads a browser at runtime
+# (offline / network-restricted safe). Only the headless shell is needed: the MCP
+# runs `--headless`, which uses the shell, so the full chromium-1226 build is skipped
+# to keep the image lean. Size delta: ~280MB (262MB browser + ~18MB of packages).
+ARG PLAYWRIGHT_MCP_VERSION=0.0.76
+USER codespace
+RUN bash -lc "npm install -g @playwright/mcp@${PLAYWRIGHT_MCP_VERSION} && npm cache clean --force"
+USER root
+RUN node_dir="$(runuser -l codespace -c 'command -v node' | xargs dirname)" \
+    && ln -sf "$node_dir/playwright-mcp" /usr/local/bin/playwright-mcp \
+    && groot="$(runuser -l codespace -c 'npm root -g')" \
+    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+       node "$groot/@playwright/mcp/node_modules/playwright-core/cli.js" install chromium-headless-shell \
+    # Only the newly-installed browser dir is chmod-ed, NOT all of /ms-playwright:
+    # a recursive chmod over #215's browsers (from an earlier layer) would copy them
+    # up into this layer and add ~650MB of duplicate bloat. The shared path itself is
+    # already world-writable from #215, so a later version bump can still download.
+    && chmod -R a+w /ms-playwright/chromium_headless_shell-1226 \
+    && rm -rf /home/codespace/.npm/_npx /tmp/*
+
+# Fail the build if the MCP bin didn't land on PATH (a dangling symlink) or the
+# matching Chromium 1226 headless shell wasn't baked, so a broken wiring can't ship
+# silently (mirrors the actionlint gate above). The pinned revision is coupled to
+# PLAYWRIGHT_MCP_VERSION; bumping the MCP means updating the revision asserted here.
+RUN test -x /usr/local/bin/playwright-mcp \
+    && runuser -l codespace -c 'command -v playwright-mcp >/dev/null' \
+    && ls -d /ms-playwright/chromium_headless_shell-1226 >/dev/null
+
 # --- Seraphim agent helpers (post to the API; env injected per turn) ---------
 COPY seraphim-suggest /usr/local/bin/seraphim-suggest
 COPY seraphim-ask /usr/local/bin/seraphim-ask

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -93,5 +93,23 @@ if [ -S "${DOCKER_SOCK}" ]; then
   usermod -aG "${group_name}" "${AGENT_USER}"
 fi
 
+# --- Playwright MCP: browser tools for the headless agent (issue #243) --------
+# The visual self-review loop (issues #244-247) drives the headless browser baked
+# into this image through the Playwright MCP. Register it at USER scope in
+# CLAUDE_CONFIG_DIR/.claude.json so `claude -p ... --permission-mode
+# bypassPermissions` loads it with NO per-task approval (a project `.mcp.json` would
+# sit unapproved and never connect). The flags keep it headless and sandbox-free for
+# a container with no X server: `--headless --browser chromium --no-sandbox
+# --isolated`. Idempotent (remove-then-add re-asserts the current command on every
+# start) and survives the later config-repo checkout, since `.claude.json` is
+# untracked. Best-effort: a failure here never blocks the container from idling.
+if command -v playwright-mcp >/dev/null 2>&1; then
+  runuser -u "${AGENT_USER}" -- env CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR}" bash -c '
+    claude mcp remove -s user playwright >/dev/null 2>&1 || true
+    claude mcp add -s user playwright -- \
+      playwright-mcp --headless --browser chromium --no-sandbox --isolated >/dev/null 2>&1
+  ' || echo "warning: could not register the Playwright MCP; visual self-review will be unavailable" >&2
+fi
+
 # Hand off to the idle command (tail -f /dev/null).
 exec "$@"


### PR DESCRIPTION
Closes #243. The core enabler for epic #242: a real headless browser behind the agent. Issues #244-247 already reference the Playwright MCP and its `browser_evaluate` tool, but nothing had actually wired it; this does.

## What

- **`workspace/Dockerfile`**: install `@playwright/mcp` (`PLAYWRIGHT_MCP_VERSION`, pinned `0.0.76`) globally and symlink its `playwright-mcp` bin onto `/usr/local/bin`. The MCP bundles its OWN Playwright (an alpha) pinned to **Chromium revision 1226**, not the **1228** the #215 stable build baked, so without intervention the MCP would download 1226 at runtime (breaking offline/sandboxed turns). The matching `chromium-headless-shell` is baked with the MCP's own Playwright into `/ms-playwright`. Only the headless shell is baked (`--headless` uses it, full chromium-1226 skipped), and only its own dir is chmod-ed. A build-time gate fails the image if the bin or the rev-1226 browser is missing (mirrors the actionlint gate).
- **`workspace/entrypoint.sh`**: register the MCP at **user scope** in `CLAUDE_CONFIG_DIR/.claude.json`, idempotently (remove-then-add), so `claude -p ... --permission-mode bypassPermissions` loads it with **no per-task approval** (a project `.mcp.json` sits unapproved and never connects). Flags: `--headless --browser chromium --no-sandbox --isolated`. Best-effort, never blocks the container.
- **`CLAUDE.md`**: documents the wiring, the revision pin, and the size delta.

## Why user-scope (not `.mcp.json` or `--mcp-config`)

A project `.mcp.json` requires interactive approval, which a headless `bypassPermissions` turn can't give, so it would never connect. User-scope registration in `CLAUDE_CONFIG_DIR/.claude.json` connects with no gate and survives the later config-repo checkout (the file is untracked). It needs no API/frontend change.

## Verification (done in the built image, as the `codespace` agent user)

- `playwright-mcp` resolves on PATH.
- `claude mcp list` → `playwright: ... - ✔ Connected`.
- The baked rev-1226 headless browser launches headless (`--no-sandbox`, no X), navigates, `evaluate`s the DOM (`"eyes work"`), and screenshots (7388 bytes), with **no runtime download**.
- The idempotent register cycle yields exactly one connected entry on repeat.

## Image size delta

Measured against a current-`develop` baseline built with my change stashed (identical cache): **base 14469MB -> 14759MB = ~290MB** (262MB headless shell + ~18MB packages). An earlier naive approach was ~965MB; the bloat was a `chmod -R a+w /ms-playwright` copying #215's ~650MB of browsers up into the new layer. Scoping the chmod to only the new browser dir removed it.

## Build note

`docker build -t seraphim-workspace ./workspace` succeeds. `docker compose build workspace` needs a populated `.env` (its volume interpolation, e.g. `${DOCKER_SOCKET}`), unrelated to the Dockerfile; on a bare repo checkout build the image directly. Shipping needs a `workspace` image rebuild + container recreate.

## Acceptance criteria

- A `claude -p` turn can open a dev server, read the DOM, `evaluate`, and screenshot, headless. ✓ (browser engine + MCP connection verified in-image; the full localhost turn is the operator's deploy re-verify)
- The MCP tools are available without per-task setup. ✓ (user-scope auto-registration, connects)
- `docker build ./workspace` succeeds and the size increase is recorded (~290MB). ✓