### PR TITLE
Agent eyes: capture screenshots, store in Postgres, render on the task (#248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,19 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and
   surfaced as toasts + native notifications + a sidebar.
+- **`task_screenshots`** (issue #248) — screenshots the agent captured during a
+  task (via the Playwright MCP, issue #243), so the operator sees what the agent
+  saw. The agent's `seraphim-screenshot <file>` helper POSTs the raw image bytes to
+  `POST /agent/screenshots` (Content-Type = MIME, metadata as query params:
+  `task_id`, `caption`, `route`, `width`/`height`); the capture is best-effort
+  associated with the task's latest turn (`turn_id`). The bytes live as `bytea`
+  following the notification-sound precedent and are NEVER returned in task/board
+  JSON: a dedicated `GET /screenshots/:id` streams them (immutable cache), and
+  `TaskDetail.screenshots` carries metadata only. The task view renders them as a
+  lazy-loaded gallery (newest first, caption / route / dimensions; click opens the
+  full image). Privacy: dev/test-data screenshots only, since the bytes persist in
+  Postgres (respect at-rest disk encryption as with the other blobs/secrets). The
+  optional GitHub-issue/PR attachment toggle is not built yet (left to a follow-up).
 - **`heart_attacks`** — recorded "heart attacks" (turns that died mid-flight),
   written by the defibrillator loop (see above), never by a request. Each holds a
   task snapshot, the status at death, the diagnostic `detail` (error logs kept for
@@ -344,9 +357,10 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    `waiting_for_input` if the agent asked a question), then (f) when nothing else is
    queued, *revisit* a PR it gave up on (`ci_blocked`), cooldown-gated
    (`REVISIT_COOLDOWN`, 15 min). The agent
-   asks via the `seraphim-ask` CLI and records environment recommendations via the
-   `seraphim-suggest` CLI (both baked into the workspace image), posting to
-   `POST /agent/questions` and `POST /agent/suggestions`; the exec injects
+   asks via the `seraphim-ask` CLI, records environment recommendations via the
+   `seraphim-suggest` CLI, and uploads screenshots via the `seraphim-screenshot`
+   CLI (all baked into the workspace image), posting to `POST /agent/questions`,
+   `POST /agent/suggestions`, and `POST /agent/screenshots`; the exec injects
    `SERAPHIM_TASK_ID` + `SERAPHIM_API_URL`. One task awaited to completion before
    the next (no overlap).
    - **Stacked dependencies (issue #256):** a fresh ticket that depends on another

--- a/api/migrations/0043_task_screenshots.sql
+++ b/api/migrations/0043_task_screenshots.sql
@@ -1,0 +1,30 @@
+-- Agent screenshots (issue #248). During a task the agent captures what it sees
+-- in a real browser (via the Playwright MCP, issue #243) and uploads each image
+-- with the `seraphim-screenshot` helper, so the operator can see what the agent
+-- saw without rebuilding the workspace state.
+--
+-- The bytes live here as `bytea`, following the notification-sound precedent
+-- (#58): they are NEVER returned in task/board JSON (a dedicated endpoint streams
+-- them by id); list payloads carry only the metadata. The images are
+-- operator-facing but still live in Postgres, so respect at-rest disk encryption
+-- as with the other binary blobs and secret columns.
+CREATE TABLE task_screenshots (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id    UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    -- Best-effort association with the turn that captured it (the latest turn at
+    -- upload time). SET NULL if that turn is later pruned, so the screenshot
+    -- history outlives any single turn.
+    turn_id    UUID REFERENCES turns(id) ON DELETE SET NULL,
+    image      BYTEA NOT NULL,
+    mime       TEXT NOT NULL,
+    -- Pixel dimensions when the uploader could determine them (e.g. a PNG header),
+    -- so the gallery can reserve layout space; NULL when unknown.
+    width      INTEGER,
+    height     INTEGER,
+    route      TEXT NOT NULL DEFAULT '',
+    caption    TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The task view lists a task's screenshots newest first.
+CREATE INDEX task_screenshots_task_idx ON task_screenshots (task_id, created_at DESC);

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -606,6 +606,24 @@ pub struct TaskPullRequest {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A screenshot the agent captured during a task (issue #248), as the API exposes
+/// it: metadata only. The `image` bytea column is deliberately NOT a field here, so
+/// it never rides along in a task/board payload; a dedicated endpoint streams the
+/// bytes by id. `width`/`height` are `None` when the uploader could not determine
+/// them, and `turn_id` is `None` once the capturing turn has been pruned.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct TaskScreenshot {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub turn_id: Option<Uuid>,
+    pub mime: String,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub route: String,
+    pub caption: String,
+    pub created_at: DateTime<Utc>,
+}
+
 /// One Claude Code invocation against a task.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
 pub struct Turn {

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -16,7 +16,8 @@ use super::models::{
     EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment,
     NetworkAccessLevel, PendingPlacement, PendingQuestion, Question, QuestionOption,
     QuestionStatus, Railway, RepoDeletionImpact, RepoSyncError, Repository, ReviewPolicy, Settings,
-    SourceKind, StatsAggregate, Task, TaskColumn, TaskPullRequest, TaskStatus, Turn,
+    SourceKind, StatsAggregate, Task, TaskColumn, TaskPullRequest, TaskScreenshot, TaskStatus,
+    Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -2194,6 +2195,80 @@ pub async fn list_open_dependency_candidates(
     .bind(exclude_id)
     .fetch_all(pool)
     .await
+}
+
+// --- Agent screenshots (issue #248) ------------------------------------------
+
+/// The screenshot metadata columns, every column EXCEPT the `image` bytea, so a
+/// `SELECT` for a list or RETURNING never drags the bytes into a JSON payload.
+const SCREENSHOT_COLUMNS: &str =
+    "id, task_id, turn_id, mime, width, height, route, caption, created_at";
+
+/// Stores one captured screenshot and returns its metadata (never the bytes).
+/// `turn_id` best-effort associates it with the turn that captured it; `width` /
+/// `height` are `None` when the uploader could not determine them.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_screenshot(
+    pool: &PgPool,
+    task_id: Uuid,
+    turn_id: Option<Uuid>,
+    image: &[u8],
+    mime: &str,
+    width: Option<i32>,
+    height: Option<i32>,
+    route: &str,
+    caption: &str,
+) -> sqlx::Result<TaskScreenshot> {
+    sqlx::query_as::<_, TaskScreenshot>(&format!(
+        "INSERT INTO task_screenshots \
+         (task_id, turn_id, image, mime, width, height, route, caption) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING {SCREENSHOT_COLUMNS}"
+    ))
+    .bind(task_id)
+    .bind(turn_id)
+    .bind(image)
+    .bind(mime)
+    .bind(width)
+    .bind(height)
+    .bind(route)
+    .bind(caption)
+    .fetch_one(pool)
+    .await
+}
+
+/// A task's screenshots, newest first, metadata only (the bytes are streamed by id).
+pub async fn list_screenshots_for_task(
+    pool: &PgPool,
+    task_id: Uuid,
+) -> sqlx::Result<Vec<TaskScreenshot>> {
+    sqlx::query_as::<_, TaskScreenshot>(&format!(
+        "SELECT {SCREENSHOT_COLUMNS} FROM task_screenshots \
+         WHERE task_id = $1 ORDER BY created_at DESC"
+    ))
+    .bind(task_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// The raw bytes and MIME of one screenshot, for the streaming endpoint. `None`
+/// when no screenshot has that id.
+pub async fn get_screenshot_image(
+    pool: &PgPool,
+    id: Uuid,
+) -> sqlx::Result<Option<(Vec<u8>, String)>> {
+    sqlx::query_as::<_, (Vec<u8>, String)>("SELECT image, mime FROM task_screenshots WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+}
+
+/// The id of a task's most recent turn, to associate an uploaded screenshot with
+/// the turn that captured it. `None` for a task that has no turns yet.
+pub async fn latest_turn_id(pool: &PgPool, task_id: Uuid) -> sqlx::Result<Option<Uuid>> {
+    sqlx::query_scalar("SELECT id FROM turns WHERE task_id = $1 ORDER BY idx DESC LIMIT 1")
+        .bind(task_id)
+        .fetch_optional(pool)
+        .await
 }
 
 /// Every pull request tracked for a task, oldest first.

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -14,6 +14,7 @@ mod notepad;
 mod questions;
 mod railways;
 mod repos;
+mod screenshots;
 mod settings;
 mod sse;
 mod stats;
@@ -104,6 +105,15 @@ pub fn router(state: AppState) -> Router {
         .route("/agent/suggestions", post(suggestions::create))
         .route("/suggestions/:id/ack", post(suggestions::acknowledge))
         .route("/suggestions/:id/create", post(suggestions::create_issue))
+        // Agent screenshots (issue #248): the raw image is the request body, so the
+        // upload route raises axum's 2MB default body limit to the screenshot cap.
+        .route(
+            "/agent/screenshots",
+            post(screenshots::create).layer(axum::extract::DefaultBodyLimit::max(
+                screenshots::MAX_SCREENSHOT_BYTES,
+            )),
+        )
+        .route("/screenshots/:id", get(screenshots::serve))
         .route("/agent/questions", post(questions::ask))
         .route("/questions/pending", get(questions::pending))
         .route("/questions/:id/answer", post(questions::answer))

--- a/api/src/http/screenshots.rs
+++ b/api/src/http/screenshots.rs
@@ -1,0 +1,121 @@
+//! Agent screenshots (issue #248): capture, store, and serve the images the agent
+//! takes during a task.
+//!
+//! The `seraphim-screenshot` helper inside the workspace uploads the raw image
+//! bytes (the request body) plus metadata (query params). The bytes live as
+//! `bytea` and are NEVER returned in a task/board payload, mirroring the
+//! notification-sound precedent; a dedicated streaming endpoint serves them by id,
+//! and the task view lists only the metadata (see [`super::tasks::TaskDetail`]).
+
+use axum::body::Bytes;
+use axum::extract::{Path, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::ApiResult;
+use crate::db::queries;
+use crate::state::AppState;
+
+/// The largest screenshot we accept. A full-page 1280px PNG sits comfortably under
+/// this; the cap bounds a runaway upload while leaving real captures headroom. The
+/// upload route raises axum's default 2MB body limit to this (see `http::router`).
+pub const MAX_SCREENSHOT_BYTES: usize = 10 * 1024 * 1024;
+
+/// Metadata the uploader passes as query params alongside the raw image body.
+#[derive(Debug, Deserialize)]
+pub struct CreateParams {
+    pub task_id: Uuid,
+    #[serde(default)]
+    pub caption: String,
+    #[serde(default)]
+    pub route: String,
+    /// Pixel dimensions, when the uploader could read them (e.g. a PNG header).
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+}
+
+/// `POST /api/v1/agent/screenshots?task_id=..&caption=..&route=..&width=..&height=..`
+///
+/// Called from inside the workspace by `seraphim-screenshot`. The raw image is the
+/// request body and its `Content-Type` becomes the stored MIME; it must be an
+/// `image/*` type. The capture is best-effort associated with the task's latest
+/// turn. Returns the new screenshot's id.
+pub async fn create(
+    State(state): State<AppState>,
+    Query(params): Query<CreateParams>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> ApiResult<Response> {
+    if queries::get_task(&state.db, params.task_id)
+        .await?
+        .is_none()
+    {
+        return Ok((StatusCode::NOT_FOUND, "task not found").into_response());
+    }
+    if body.is_empty() {
+        return Ok((StatusCode::BAD_REQUEST, "empty image").into_response());
+    }
+    if body.len() > MAX_SCREENSHOT_BYTES {
+        return Ok((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "screenshot is too large (max 10 MB)",
+        )
+            .into_response());
+    }
+    let mime = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    if !mime.starts_with("image/") {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "body must be an image (set Content-Type: image/...)",
+        )
+            .into_response());
+    }
+
+    // Best-effort: tie the capture to the turn that most likely took it.
+    let turn_id = queries::latest_turn_id(&state.db, params.task_id).await?;
+    let screenshot = queries::create_screenshot(
+        &state.db,
+        params.task_id,
+        turn_id,
+        &body,
+        mime,
+        params.width,
+        params.height,
+        params.route.trim(),
+        params.caption.trim(),
+    )
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(json!({ "id": screenshot.id }))).into_response())
+}
+
+/// `GET /api/v1/screenshots/:id` - stream a stored screenshot's bytes. A screenshot
+/// is immutable once stored, so it caches aggressively. 404 when the id is unknown.
+pub async fn serve(State(state): State<AppState>, Path(id): Path<Uuid>) -> ApiResult<Response> {
+    let Some((image, mime)) = queries::get_screenshot_image(&state.db, id).await? else {
+        return Ok((StatusCode::NOT_FOUND, "screenshot not found").into_response());
+    };
+    let content_type = if mime.is_empty() {
+        "application/octet-stream".to_string()
+    } else {
+        mime
+    };
+    Ok((
+        [
+            (header::CONTENT_TYPE, content_type),
+            (
+                header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable".to_string(),
+            ),
+        ],
+        image,
+    )
+        .into_response())
+}

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use super::ApiResult;
 use crate::db::models::{
-    EnvSuggestion, Event, Question, SourceKind, Task, TaskColumn, TaskPullRequest,
+    EnvSuggestion, Event, Question, SourceKind, Task, TaskColumn, TaskPullRequest, TaskScreenshot,
 };
 use crate::db::queries;
 use crate::git;
@@ -59,10 +59,13 @@ pub struct TaskDetail {
     /// Every pull request the task has opened, across all repos it spans. The
     /// review loop gates Done on all of them passing CI and merging.
     pub pull_requests: Vec<TaskPullRequest>,
+    /// Screenshots the agent captured during the task (issue #248), newest first,
+    /// metadata only; the bytes stream from `/screenshots/:id`.
+    pub screenshots: Vec<TaskScreenshot>,
 }
 
 /// `GET /api/v1/tasks/:id` - the card, its conversation events, its environment
-/// suggestions, its escalated questions, and its pull requests.
+/// suggestions, its escalated questions, its pull requests, and its screenshots.
 pub async fn get_task(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -78,12 +81,14 @@ pub async fn get_task(
     let suggestions = queries::list_suggestions_for_task(&state.db, id).await?;
     let questions = queries::list_questions_for_task(&state.db, id).await?;
     let pull_requests = queries::list_task_prs(&state.db, id).await?;
+    let screenshots = queries::list_screenshots_for_task(&state.db, id).await?;
     Ok(Json(TaskDetail {
         task,
         events,
         suggestions,
         questions,
         pull_requests,
+        screenshots,
     })
     .into_response())
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -529,12 +529,28 @@ export type TaskPullRequest = {
   updated_at: string
 }
 
+// A screenshot the agent captured during a task (issue #248), metadata only. The
+// image bytes are streamed from `/api/v1/screenshots/:id`, never inlined here.
+export type TaskScreenshot = {
+  id: string
+  task_id: string
+  turn_id: string | null
+  mime: string
+  // Pixel dimensions when known (e.g. read from a PNG header), else null.
+  width: number | null
+  height: number | null
+  route: string
+  caption: string
+  created_at: string
+}
+
 export type TaskDetail = {
   task: Task
   events: AgentEvent[]
   suggestions: EnvSuggestion[]
   questions: Question[]
   pull_requests: TaskPullRequest[]
+  screenshots: TaskScreenshot[]
 }
 
 // The kanban lanes, in display order, with human-readable labels.

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -6,7 +6,8 @@
     Question,
     Repository,
     Task,
-    TaskPullRequest
+    TaskPullRequest,
+    TaskScreenshot
   } from '$lib/types'
 
   import { onMount, onDestroy, tick } from 'svelte'
@@ -15,6 +16,7 @@
   import { goto } from '$app/navigation'
   import {
     Ban,
+    Camera,
     ChevronDown,
     ExternalLink,
     GitPullRequest,
@@ -65,6 +67,7 @@
   let suggestions = $state<EnvSuggestion[]>([])
   let questions = $state<Question[]>([])
   let pullRequests = $state<TaskPullRequest[]>([])
+  let screenshots = $state<TaskScreenshot[]>([])
   let eventSource: EventSource | null = null
 
   // Target-repo picker, shown only for internal tickets (a GitHub task's repo is
@@ -320,6 +323,7 @@
     suggestions = detail.suggestions
     questions = detail.questions
     pullRequests = detail.pull_requests
+    screenshots = detail.screenshots
     // Seed the notepad once, and open it if there is already something to read.
     if (!notesInitialized) {
       notes = detail.task.notes
@@ -610,6 +614,54 @@
             </li>
           {/each}
         </ul>
+      </section>
+    {/if}
+
+    {#if screenshots.length}
+      <!-- Screenshots the agent captured during the task (issue #248), newest
+           first. The bytes stream from a dedicated endpoint and are lazy-loaded,
+           so a long gallery stays cheap; the metadata rides in the task payload but
+           the bytes only load when a thumbnail scrolls into view. Click one to open
+           the full image. -->
+      <section class="rounded-lg border border-border bg-card p-3">
+        <h2 class="flex items-center gap-1.5 text-sm font-semibold">
+          <Camera class="size-4 text-muted-foreground" />
+          Screenshots
+          <span class="text-xs font-normal text-muted-foreground">({screenshots.length})</span>
+        </h2>
+        <div class="mt-2 grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {#each screenshots as shot (shot.id)}
+            <figure class="min-w-0">
+              <a
+                href={`/api/v1/screenshots/${shot.id}`}
+                target="_blank"
+                rel="noreferrer"
+                class="block overflow-hidden rounded border border-border hover:border-primary"
+                title="Open full screenshot"
+              >
+                <img
+                  src={`/api/v1/screenshots/${shot.id}`}
+                  alt={shot.caption || shot.route || 'agent screenshot'}
+                  loading="lazy"
+                  class="h-32 w-full bg-muted object-cover"
+                />
+              </a>
+              <figcaption class="mt-1 flex flex-col gap-0.5">
+                {#if shot.caption}
+                  <span class="truncate text-xs font-medium" title={shot.caption}>
+                    {shot.caption}
+                  </span>
+                {/if}
+                <span class="truncate text-[11px] text-muted-foreground">
+                  {#if shot.route}{shot.route}{/if}
+                  {#if shot.width && shot.height}
+                    <span>{shot.route ? ' · ' : ''}{shot.width}×{shot.height}</span>
+                  {/if}
+                </span>
+              </figcaption>
+            </figure>
+          {/each}
+        </div>
       </section>
     {/if}
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -148,9 +148,10 @@ COPY seraphim-ask /usr/local/bin/seraphim-ask
 COPY seraphim-comment /usr/local/bin/seraphim-comment
 COPY seraphim-state /usr/local/bin/seraphim-state
 COPY seraphim-draft /usr/local/bin/seraphim-draft
+COPY seraphim-screenshot /usr/local/bin/seraphim-screenshot
 RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
     /usr/local/bin/seraphim-comment /usr/local/bin/seraphim-state \
-    /usr/local/bin/seraphim-draft
+    /usr/local/bin/seraphim-draft /usr/local/bin/seraphim-screenshot
 
 # --- Computed-style check library for visual self-review (issue #245) ---------
 # The deterministic CSS checks (centering/spacing/overflow/stacking) the agent

--- a/workspace/seraphim-screenshot
+++ b/workspace/seraphim-screenshot
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// seraphim-screenshot: the agent stores a screenshot it captured during a task.
+//
+// During visual self-review (issues #243-247) the agent drives a real browser
+// through the Playwright MCP and writes screenshots to disk. This uploads one to
+// Seraphim so the operator can see what the agent saw, on the task view, without
+// rebuilding the workspace state. The image bytes are stored in Postgres and
+// streamed back by id; they never ride along in board/task JSON.
+//
+// Usage:
+//   seraphim-screenshot <image-file> [--caption "..."] [--route "/dashboard"]
+//
+// Only dev/test-data screenshots, please: the bytes persist in the database.
+
+const fs = require('fs')
+const path = require('path')
+
+const API_URL = process.env.SERAPHIM_API_URL
+const TASK_ID = process.env.SERAPHIM_TASK_ID
+
+function fail(message) {
+  console.error(`seraphim-screenshot: ${message}`)
+  process.exit(1)
+}
+
+// Parses `<file> [--caption text] [--route text]` into its pieces. The first
+// non-flag argument is the image path.
+function parseArgs(argv) {
+  const result = { file: null, caption: '', route: '' }
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '--caption') {
+      result.caption = argv[++index] ?? ''
+    } else if (arg === '--route') {
+      result.route = argv[++index] ?? ''
+    } else if (!result.file) {
+      result.file = arg
+    }
+  }
+  return result
+}
+
+// The image MIME, from the file's magic bytes first (most reliable), then its
+// extension. Returns null for something that is not a recognized image.
+function detectMime(buffer, file) {
+  if (buffer.length >= 8 && buffer.toString('latin1', 0, 8) === '\x89PNG\r\n\x1a\n') {
+    return 'image/png'
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg'
+  }
+  if (buffer.length >= 12 && buffer.toString('latin1', 0, 4) === 'RIFF' && buffer.toString('latin1', 8, 12) === 'WEBP') {
+    return 'image/webp'
+  }
+  if (buffer.length >= 6 && buffer.toString('latin1', 0, 6).startsWith('GIF8')) {
+    return 'image/gif'
+  }
+  const byExtension = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.webp': 'image/webp',
+    '.gif': 'image/gif'
+  }
+  return byExtension[path.extname(file).toLowerCase()] ?? null
+}
+
+// PNG width/height live in the IHDR chunk at fixed offsets, so they are cheap to
+// read without an image library. Returns {} for anything that is not a PNG.
+function pngDimensions(buffer, mime) {
+  if (mime !== 'image/png' || buffer.length < 24) {
+    return {}
+  }
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+}
+
+async function main() {
+  if (!API_URL || !TASK_ID) {
+    fail('SERAPHIM_API_URL and SERAPHIM_TASK_ID must be set (they are injected by the orchestrator)')
+  }
+
+  const { file, caption, route } = parseArgs(process.argv.slice(2))
+  if (!file) {
+    fail('no image file given (usage: seraphim-screenshot <image-file> [--caption "..."] [--route "/path"])')
+  }
+
+  let buffer
+  try {
+    buffer = fs.readFileSync(file)
+  } catch (error) {
+    fail(`could not read ${file}: ${error.message}`)
+  }
+  if (!buffer.length) {
+    fail(`${file} is empty`)
+  }
+
+  const mime = detectMime(buffer, file)
+  if (!mime) {
+    fail(`${file} is not a recognized image (expected PNG, JPEG, WebP, or GIF)`)
+  }
+
+  const query = new URLSearchParams({ task_id: TASK_ID })
+  if (caption.trim()) {
+    query.set('caption', caption.trim())
+  }
+  if (route.trim()) {
+    query.set('route', route.trim())
+  }
+  const { width, height } = pngDimensions(buffer, mime)
+  if (width && height) {
+    query.set('width', String(width))
+    query.set('height', String(height))
+  }
+
+  let response
+  try {
+    response = await fetch(`${API_URL}/api/v1/agent/screenshots?${query.toString()}`, {
+      method: 'POST',
+      headers: { 'content-type': mime },
+      body: buffer
+    })
+  } catch (error) {
+    fail(`could not reach the Seraphim API at ${API_URL}: ${error.message}`)
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    fail(`the API rejected the screenshot (HTTP ${response.status}): ${detail}`)
+  }
+
+  console.log(`Stored screenshot ${path.basename(file)} for the user to see on the task view.`)
+}
+
+main().catch((error) => fail(error.message))


### PR DESCRIPTION
Closes #248. Part of epic #242. This is the storage foundation the activity-feed thumbnails (#249) build on, spanning workspace + API + frontend.

## What

The agent captures what it sees mid-task (via the Playwright MCP, #243) and the operator views it on the task page without rebuilding workspace state.

- **`workspace/seraphim-screenshot`** (new helper, modeled on `seraphim-suggest`): `seraphim-screenshot <file> [--caption ..] [--route ..]` POSTs the image's raw bytes to the API. It detects the MIME from magic bytes (PNG/JPEG/WebP/GIF) and reads PNG dimensions from the IHDR header. Baked into the workspace image.
- **`POST /api/v1/agent/screenshots`**: the raw image is the request body (`Content-Type` -> stored MIME), metadata as query params (`task_id`, `caption`, `route`, `width`/`height`). This mirrors the notification-sound raw-`Bytes` upload, so **no axum `multipart` feature** is needed. The route raises axum's 2MB default body limit to 10MB. The capture is best-effort associated with the task's latest turn.
- **`task_screenshots` table** (migration `0043`): `bytea` image + metadata, following the notification-sound `bytea` precedent. The bytes are **never** selected into a list payload (a `SCREENSHOT_COLUMNS` list excludes `image`).
- **`GET /api/v1/screenshots/:id`**: streams the bytes with the stored MIME and an immutable cache header. `TaskDetail` gains a metadata-only `screenshots` list, so the bytes never ride along in task/board JSON.
- **Task view**: a lazy-loaded gallery (newest first; caption / route / dimensions; click opens the full image), refreshed via the existing task stream.
- **`CLAUDE.md`**: documents the table, helper, endpoints, and privacy note.

## Acceptance criteria

- The agent can call `seraphim-screenshot <file>` mid-task and the image is stored against the task and shows on the task view. ✓
- Image bytes are streamed from a dedicated endpoint and never included in board/task JSON. ✓ (metadata-only `TaskScreenshot`; `image` column never selected into a payload)
- (Optional, behind a toggle) attach to the GitHub issue/PR. **Deliberately deferred** to a follow-up; it is marked optional in the issue, and skipping keeps this PR focused on the storage foundation.
- cargo fmt / clippy / test and npm run check / build pass. ✓

## Verification

- `cargo +1.88 fmt --check` clean; clippy no new warnings; full suite **153/153** pass.
- Frontend `svelte-check` 0 errors / 0 warnings; `vite build` succeeds; `node --check` on the helper OK.
- Migration + the exact screenshot SQL (INSERT/RETURNING metadata, metadata-only list, byte+MIME fetch, `ON DELETE CASCADE`) exercised against an ephemeral Postgres 17.

## Notes

- Shipping needs all three rebuilt (workspace image for the helper, API, frontend). A server-side thumbnail/resize is not added here; the gallery sizes full images with CSS and lazy-loads them, so a long gallery stays cheap. #249 (live feed thumbnails) can add a resize variant if needed.