### PR TITLE
Re-run the repo setup script before every task (per-repo toggle, #275)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,9 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 - **`repositories`** — `full_name`, `clone_url`, `default_branch`,
   `branch_template`, `setup_script` (per-repo setup), `instructions`,
   `review_policy` (NULL = inherit default), `enabled`, `sync_issues` (poll this
-  repo for issues), `issue_labels` (label filter), and `sync_error` /
+  repo for issues), `issue_labels` (label filter), `setup_script_always_run`
+  (issue #275: re-run `setup_script` on the persistent clone before every task,
+  not just on first clone / full provision; off by default), and `sync_error` /
   `sync_error_at` (issue #213: the last issue-sync failure for the repo, NULL when
   the most recent sync succeeded; set when listing the repo's issues fails, cleared
   on the next clean sync). There is **no** separate issue-source entity; a repo
@@ -285,7 +287,13 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
     live in each repo under test, not here.
 - **Two-tier setup:** environment setup (`settings.base_setup_script`) runs once
   per provision/recreate (install CLIs/toolchains); per-repo setup
-  (`repositories.setup_script`) runs after each clone (e.g. `yarn install`).
+  (`repositories.setup_script`) runs after each clone (e.g. `yarn install`). A
+  repo can opt into `setup_script_always_run` (issue #275) to re-run its setup
+  script before *every* task on the persistent clone, not just on first clone,
+  so a stacked-dependency merge that adds new deps gets them reinstalled before
+  the task's build/test. The toggle flows through `provision::prepare_branch` /
+  `prepare_existing_branch` into `repo_block`'s `always_setup` (which already
+  governed the full-provision re-run); no "did the lockfile change" guard.
 - **Submodules (issue #251):** a cloned repo's git submodules are initialized
   automatically (`provision::submodule_update_snippet`, generic to any repo with a
   `.gitmodules`), before its setup script, on clone and after a branch checkout.

--- a/api/migrations/0045_repo_setup_script_always_run.sql
+++ b/api/migrations/0045_repo_setup_script_always_run.sql
@@ -1,0 +1,10 @@
+-- Per-repo "re-run the setup script before every task" toggle (issue #275).
+-- When a stacked foundation ticket merges a dependency branch that adds new
+-- devDependencies, the persistent clone's node_modules go stale and the next
+-- script (e.g. `cross-env ... prisma generate`) fails with "command not found".
+-- With this on, the repo's `setup_script` re-runs on the existing clone before
+-- each task (not just on a fresh clone), so deps are reinstalled programmatically
+-- without any repo-specific logic baked into Seraphim. Defaults off so existing
+-- repos keep running setup only on first clone / full provision.
+ALTER TABLE repositories
+    ADD COLUMN setup_script_always_run BOOLEAN NOT NULL DEFAULT FALSE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -385,6 +385,10 @@ pub struct Repository {
     pub sync_issues: bool,
     /// Only sync issues carrying all of these labels (empty = no filter).
     pub issue_labels: Vec<String>,
+    /// Re-run [`Self::setup_script`] on the persistent clone before every task,
+    /// not just on first clone / full provision (issue #275). Lets a repo
+    /// reinstall dependencies after a stacked-dependency merge adds new ones.
+    pub setup_script_always_run: bool,
     /// The last issue-sync failure for this repo (issue #213), or `None` when the
     /// most recent sync succeeded. Cleared on the next successful sync.
     pub sync_error: Option<String>,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -874,15 +874,16 @@ pub async fn upsert_repository(
     enabled: bool,
     sync_issues: bool,
     issue_labels: &[String],
+    setup_script_always_run: bool,
 ) -> sqlx::Result<Repository> {
     sqlx::query_as::<_, Repository>(
         // New repos default to the `main` railway (issue #201). Set via subquery
         // so the existing bound-parameter numbering is untouched.
         "INSERT INTO repositories \
          (railway_id, full_name, clone_url, default_branch, branch_template, setup_script, \
-          instructions, review_policy, enabled, sync_issues, issue_labels) \
+          instructions, review_policy, enabled, sync_issues, issue_labels, setup_script_always_run) \
          VALUES ((SELECT id FROM railways WHERE is_main), \
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) \
          ON CONFLICT (full_name) DO UPDATE SET \
          clone_url = EXCLUDED.clone_url, \
          default_branch = EXCLUDED.default_branch, \
@@ -893,6 +894,7 @@ pub async fn upsert_repository(
          enabled = EXCLUDED.enabled, \
          sync_issues = EXCLUDED.sync_issues, \
          issue_labels = EXCLUDED.issue_labels, \
+         setup_script_always_run = EXCLUDED.setup_script_always_run, \
          updated_at = now() \
          RETURNING *",
     )
@@ -906,6 +908,7 @@ pub async fn upsert_repository(
     .bind(enabled)
     .bind(sync_issues)
     .bind(issue_labels)
+    .bind(setup_script_always_run)
     .fetch_one(pool)
     .await
 }
@@ -929,12 +932,13 @@ pub async fn update_repository(
     enabled: bool,
     sync_issues: bool,
     issue_labels: &[String],
+    setup_script_always_run: bool,
 ) -> sqlx::Result<Repository> {
     sqlx::query_as::<_, Repository>(
         "UPDATE repositories SET \
          full_name = $2, clone_url = $3, default_branch = $4, branch_template = $5, \
          setup_script = $6, instructions = $7, review_policy = $8, enabled = $9, \
-         sync_issues = $10, issue_labels = $11, updated_at = now() \
+         sync_issues = $10, issue_labels = $11, setup_script_always_run = $12, updated_at = now() \
          WHERE id = $1 RETURNING *",
     )
     .bind(id)
@@ -948,6 +952,7 @@ pub async fn update_repository(
     .bind(enabled)
     .bind(sync_issues)
     .bind(issue_labels)
+    .bind(setup_script_always_run)
     .fetch_one(pool)
     .await
 }
@@ -980,6 +985,9 @@ pub async fn create_repository_if_absent(
         true,
         sync_issues,
         issue_labels,
+        // Org-imported repos default to running setup only on first clone; the
+        // operator can opt a repo into per-task re-runs later (issue #275).
+        false,
     )
     .await
 }

--- a/api/src/http/data.rs
+++ b/api/src/http/data.rs
@@ -117,6 +117,9 @@ pub struct RepoExport {
     pub enabled: bool,
     pub sync_issues: bool,
     pub issue_labels: Vec<String>,
+    // Re-run the setup script before every task (issue #275); omitted = off.
+    #[serde(default)]
+    pub setup_script_always_run: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -172,6 +175,7 @@ pub async fn export(State(state): State<AppState>) -> ApiResult<Json<ConfigBundl
                 enabled: repo.enabled,
                 sync_issues: repo.sync_issues,
                 issue_labels: repo.issue_labels,
+                setup_script_always_run: repo.setup_script_always_run,
             })
             .collect(),
     };
@@ -230,6 +234,7 @@ pub async fn import(
             repo.enabled,
             repo.sync_issues,
             &repo.issue_labels,
+            repo.setup_script_always_run,
         )
         .await?;
     }

--- a/api/src/http/repos.rs
+++ b/api/src/http/repos.rs
@@ -107,6 +107,10 @@ pub struct UpsertRepoRequest {
     pub sync_issues: bool,
     #[serde(default)]
     pub issue_labels: Vec<String>,
+    /// Re-run the repo's setup script before every task, not just on first clone
+    /// (issue #275).
+    #[serde(default)]
+    pub setup_script_always_run: bool,
 }
 
 fn default_branch() -> String {
@@ -143,6 +147,7 @@ pub async fn upsert(
         body.enabled,
         body.sync_issues,
         &body.issue_labels,
+        body.setup_script_always_run,
     )
     .await?;
     state.notify_board();
@@ -169,6 +174,7 @@ pub async fn update(
         body.enabled,
         body.sync_issues,
         &body.issue_labels,
+        body.setup_script_always_run,
     )
     .await?;
     state.notify_board();

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -828,6 +828,7 @@ mod tests {
             enabled: true,
             sync_issues: false,
             issue_labels: Vec::new(),
+            setup_script_always_run: false,
             sync_error: None,
             sync_error_at: None,
             created_at: chrono::Utc::now(),

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -244,7 +244,10 @@ pub async fn prepare_branch(
     let mut script = String::from("set -e\n");
     script.push_str(&prelude_agents(settings));
     // Ensure the focus repo exists (clone + setup on first sight), then branch.
-    script.push_str(&repo_block(repo, false));
+    // Repos opted into `setup_script_always_run` also re-run setup on the existing
+    // clone, so a stacked-dependency merge that added deps gets them reinstalled
+    // before this task's build/test (issue #275).
+    script.push_str(&repo_block(repo, repo.setup_script_always_run));
     script.push_str(&format!("cd \"{dir}\"\n", dir = dir));
     script.push_str(reset_tree_snippet());
     script.push_str(&branch_prep_snippet(&repo.default_branch, branch));
@@ -288,8 +291,9 @@ pub async fn prepare_existing_branch(
     let mut script = String::from("set -e\n");
     script.push_str(&prelude_agents(settings));
     // Ensure the focus repo exists (clone on first sight), then sync to the
-    // remote branch tip CI actually tested.
-    script.push_str(&repo_block(repo, false));
+    // remote branch tip CI actually tested. Honor `setup_script_always_run` here
+    // too so a fix turn rebuilds deps if the branch's deps changed (issue #275).
+    script.push_str(&repo_block(repo, repo.setup_script_always_run));
     script.push_str(&format!("cd \"{dir}\"\n", dir = dir));
     script.push_str(reset_tree_snippet());
     script.push_str(&format!(
@@ -330,8 +334,10 @@ fn submodule_update_snippet(dir: &str) -> String {
     )
 }
 
-/// Bash to clone-or-update a single repo, write its CLAUDE.md, and (on a fresh
-/// clone, or always during a full provision) run its setup script.
+/// Bash to clone-or-update a single repo, write its CLAUDE.md, and run its setup
+/// script. Setup always runs on a fresh clone; on an existing clone it runs only
+/// when `always_setup` is set (a full provision, or a repo opted into
+/// `setup_script_always_run` for per-task re-runs, issue #275).
 fn repo_block(repo: &Repository, always_setup: bool) -> String {
     let dir = format!("/workspace/{}", repo_dir_name(&repo.full_name));
     let setup = repo.setup_script.trim();
@@ -345,7 +351,8 @@ fn repo_block(repo: &Repository, always_setup: bool) -> String {
         format!("(\ncd \"{dir}\"\n{setup}\n)\n")
     };
 
-    // Run setup after a fresh clone; during a full provision, run it every time.
+    // Run setup after a fresh clone; on an existing clone, only when the caller
+    // opted in (full provision, or a per-task re-run for an opted-in repo, #275).
     let clone_setup = setup_block.clone();
     let update_setup = if always_setup {
         setup_block
@@ -432,6 +439,7 @@ mod tests {
             enabled: true,
             sync_issues: false,
             issue_labels: Vec::new(),
+            setup_script_always_run: false,
             sync_error: None,
             sync_error_at: None,
             created_at: Utc::now(),
@@ -482,6 +490,24 @@ mod tests {
         assert!(script.contains("--get-regexp"));
         assert!(script.contains("BRAND_DEPLOY_KEY"));
         assert!(script.contains("exit 1"));
+    }
+
+    #[test]
+    fn repo_block_reruns_setup_on_existing_clone_only_when_opted_in() {
+        // A repo with a setup script. The marker is distinctive so we can count how
+        // many times the setup block is emitted across the clone/update branches.
+        let mut repo = repo();
+        repo.setup_script = "yarn install --frozen-lockfile".to_string();
+
+        // Per-task default (existing clone): setup runs on a fresh clone only, so
+        // the marker appears exactly once (issue #275: opted-out repos unchanged).
+        let once = repo_block(&repo, false);
+        assert_eq!(once.matches("yarn install --frozen-lockfile").count(), 1);
+
+        // Opted in (or a full provision): setup also runs on the existing clone, so
+        // the marker appears in both the clone and the update branch.
+        let twice = repo_block(&repo, true);
+        assert_eq!(twice.matches("yarn install --frozen-lockfile").count(), 2);
     }
 
     #[test]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -282,6 +282,8 @@ export type UpsertRepoRequest = {
   enabled?: boolean
   sync_issues?: boolean
   issue_labels?: string[]
+  // Re-run the setup script before every task, not just on first clone (issue #275).
+  setup_script_always_run?: boolean
 }
 
 export function upsertRepo(body: UpsertRepoRequest) {

--- a/frontend/src/lib/components/RepoForm.svelte
+++ b/frontend/src/lib/components/RepoForm.svelte
@@ -32,6 +32,7 @@
     review_policy: ReviewPolicy | ''
     instructions: string
     setup_script: string
+    setup_script_always_run: boolean
     enabled: boolean
     sync_issues: boolean
     issue_labels: string
@@ -39,7 +40,13 @@
 
   type FormPrefs = Pick<
     FormState,
-    'default_branch' | 'branch_template' | 'review_policy' | 'enabled' | 'sync_issues' | 'issue_labels'
+    | 'default_branch'
+    | 'branch_template'
+    | 'review_policy'
+    | 'enabled'
+    | 'sync_issues'
+    | 'issue_labels'
+    | 'setup_script_always_run'
   >
 
   function loadPrefs(): FormPrefs {
@@ -49,7 +56,8 @@
       review_policy: '',
       enabled: true,
       sync_issues: true,
-      issue_labels: ''
+      issue_labels: '',
+      setup_script_always_run: false
     }
     if (typeof localStorage === 'undefined') {
       return fallback
@@ -72,7 +80,8 @@
       review_policy: state.review_policy,
       enabled: state.enabled,
       sync_issues: state.sync_issues,
-      issue_labels: state.issue_labels
+      issue_labels: state.issue_labels,
+      setup_script_always_run: state.setup_script_always_run
     }
     localStorage.setItem(PREFS_KEY, JSON.stringify(prefs))
   }
@@ -87,6 +96,7 @@
         review_policy: repo.review_policy ?? '',
         instructions: repo.instructions,
         setup_script: repo.setup_script,
+        setup_script_always_run: repo.setup_script_always_run,
         enabled: repo.enabled,
         sync_issues: repo.sync_issues,
         issue_labels: repo.issue_labels.join(', ')
@@ -139,6 +149,7 @@
       review_policy: form.review_policy === '' ? null : form.review_policy,
       instructions: form.instructions,
       setup_script: form.setup_script,
+      setup_script_always_run: form.setup_script_always_run,
       enabled: form.enabled,
       sync_issues: form.sync_issues,
       issue_labels: labels
@@ -233,6 +244,18 @@
         sequentially, e.g. <code class="rounded bg-secondary px-1 py-0.5 text-xs">pnpm install</code> or
         <code class="rounded bg-secondary px-1 py-0.5 text-xs">yarn install</code>. pnpm, yarn, and npm are
         preinstalled, so skip <code class="rounded bg-secondary px-1 py-0.5 text-xs">corepack enable</code>.
+      </p>
+    </div>
+
+    <div class="space-y-1.5">
+      <div class="flex items-center gap-2">
+        <Switch id="rsetup-always" bind:checked={form.setup_script_always_run} />
+        <Label for="rsetup-always">Re-run the setup script before every task</Label>
+      </div>
+      <p class="text-xs leading-relaxed text-muted-foreground">
+        By default the setup script runs only on a fresh clone. Turn this on to re-run it before
+        every task, so dependencies are reinstalled after a stacked-dependency branch is merged in
+        (which can add new dev dependencies the persistent clone is missing).
       </p>
     </div>
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -292,6 +292,8 @@ export type Repository = {
   enabled: boolean
   sync_issues: boolean
   issue_labels: string[]
+  // Re-run the setup script before every task, not just on first clone (issue #275).
+  setup_script_always_run: boolean
   // The last issue-sync failure for this repo (issue #213), or null when the most
   // recent sync succeeded. Cleared automatically on the next successful sync.
   sync_error: string | null


### PR DESCRIPTION
Closes #275.

## Background
When a stacked foundation ticket merges its dependency branch (e.g. A7 into A8), that branch can introduce new devDependencies (prisma, @prisma/client, cross-env, pg, @electric-sql/pglite). The persistent clone's `node_modules` go stale, so the next script (`cross-env ... prisma generate`) fails with `command not found: cross-env` until `yarn install` is re-run.

## Approach
Following @navarrotech's comment on the issue (which supersedes the original description): instead of baking repo-specific logic into a repo's `CLAUDE.md`, add a **per-repo toggle** so the operator can opt a repo into re-running its setup script before every task. No "did the lockfile change" guard, as requested.

When the toggle is on, the repo's `setup_script` re-runs on the existing persistent clone before each task, reinstalling whatever the merged dependency branch added. Off by default, so existing repos keep running setup only on first clone / full provision.

## What changed
- **Migration `0045`**: `repositories.setup_script_always_run BOOLEAN NOT NULL DEFAULT FALSE`.
- **`provision::prepare_branch` / `prepare_existing_branch`** pass the flag into `repo_block`'s existing `always_setup` parameter (which already governed the full-provision re-run). Fresh clones still always run setup; opted-out repos are unchanged. Both fresh-work and PR-fix/review prep honor it, so "before every task" holds across turn types.
- Threaded through the `Repository` model, the `upsert`/`update` repo queries, the `repos` HTTP request body (both handlers), and the export/import bundle so it round-trips.
- **`RepoForm`** gains a Switch under the setup-script field (remembered in the new-repo prefs); `api.ts` and `types.ts` carry the field.
- New unit test asserts the setup block is emitted once when opted out and twice when opted in.
- `CLAUDE.md` updated (source-of-truth policy) for the new column and the two-tier-setup behavior.

## Verification
- `cargo +1.88 fmt --check` clean, `clippy --all-targets` adds no new warnings, 157 backend tests pass (1 new).
- Full migration chain (0001 -> 0045) applies cleanly on a fresh PG17; the column lands as `boolean not null default false`.
- Frontend `check` 0 errors / 0 warnings and `build` pass.