### PR TITLE
Scroll each kanban column independently so cross-column drag is easy (#273)

### DIFF
--- a/frontend/src/lib/components/RailwayLane.svelte
+++ b/frontend/src/lib/components/RailwayLane.svelte
@@ -37,7 +37,12 @@
   const lifecycle = $derived(stateStyle[railway.lifecycle_state])
 </script>
 
-<section class="flex min-h-0 flex-col rounded-lg border border-border bg-card/40">
+<!-- On lg the lane fills the board's height so its columns scroll individually
+     (issue #273); multiple lanes each take full height and scroll between them via
+     the swimlanes container. Below lg it sizes to content and the page scrolls. -->
+<section
+  class="flex min-h-0 flex-col rounded-lg border border-border bg-card/40 lg:h-full lg:flex-none"
+>
   <header
     class="flex flex-none flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border-border px-4 py-2.5"
   >

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -840,9 +840,10 @@
 <!--
   Fill the available height (viewport minus the topbar, supplied by `<main>`) as a
   single flex column: the banners and the env-name/action row size to content,
-  while the swimlane stack takes the remaining space and scrolls. Each lane holds
-  its own kanban columns row; the lanes are stacked vertically (the board scrolls
-  as a whole rather than each column scrolling independently).
+  while the swimlane stack takes the remaining space. On lg each kanban COLUMN
+  scrolls independently within a full-height lane, so a deep card in Available is
+  always next to To Do and the page itself never has to scroll (issue #273). Below
+  lg the columns stack and the page scrolls as before.
 -->
 <svelte:window onkeydown={onWindowKeydown} />
 
@@ -1128,7 +1129,7 @@
        a single lane, so the layout degrades to today's board through one lane. -->
   {#snippet swimlanes()}
     <div
-      class="flex flex-col gap-4 p-4 lg:px-6 lg:pb-6 {bulkMode
+      class="flex flex-col gap-4 p-4 lg:h-full lg:min-h-0 lg:overflow-y-auto lg:px-6 lg:pb-6 {bulkMode
         ? 'rounded-lg ring-1 ring-inset ring-primary/40'
         : ''}"
     >
@@ -1138,7 +1139,7 @@
           taskCount={laneVisibleCount(railway.id)}
           onTogglePause={() => toggleRailwayPause(railway)}
         >
-          <div class="grid grid-cols-1 items-start gap-3 lg:grid-cols-6">
+          <div class="grid grid-cols-1 gap-3 lg:h-full lg:min-h-0 lg:grid-cols-6">
             {@render kanbanColumns(railway.id)}
           </div>
         </RailwayLane>


### PR DESCRIPTION
Closes #273.

## Problem

With a lot of cards in Available or Done, dragging a deep card into To Do meant scrolling the whole page up first, because the board scrolled as a whole rather than each column scrolling on its own.

## Root cause

The board is already bounded to the viewport (`<main>` is `flex-1 min-h-0`, the board root is `lg:h-full`), and each column's card list already has `overflow-y-auto`. But the bounded height stopped propagating at the swimlane stack: the swimlanes container, the lane, and the columns grid (which used `items-start`) were all content-height, so the columns grew to fit every card and the page scrolled instead of the columns.

## Fix (lg only; mobile unchanged)

Propagate the bounded height down to the columns so each one scrolls inside a full-height lane and the page never scrolls:

- **Swimlanes container** fills the board height and scrolls vertically only *between* lanes: `lg:h-full lg:min-h-0 lg:overflow-y-auto`.
- **Each `RailwayLane`** fills the board height (`lg:h-full lg:flex-none`); a single lane (the common `main`-only board) fills exactly, multiple lanes scroll between them.
- **The columns grid** fills the lane height and stretches its columns (`lg:h-full lg:min-h-0`, dropping `items-start`), so each column's existing `overflow-y-auto` card list scrolls independently.

Result: a deep card in Available is always next to To Do; both stay visible and you drag a short distance. Below `lg` the columns stack and the page scrolls as before.

3 utility-class changes + 2 comment updates across 2 files; no backend or behavior change.

## Verification

- `svelte-check` 0 errors / 0 warnings; `vite build` succeeds.
- A Playwright check on the exact flex/Tailwind chain (Available filled with 60 cards, To Do with 3, at 1280x800) asserts: `pageScrolls: false`, `availColumnScrolls: true`, `todoColumnScrolls: false` - the page never scrolls, a full column scrolls internally, and a short column shows no spurious scrollbar.