### PR TITLE
Follow-up work suggestions from the agent at the end of a task (#272)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,13 +170,22 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   squash-merge, an external merge/close found by the review refresh, a per-task
   reset close, and the issue-close-on-Done path). Both flow through the
   synthetic CI turn (`get_or_create_ci_turn`).
-- **`environment_suggestions`** — setup recommendations the agent makes after a
-  task (`title`, `detail`, `acknowledged`). Posted by the agent's
-  `seraphim-suggest` helper; shown loudly on the board and as checkboxes on the
-  task until the user acknowledges them. A split "Create issue" button
-  (`POST /suggestions/:id/create` with `target` internal/github/jira) turns one
-  into a tracked issue (internal task, a GitHub issue in the task's repo via
-  octocrab, or a Jira ticket) and marks the recommendation done.
+- **`environment_suggestions`** — recommendations the agent makes about a task
+  (`title`, `detail`, `acknowledged`, `kind`), of two kinds sharing one pipeline:
+  `environment` setup tips (the `seraphim-suggest` helper) and, at the end of a
+  task, `follow_up` work it noticed but kept out of scope (dead/duplicate code,
+  tech debt, an inefficient process, a missing security layer, a now-unused system
+  to deprecate; the `seraphim-followup` helper, issue #272). Both post to
+  `POST /agent/suggestions` (`kind` defaults to `environment`); both show loudly on
+  the board (one badge, count is kind-agnostic) and as checkboxes on the task,
+  split by kind ("Environment recommendations" / "Follow-up work"), until
+  acknowledged. A split "Create issue" button (`POST /suggestions/:id/create` with
+  `target` internal/github/jira) turns one into a tracked issue (internal task, a
+  GitHub issue in the task's repo via octocrab, or a Jira ticket) and marks it done.
+  Follow-ups get a light de-dup: a normalized-title check (`suggestions::already_queued`,
+  unit-tested) drops any whose title matches a task still on the board, so the agent
+  never re-recommends queued work. Both standing instructions live in the shared
+  prompt header (`ENVIRONMENT_SUGGESTIONS`, `FOLLOW_UP_SUGGESTIONS`).
 - **`questions`** — decisions the agent escalated to the user, stored on the task
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and
@@ -382,12 +391,12 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    `waiting_for_input` if the agent asked a question), then (f) when nothing else is
    queued, *revisit* a PR it gave up on (`ci_blocked`), cooldown-gated
    (`REVISIT_COOLDOWN`, 15 min). The agent
-   asks via the `seraphim-ask` CLI, records environment recommendations via the
-   `seraphim-suggest` CLI, and uploads screenshots via the `seraphim-screenshot`
-   CLI (all baked into the workspace image), posting to `POST /agent/questions`,
-   `POST /agent/suggestions`, and `POST /agent/screenshots`; the exec injects
-   `SERAPHIM_TASK_ID` + `SERAPHIM_API_URL`. One task awaited to completion before
-   the next (no overlap).
+   asks via the `seraphim-ask` CLI, records environment recommendations via
+   `seraphim-suggest`, bubbles up follow-up work via `seraphim-followup` (issue
+   #272), and uploads screenshots via `seraphim-screenshot` (all baked into the
+   workspace image), posting to `POST /agent/questions`, `POST /agent/suggestions`,
+   and `POST /agent/screenshots`; the exec injects `SERAPHIM_TASK_ID` +
+   `SERAPHIM_API_URL`. One task awaited to completion before the next (no overlap).
    - **Stacked dependencies (issue #256):** a fresh ticket that depends on another
      ticket whose PR is still open builds on a default branch that lacks that work.
      A `Depends on:` marker in the ticket body (e.g. `Depends on: A1 (package

--- a/api/migrations/0044_suggestion_kind.sql
+++ b/api/migrations/0044_suggestion_kind.sql
@@ -1,0 +1,12 @@
+-- Follow-up work suggestions (issue #272). The agent already records environment
+-- setup recommendations after a task; this adds a second KIND of suggestion: at
+-- the end of a task it can also bubble up follow-up work it noticed (cleanup, tech
+-- debt, dead/duplicate code, inefficient processes, security gaps, deprecations),
+-- which the operator reviews and one-clicks into a tracked issue, exactly like the
+-- setup suggestions.
+--
+-- Both kinds share this table and the whole ack / create-issue / board-badge /
+-- task-view pipeline; `kind` is the only discriminator. Existing rows are
+-- environment suggestions, so that is the default.
+ALTER TABLE environment_suggestions
+    ADD COLUMN kind TEXT NOT NULL DEFAULT 'environment';   -- 'environment' | 'follow_up'

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -653,13 +653,18 @@ pub struct Event {
     pub created_at: DateTime<Utc>,
 }
 
-/// A setup recommendation the agent made after finishing a task.
+/// A recommendation the agent made about a task: either an environment setup
+/// improvement or a piece of follow-up work it noticed (issue #272). Both kinds
+/// share this struct and the ack / create-issue pipeline; `kind` discriminates.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
 pub struct EnvSuggestion {
     pub id: Uuid,
     pub task_id: Uuid,
     pub title: String,
     pub detail: String,
+    /// `"environment"` (setup improvements) or `"follow_up"` (cleanup / tech debt /
+    /// dead code / security / deprecations the agent spotted while working).
+    pub kind: String,
     /// Checked off by the user; the board badge counts the unacknowledged ones.
     pub acknowledged: bool,
     pub created_at: DateTime<Utc>,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -2670,18 +2670,29 @@ pub async fn list_events_for_task(
 pub async fn create_suggestion(
     pool: &PgPool,
     task_id: Uuid,
+    kind: &str,
     title: &str,
     detail: &str,
 ) -> sqlx::Result<EnvSuggestion> {
     sqlx::query_as::<_, EnvSuggestion>(
-        "INSERT INTO environment_suggestions (task_id, title, detail) \
-         VALUES ($1, $2, $3) RETURNING *",
+        "INSERT INTO environment_suggestions (task_id, kind, title, detail) \
+         VALUES ($1, $2, $3, $4) RETURNING *",
     )
     .bind(task_id)
+    .bind(kind)
     .bind(title)
     .bind(detail)
     .fetch_one(pool)
     .await
+}
+
+/// Titles of every task that is not finished, i.e. still on the board as work
+/// (Available / To Do / In Progress / In Review). Used as the light de-dup check
+/// (issue #272) so the agent never recommends follow-up work already queued.
+pub async fn open_task_titles(pool: &PgPool) -> sqlx::Result<Vec<String>> {
+    sqlx::query_scalar("SELECT title FROM tasks WHERE board_column NOT IN ('done', 'ignored')")
+        .fetch_all(pool)
+        .await
 }
 
 /// One suggestion by id (to act on it, e.g. create an issue from it).

--- a/api/src/http/suggestions.rs
+++ b/api/src/http/suggestions.rs
@@ -1,9 +1,10 @@
-//! Environment setup suggestions the agent makes, and the user acknowledging
-//! them.
+//! Recommendations the agent makes about a task, and the user acting on them.
 //!
-//! The agent's `seraphim-suggest` helper posts recommendations
-//! (`POST /agent/suggestions`); the task view checks them off
-//! (`POST /suggestions/:id/ack`) or turns one into a tracked issue
+//! Two kinds share this pipeline: **environment** setup tips (the `seraphim-suggest`
+//! helper) and end-of-task **follow-up work** the agent noticed, e.g. cleanup, tech
+//! debt, dead code, or security gaps (the `seraphim-followup` helper, issue #272).
+//! Both post to `POST /agent/suggestions`; the task view checks them off
+//! (`POST /suggestions/:id/ack`) or one-clicks one into a tracked issue
 //! (`POST /suggestions/:id/create`). They are listed as part of the task detail.
 
 use axum::extract::{Path, State};
@@ -27,12 +28,19 @@ const MAX_SUGGESTIONS: usize = 10;
 pub struct SuggestRequest {
     pub task_id: Uuid,
     pub suggestions: Vec<EnvSuggestionWrite>,
+    /// `"follow_up"` for end-of-task follow-up work (issue #272); anything else
+    /// (including omitted) is an environment setup recommendation.
+    #[serde(default)]
+    pub kind: Option<String>,
 }
 
-/// `POST /api/v1/agent/suggestions` - the agent records setup recommendations.
+/// `POST /api/v1/agent/suggestions` - the agent records recommendations.
 ///
-/// Called from inside the workspace by `seraphim-suggest`. Blank-titled entries
-/// are skipped, and the board badge lights up for the task.
+/// Called from inside the workspace by `seraphim-suggest` (environment) and
+/// `seraphim-followup` (`kind = "follow_up"`). Blank-titled entries are skipped,
+/// and the board badge lights up for the task. For follow-up work, anything whose
+/// title already matches a task still on the board is dropped, so the agent never
+/// recommends work that is already queued (issue #272).
 pub async fn create(
     State(state): State<AppState>,
     Json(body): Json<SuggestRequest>,
@@ -45,22 +53,95 @@ pub async fn create(
             .into_response());
     }
 
+    let kind = if body.kind.as_deref() == Some("follow_up") {
+        "follow_up"
+    } else {
+        "environment"
+    };
+    // The light de-dup applies only to follow-up work (environment tips are not
+    // board tasks); fetch the open board's titles once to compare against.
+    let queued_titles = if kind == "follow_up" {
+        queries::open_task_titles(&state.db).await?
+    } else {
+        Vec::new()
+    };
+
     let mut ids = Vec::new();
+    let mut skipped_duplicates = 0;
     for suggestion in body.suggestions.into_iter().take(MAX_SUGGESTIONS) {
         let title = suggestion.title.trim();
         if title.is_empty() {
             continue;
         }
-        let created =
-            queries::create_suggestion(&state.db, body.task_id, title, suggestion.detail.trim())
-                .await?;
+        if kind == "follow_up" && already_queued(title, &queued_titles) {
+            skipped_duplicates += 1;
+            continue;
+        }
+        let created = queries::create_suggestion(
+            &state.db,
+            body.task_id,
+            kind,
+            title,
+            suggestion.detail.trim(),
+        )
+        .await?;
         ids.push(created.id);
     }
 
     // The board badge reflects the new unacknowledged suggestions.
     state.notify_board();
 
-    Ok(Json(json!({ "suggestion_ids": ids })).into_response())
+    Ok(
+        Json(json!({ "suggestion_ids": ids, "skipped_duplicates": skipped_duplicates }))
+            .into_response(),
+    )
+}
+
+/// Normalizes a title for the light duplicate check: lowercased, with every run of
+/// non-alphanumeric characters collapsed to a single space and the ends trimmed. So
+/// "Add a security layer!" and "add  a  security layer" compare equal.
+fn normalize_title(title: &str) -> String {
+    let mut out = String::with_capacity(title.len());
+    let mut pending_space = false;
+    for ch in title.chars() {
+        if ch.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.extend(ch.to_lowercase());
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// Whether a follow-up `title` is already represented by one of the `queued` task
+/// titles. Deliberately light and deterministic (issue #272): a hit is normalized
+/// equality, or one normalized title fully containing the other when the shorter is
+/// substantial, to catch obvious restatements without over-matching on a shared
+/// word. Not a fuzzy/semantic match.
+fn already_queued(title: &str, queued: &[String]) -> bool {
+    // Below this many characters the containment rule is off, so short titles only
+    // match exactly (otherwise a common phrase would swallow unrelated work).
+    const MIN_CONTAIN_CHARS: usize = 12;
+    let needle = normalize_title(title);
+    if needle.is_empty() {
+        return false;
+    }
+    queued.iter().any(|other| {
+        let hay = normalize_title(other);
+        if hay == needle {
+            return true;
+        }
+        let (short, long) = if needle.len() <= hay.len() {
+            (needle.as_str(), hay.as_str())
+        } else {
+            (hay.as_str(), needle.as_str())
+        };
+        short.len() >= MIN_CONTAIN_CHARS && long.contains(short)
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,4 +305,44 @@ async fn create_jira_issue(
         .await
         .map_err(|error| error.to_string())?;
     Ok(issue.url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{already_queued, normalize_title};
+
+    #[test]
+    fn normalize_collapses_case_punctuation_and_spacing() {
+        assert_eq!(
+            normalize_title("Add a security layer!"),
+            "add a security layer"
+        );
+        assert_eq!(
+            normalize_title("  Dead-code   removal  "),
+            "dead code removal"
+        );
+        assert_eq!(normalize_title("!!!"), "");
+    }
+
+    #[test]
+    fn already_queued_matches_restatements_not_shared_words() {
+        let queued = vec![
+            "Add a security layer to uploads".to_string(),
+            "Photo upload system".to_string(),
+        ];
+        // Exact restatement (case/punctuation aside) is a duplicate.
+        assert!(already_queued("photo upload system", &queued));
+        // A substantial restatement contained in a queued title is a duplicate.
+        assert!(already_queued("Add a security layer!", &queued));
+        // Genuinely new work is not a duplicate, even sharing a word ("upload").
+        assert!(!already_queued("Add thumbnail generation", &queued));
+        // A short shared phrase must NOT over-match (containment rule is off).
+        assert!(!already_queued("add a test", &queued));
+    }
+
+    #[test]
+    fn already_queued_is_false_against_an_empty_board() {
+        assert!(!already_queued("anything at all", &[]));
+        assert!(!already_queued("", &["something".to_string()]));
+    }
 }

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -476,6 +476,9 @@ fn context_header(
     // Shared by every mode: noticing missing tooling can happen on any run, so
     // the recommend-improvements guidance lives in the common header.
     prompt.push_str(ENVIRONMENT_SUGGESTIONS);
+    // Likewise follow-up work the agent spots while working (issue #272): bubble it
+    // up at the end so the operator can one-click it into a ticket.
+    prompt.push_str(FOLLOW_UP_SUGGESTIONS);
     // Build-then-verify for UI work: first steer toward the repo's design vocabulary
     // (issue #247) so spacing is picked from a fixed set, then the self-review loop
     // checks the result. Both are shared by every mode.
@@ -563,6 +566,23 @@ const ENVIRONMENT_SUGGESTIONS: &str = "\n\
     \x20 JSON\n\n\
     Only suggest things that genuinely help; if nothing comes to mind, skip it. \
     This does not replace opening the pull request.\n";
+
+/// Guidance, appended to every task prompt, on bubbling up follow-up work (#272).
+const FOLLOW_UP_SUGGESTIONS: &str = "\n\
+    # Recommend follow-up work\n\
+    As you work, keep an eye out for follow-up work worth its own ticket that is \
+    OUTSIDE this task's scope: dead or duplicated code you noticed, tech debt, an \
+    inefficient or fragile process, a missing security layer, or a now-unused system \
+    that could be deprecated. Do NOT do this work now (it belongs in its own ticket) \
+    and do NOT pad your PR with it. Instead, at the end, bubble each up so the \
+    operator can one-click it into a ticket. Keep it LIGHT: only genuine, specific \
+    finds, and skip anything already covered by a ticket in the queue (the API also \
+    drops follow-ups whose title matches a task already on the board). If nothing \
+    stands out, skip this entirely. Pass valid JSON to `seraphim-followup` on stdin \
+    via a heredoc:\n\n\
+    \x20 seraphim-followup <<'JSON'\n\
+    \x20 {\"suggestions\":[{\"title\":\"<short, specific follow-up>\",\"detail\":\"<what and why, e.g. which dead code or what security gap>\"}]}\n\
+    \x20 JSON\n";
 
 /// Standing instruction (issue #247) to build UI from the repo's design vocabulary
 /// rather than ad-hoc spacing.

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -362,9 +362,9 @@
     {#if suggestionCount > 0}
       <div
         class="mt-2 animate-pulse rounded-md bg-warning px-2 py-1 text-center text-xs font-bold text-background motion-reduce:animate-none"
-        title="The agent recommended environment changes"
+        title="The agent has recommendations (setup improvements and/or follow-up work)"
       >
-        💡 {suggestionCount} setup {suggestionCount === 1 ? 'suggestion' : 'suggestions'}
+        💡 {suggestionCount} {suggestionCount === 1 ? 'suggestion' : 'suggestions'}
       </div>
     {/if}
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -390,6 +390,9 @@ export type EnvSuggestion = {
   task_id: string
   title: string
   detail: string
+  // 'environment' (setup tips) or 'follow_up' (cleanup / tech debt / dead code /
+  // security / deprecations the agent spotted while working; issue #272).
+  kind: string
   acknowledged: boolean
   created_at: string
   acknowledged_at: string | null

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -66,6 +66,12 @@
   let task = $state<Task | null>(null)
   let events = $state<StreamEvent[]>([])
   let suggestions = $state<EnvSuggestion[]>([])
+  // Split by kind (issue #272): environment setup tips vs follow-up work the agent
+  // noticed. Both render with the same checkbox + create-issue control.
+  const envSuggestions = $derived(suggestions.filter((suggestion) => suggestion.kind !== 'follow_up'))
+  const followUpSuggestions = $derived(
+    suggestions.filter((suggestion) => suggestion.kind === 'follow_up')
+  )
   let questions = $state<Question[]>([])
   let pullRequests = $state<TaskPullRequest[]>([])
   let screenshots = $state<TaskScreenshot[]>([])
@@ -584,16 +590,15 @@
       </section>
     {/if}
 
-    {#if suggestions.length}
-      <!-- Loud on the task too: the checkboxes here are what clear the board badge. -->
+    <!-- A list of the agent's recommendations of one kind. Loud on the task too:
+         the checkboxes here are what clear the board badge. Shared by the
+         environment tips and the follow-up work (issue #272). -->
+    {#snippet suggestionList(items: EnvSuggestion[], heading: string, blurb: string)}
       <section class="rounded-lg border border-warning/50 bg-card p-3">
-        <h2 class="text-sm font-semibold">💡 Environment recommendations</h2>
-        <p class="mt-0.5 text-xs text-muted-foreground">
-          Things the agent thinks would make future runs smoother. Check one off once you have
-          handled it; unchecked ones stay loud on the board.
-        </p>
+        <h2 class="text-sm font-semibold">{heading}</h2>
+        <p class="mt-0.5 text-xs text-muted-foreground">{blurb}</p>
         <ul class="mt-2 divide-y divide-border">
-          {#each suggestions as suggestion (suggestion.id)}
+          {#each items as suggestion (suggestion.id)}
             <li class="flex items-start justify-between gap-3 py-2">
               <button
                 type="button"
@@ -635,6 +640,22 @@
           {/each}
         </ul>
       </section>
+    {/snippet}
+
+    {#if envSuggestions.length}
+      {@render suggestionList(
+        envSuggestions,
+        '💡 Environment recommendations',
+        'Things the agent thinks would make future runs smoother. Check one off once you have handled it; unchecked ones stay loud on the board.'
+      )}
+    {/if}
+
+    {#if followUpSuggestions.length}
+      {@render suggestionList(
+        followUpSuggestions,
+        '🧹 Follow-up work',
+        'Work the agent noticed but kept out of this task (dead code, tech debt, security, deprecations). Check one off, or one-click it into a ticket; unchecked ones stay loud on the board.'
+      )}
     {/if}
 
     {#if screenshots.length}

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -187,9 +187,11 @@ COPY seraphim-comment /usr/local/bin/seraphim-comment
 COPY seraphim-state /usr/local/bin/seraphim-state
 COPY seraphim-draft /usr/local/bin/seraphim-draft
 COPY seraphim-screenshot /usr/local/bin/seraphim-screenshot
+COPY seraphim-followup /usr/local/bin/seraphim-followup
 RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
     /usr/local/bin/seraphim-comment /usr/local/bin/seraphim-state \
-    /usr/local/bin/seraphim-draft /usr/local/bin/seraphim-screenshot
+    /usr/local/bin/seraphim-draft /usr/local/bin/seraphim-screenshot \
+    /usr/local/bin/seraphim-followup
 
 # --- Computed-style check library for visual self-review (issue #245) ---------
 # The deterministic CSS checks (centering/spacing/overflow/stacking) the agent

--- a/workspace/seraphim-followup
+++ b/workspace/seraphim-followup
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// seraphim-followup: the agent recommends follow-up work it noticed (issue #272).
+//
+// At the end of a task, if the agent spotted work worth its own ticket but OUTSIDE
+// this task's scope (dead or duplicated code, tech debt, an inefficient/fragile
+// process, a missing security layer, a now-unused system to deprecate), it bubbles
+// it up here. The operator sees these on the board and the task view, just like
+// environment suggestions, and can one-click each into a tracked issue. The API
+// drops any whose title matches a task already on the board, so nothing already
+// queued is re-recommended. Do NOT do the work now; that belongs in its own ticket.
+//
+// Usage (JSON as an argument or on stdin):
+//   seraphim-followup '{"suggestions":[{"title":"Deprecate the legacy uploader",
+//                       "detail":"Nothing references src/legacy/upload.ts anymore."}]}'
+//
+// A bare string, a single {title, detail} object, or an array of those are all
+// accepted for convenience.
+
+const API_URL = process.env.SERAPHIM_API_URL
+const TASK_ID = process.env.SERAPHIM_TASK_ID
+
+function fail(message) {
+  console.error(`seraphim-followup: ${message}`)
+  process.exit(1)
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => (data += chunk))
+    process.stdin.on('end', () => resolve(data))
+  })
+}
+
+// Normalizes the accepted input shapes into an array of {title, detail}.
+function normalizeSuggestions(parsed) {
+  const rawList = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.suggestions)
+      ? parsed.suggestions
+      : [parsed]
+
+  return rawList
+    .map((entry) => {
+      const suggestion = typeof entry === 'string' ? { title: entry } : entry
+      return {
+        title: String(suggestion?.title ?? '').trim(),
+        detail: String(suggestion?.detail ?? '').trim()
+      }
+    })
+    .filter((suggestion) => suggestion.title.length > 0)
+}
+
+async function main() {
+  if (!API_URL || !TASK_ID) {
+    fail('SERAPHIM_API_URL and SERAPHIM_TASK_ID must be set (they are injected by the orchestrator)')
+  }
+
+  const rawInput = process.argv[2] ?? (await readStdin())
+  if (!rawInput || !rawInput.trim()) {
+    fail('no follow-up provided (pass JSON as an argument or on stdin)')
+  }
+
+  let parsed
+  const trimmedInput = rawInput.trim()
+  try {
+    parsed = JSON.parse(trimmedInput)
+  } catch (error) {
+    // Input that begins with `{` or `[` was meant to be JSON. If it does not
+    // parse, it is malformed; do NOT fall back to recording the whole blob as one
+    // suggestion's title. Fail loudly so the agent re-emits valid JSON.
+    if (trimmedInput.startsWith('{') || trimmedInput.startsWith('[')) {
+      fail(
+        `the input looks like JSON but could not be parsed (${error.message}). ` +
+          'Nothing was sent. Re-run with valid JSON. To avoid shell-quoting problems ' +
+          'with quotes and apostrophes inside the payload, pipe it on stdin via a heredoc:\n' +
+          "  seraphim-followup <<'JSON'\n" +
+          '  {"suggestions":[{"title":"...","detail":"..."}]}\n' +
+          '  JSON'
+      )
+    }
+    // A genuinely plain, unquoted recommendation string is still allowed.
+    parsed = trimmedInput
+  }
+
+  const suggestions = normalizeSuggestions(parsed)
+  if (!suggestions.length) {
+    fail('could not find any follow-up title in the input')
+  }
+
+  let response
+  try {
+    response = await fetch(`${API_URL}/api/v1/agent/suggestions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ task_id: TASK_ID, kind: 'follow_up', suggestions })
+    })
+  } catch (error) {
+    fail(`could not reach the Seraphim API at ${API_URL}: ${error.message}`)
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    fail(`the API rejected the follow-up (HTTP ${response.status}): ${detail}`)
+  }
+
+  // The API drops follow-ups already on the board; report what actually landed.
+  const result = await response.json().catch(() => ({}))
+  const recorded = Array.isArray(result?.suggestion_ids) ? result.suggestion_ids.length : suggestions.length
+  const skipped = Number(result?.skipped_duplicates ?? 0)
+  const skippedNote = skipped ? ` (${skipped} already queued, skipped)` : ''
+  console.log(`Recorded ${recorded} follow-up suggestion${recorded === 1 ? '' : 's'} for the user${skippedNote}.`)
+}
+
+main().catch((error) => fail(error.message))


### PR DESCRIPTION
Closes #272.

At the end of a task, the agent now bubbles up follow-up work it noticed but kept out of scope (cleanup, tech debt, dead/duplicate code, inefficient processes, security gaps, deprecations). These surface exactly like the existing environment "setup suggestions": on the kanban board and the task view, where the operator reviews them one by one and one-clicks each into a tracked issue (internal / GitHub / Jira).

## Approach: reuse, don't rebuild

The issue says this should work "just like environment creation" / "similarly to setup suggestions," so I extended that proven pipeline with a `kind` discriminator rather than building a parallel system. One table, one endpoint, one ack/create-issue/badge/task-view path.

- **Migration `0044`**: adds `kind` to `environment_suggestions` (`'environment' | 'follow_up'`); existing rows default to `environment`.
- **`POST /agent/suggestions`** now accepts an optional `kind`. The ack, create-issue, board-badge, and task-detail machinery are unchanged and serve both kinds.
- **`seraphim-followup`** helper (new, modeled on `seraphim-suggest`, posts `kind: "follow_up"`), baked into the workspace image. A dedicated helper keeps the agent's two end-of-task actions unambiguous.
- **`FOLLOW_UP_SUGGESTIONS`** standing instruction in the shared prompt header: watch for out-of-scope follow-up work, do NOT do it now or pad the PR, bubble each up at the end, keep it light, and skip anything already queued.

## The "don't recommend what already exists" check

The issue asks for "a small, light check" so the agent doesn't recommend work already in the queue. For follow-up suggestions, the API drops any whose title matches a task still on the board (not done/ignored), via a deterministic normalized-title check (`normalize_title` + `already_queued`): normalized equality, or one title substantially containing the other. Deliberately light, not fuzzy/semantic, and unit-tested (restatements match, shared single words do not). The prompt also tells the agent to skip queued work, so it's belt-and-suspenders.

## Frontend

The task view splits the agent's recommendations into two sections by kind, "Environment recommendations" and "Follow-up work", sharing one Svelte snippet (same acknowledge checkbox + create-issue split button). The board card badge is now kind-agnostic ("N suggestions").

## Verification

- `cargo +1.88 fmt --check` clean; clippy no new warnings; full suite **156/156** pass (3 new de-dup unit tests).
- Frontend `svelte-check` **0 errors / 0 warnings**; `vite build` succeeds; `node --check` on the helper OK.
- Migration + the `kind` column (default + explicit) + the open-task de-dup query exercised against an ephemeral Postgres 17.

## Notes

Shipping needs the workspace image rebuilt (for `seraphim-followup`) plus api + frontend. The `environment_suggestions` table keeps its name (an additive `kind` column is lower-risk than a rename across the whole pipeline); it now holds both kinds.