### PR TITLE
Capture ticket attachments into ticket data (#291)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,30 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   dev/test-data screenshots only, since the bytes persist in Postgres (respect
   at-rest disk encryption as with the other blobs/secrets). The optional
   GitHub-issue/PR attachment toggle is not built yet (left to a follow-up).
+- **`task_attachments`** (issue #291) — files attached to a ticket so the agent
+  actually sees them: operator uploads on an internal ticket, plus source-ticket
+  attachments (Jira) pulled into ticket data on sync/work. One shared table keyed
+  by `task_id`, carrying a `source` (`operator` | `jira` | `github`) and, for
+  pulled ones, the source tracker's `external_id` (deduped via a partial unique
+  index so a re-pull never duplicates). The bytes live as `bytea` and are NEVER
+  returned in task/board JSON, mirroring `task_screenshots`: an operator uploads
+  one file per request to `POST /tasks/:id/attachments` (raw body = bytes,
+  Content-Type = MIME, `?filename=`; no multipart dep, like screenshots),
+  `GET /attachments/:id` streams them (immutable cache, `Content-Disposition`
+  carries the file name), and `TaskDetail.attachments` carries metadata only. The
+  task view shows images as thumbnails and other files as download links, with an
+  "Add files" control on internal tickets; the create-issue form uploads selected
+  files right after the ticket exists. **Jira capture:** on a Jira ticket's first
+  sync, and again when the agent works it, `orchestrator::capture_jira_attachments`
+  lists the issue's attachments (`JiraClient::list_attachments`) and downloads +
+  stores each not-already-stored one (`download_attachment`, deduped on the Jira
+  attachment id), so its screenshots/logs are captured with no manual Jira CLI
+  fetch (best-effort; oversized files past `MAX_ATTACHMENT_BYTES` are skipped).
+  **Prompt:** `prompt::build` renders an `# Attachments` section
+  (`render_attachments`): small text/log files are inlined head/tail-capped
+  (`ATTACHMENT_INLINE_TEXT_CAP`), images/binaries are listed as openable refs the
+  agent fetches with `curl "$SERAPHIM_API_URL/api/v1/attachments/<id>"`. Same
+  at-rest-encryption caveat as the other blobs.
 - **`heart_attacks`** — recorded "heart attacks" (turns that died mid-flight),
   written by the defibrillator loop (see above), never by a request. Each holds a
   task snapshot, the status at death, the diagnostic `detail` (error logs kept for

--- a/api/migrations/0046_task_attachments.sql
+++ b/api/migrations/0046_task_attachments.sql
@@ -1,0 +1,33 @@
+-- Ticket attachments (issue #291): operator uploads on internal tickets, plus
+-- source-ticket attachments (Jira) pulled into ticket data so the agent sees
+-- them. One shared table keyed by task, mirroring `task_screenshots` (#248): the
+-- bytes live here as `bytea` and are NEVER returned in board/task JSON (a
+-- dedicated endpoint streams them by id); list payloads carry only metadata.
+-- Operator-facing but still in Postgres, so respect at-rest disk encryption as
+-- with the other binary blobs and secret columns.
+CREATE TABLE task_attachments (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id     UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    -- Where the attachment came from: an operator upload, or pulled from the
+    -- source tracker. 'operator' | 'jira' | 'github'.
+    source      TEXT NOT NULL DEFAULT 'operator',
+    -- The source tracker's own attachment id (e.g. the Jira attachment id), used
+    -- to dedupe re-pulls so a re-sync never stores the same file twice. NULL for
+    -- operator uploads (each upload is its own distinct attachment).
+    external_id TEXT,
+    file_name   TEXT NOT NULL,
+    mime        TEXT NOT NULL DEFAULT '',
+    byte_size   BIGINT NOT NULL,
+    data        BYTEA NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The task view lists a task's attachments oldest first (upload/source order).
+CREATE INDEX task_attachments_task_idx ON task_attachments (task_id, created_at);
+
+-- Dedupe pulled source attachments: at most one row per (task, source, source id),
+-- so re-syncing a Jira ticket never duplicates its attachments. Operator uploads
+-- (external_id NULL) are exempt, so the same file can be uploaded more than once.
+CREATE UNIQUE INDEX task_attachments_source_uniq
+    ON task_attachments (task_id, source, external_id)
+    WHERE external_id IS NOT NULL;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -628,6 +628,22 @@ pub struct TaskScreenshot {
     pub created_at: DateTime<Utc>,
 }
 
+/// A ticket attachment (issue #291): an operator upload on an internal ticket, or
+/// a source-ticket attachment (e.g. Jira) pulled into the ticket. As the API
+/// exposes it: metadata only. The `data` bytea is deliberately NOT a field here,
+/// so it never rides along in a task/board payload; a dedicated endpoint streams
+/// the bytes by id. `source` is `operator` | `jira` | `github`.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct TaskAttachment {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub source: String,
+    pub file_name: String,
+    pub mime: String,
+    pub byte_size: i64,
+    pub created_at: DateTime<Utc>,
+}
+
 /// One Claude Code invocation against a task.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
 pub struct Turn {

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -16,8 +16,8 @@ use super::models::{
     EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment,
     NetworkAccessLevel, PendingPlacement, PendingQuestion, Question, QuestionOption,
     QuestionStatus, Railway, RepoDeletionImpact, RepoSyncError, Repository, ReviewPolicy, Settings,
-    SourceKind, StatsAggregate, Task, TaskColumn, TaskPullRequest, TaskScreenshot, TaskStatus,
-    Turn,
+    SourceKind, StatsAggregate, Task, TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot,
+    TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -2281,6 +2281,91 @@ pub async fn get_screenshot_image(
         .bind(id)
         .fetch_optional(pool)
         .await
+}
+
+// --- Ticket attachments (issue #291) -----------------------------------------
+
+/// The attachment metadata columns, every column EXCEPT the `data` bytea (and the
+/// internal `external_id` dedup key), so a `SELECT` for a list or RETURNING never
+/// drags the bytes into a JSON payload.
+const ATTACHMENT_COLUMNS: &str = "id, task_id, source, file_name, mime, byte_size, created_at";
+
+/// Stores one ticket attachment and returns its metadata (never the bytes).
+///
+/// `source` is `operator` | `jira` | `github`; `external_id` is the source
+/// tracker's own attachment id for pulled attachments (so a re-pull dedupes on the
+/// `task_attachments_source_uniq` index) and `None` for operator uploads.
+pub async fn create_attachment(
+    pool: &PgPool,
+    task_id: Uuid,
+    source: &str,
+    external_id: Option<&str>,
+    file_name: &str,
+    mime: &str,
+    data: &[u8],
+) -> sqlx::Result<TaskAttachment> {
+    sqlx::query_as::<_, TaskAttachment>(&format!(
+        "INSERT INTO task_attachments \
+         (task_id, source, external_id, file_name, mime, byte_size, data) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING {ATTACHMENT_COLUMNS}"
+    ))
+    .bind(task_id)
+    .bind(source)
+    .bind(external_id)
+    .bind(file_name)
+    .bind(mime)
+    .bind(i64::try_from(data.len()).unwrap_or(i64::MAX))
+    .bind(data)
+    .fetch_one(pool)
+    .await
+}
+
+/// A task's attachments, oldest first, metadata only (the bytes are streamed by id).
+pub async fn list_attachments_for_task(
+    pool: &PgPool,
+    task_id: Uuid,
+) -> sqlx::Result<Vec<TaskAttachment>> {
+    sqlx::query_as::<_, TaskAttachment>(&format!(
+        "SELECT {ATTACHMENT_COLUMNS} FROM task_attachments \
+         WHERE task_id = $1 ORDER BY created_at"
+    ))
+    .bind(task_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// The raw bytes, MIME, and file name of one attachment, for the streaming
+/// endpoint. `None` when no attachment has that id.
+pub async fn get_attachment_data(
+    pool: &PgPool,
+    id: Uuid,
+) -> sqlx::Result<Option<(Vec<u8>, String, String)>> {
+    sqlx::query_as::<_, (Vec<u8>, String, String)>(
+        "SELECT data, mime, file_name FROM task_attachments WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Whether a pulled source attachment is already stored, so a re-sync can skip
+/// re-downloading it. Keyed on the source tracker's own attachment id.
+pub async fn source_attachment_exists(
+    pool: &PgPool,
+    task_id: Uuid,
+    source: &str,
+    external_id: &str,
+) -> sqlx::Result<bool> {
+    let exists: Option<Uuid> = sqlx::query_scalar(
+        "SELECT id FROM task_attachments \
+         WHERE task_id = $1 AND source = $2 AND external_id = $3 LIMIT 1",
+    )
+    .bind(task_id)
+    .bind(source)
+    .bind(external_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(exists.is_some())
 }
 
 /// The id of a task's most recent turn, to associate an uploaded screenshot with

--- a/api/src/http/attachments.rs
+++ b/api/src/http/attachments.rs
@@ -1,0 +1,116 @@
+//! Ticket attachments (issue #291): operator uploads on a ticket, stored and
+//! served like screenshots (issue #248).
+//!
+//! An operator attaches an image or file to a ticket; the raw bytes are the
+//! request body and live as `bytea`, NEVER returned in a task/board payload. A
+//! dedicated streaming endpoint serves them by id, and the task view lists only
+//! the metadata (see [`super::tasks::TaskDetail`]). Source-ticket attachments
+//! (e.g. Jira) are pulled into the same table by the orchestrator at work time;
+//! they reuse the same storage and the same serve endpoint.
+
+use axum::body::Bytes;
+use axum::extract::{Path, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::ApiResult;
+use crate::db::queries;
+use crate::state::AppState;
+
+/// The largest attachment we accept. Generous enough for a crash log or a
+/// full-page screenshot while bounding a runaway upload; the upload route raises
+/// axum's default 2MB body limit to this (see `http::router`).
+pub const MAX_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
+
+/// Metadata the uploader passes as query params alongside the raw file body.
+#[derive(Debug, Deserialize)]
+pub struct CreateParams {
+    /// The original file name, shown in the task view and used by the agent when it
+    /// fetches the file into the workspace. Defaults to a generic name when absent.
+    #[serde(default)]
+    pub filename: String,
+}
+
+/// `POST /api/v1/tasks/:id/attachments?filename=..`
+///
+/// The raw file is the request body and its `Content-Type` becomes the stored
+/// MIME. One request per file (the frontend uploads each selected file in turn),
+/// which keeps this dependency-free (no multipart parser), mirroring the
+/// screenshot upload. Returns the new attachment's metadata.
+pub async fn create(
+    State(state): State<AppState>,
+    Path(task_id): Path<Uuid>,
+    Query(params): Query<CreateParams>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> ApiResult<Response> {
+    if queries::get_task(&state.db, task_id).await?.is_none() {
+        return Ok((StatusCode::NOT_FOUND, "task not found").into_response());
+    }
+    if body.is_empty() {
+        return Ok((StatusCode::BAD_REQUEST, "empty attachment").into_response());
+    }
+    if body.len() > MAX_ATTACHMENT_BYTES {
+        return Ok((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "attachment is too large (max 25 MB)",
+        )
+            .into_response());
+    }
+
+    let mime = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let file_name = match params.filename.trim() {
+        "" => "attachment",
+        name => name,
+    };
+
+    let attachment =
+        queries::create_attachment(&state.db, task_id, "operator", None, file_name, mime, &body)
+            .await?;
+    state.notify_board();
+
+    Ok((StatusCode::CREATED, Json(attachment)).into_response())
+}
+
+/// `GET /api/v1/attachments/:id` - stream a stored attachment's bytes. An
+/// attachment is immutable once stored, so it caches aggressively. The original
+/// file name rides in `Content-Disposition` so a browser download keeps it. 404
+/// when the id is unknown.
+pub async fn serve(State(state): State<AppState>, Path(id): Path<Uuid>) -> ApiResult<Response> {
+    let Some((data, mime, file_name)) = queries::get_attachment_data(&state.db, id).await? else {
+        return Ok((StatusCode::NOT_FOUND, "attachment not found").into_response());
+    };
+    let content_type = if mime.is_empty() {
+        "application/octet-stream".to_string()
+    } else {
+        mime
+    };
+    // `inline` so an image previews in the browser; the sanitized file name keeps a
+    // manual download readable. Quotes/control chars are stripped so the header
+    // value is always well-formed regardless of the source file name.
+    let safe_name: String = file_name
+        .chars()
+        .map(|c| if c == '"' || c.is_control() { '_' } else { c })
+        .collect();
+    Ok((
+        [
+            (header::CONTENT_TYPE, content_type),
+            (
+                header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable".to_string(),
+            ),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("inline; filename=\"{safe_name}\""),
+            ),
+        ],
+        data,
+    )
+        .into_response())
+}

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -4,6 +4,9 @@
 //! turns an `eyre` error into a 500 with a JSON body, so the happy path stays
 //! free of error plumbing.
 
+// Crate-visible so the orchestrator can reuse the shared attachment size cap when
+// it pulls source-ticket attachments (issue #291).
+pub(crate) mod attachments;
 mod automation;
 mod board;
 mod compose;
@@ -115,6 +118,17 @@ pub fn router(state: AppState) -> Router {
             )),
         )
         .route("/screenshots/:id", get(screenshots::serve))
+        // Ticket attachments (issue #291): operator uploads on a ticket. The raw
+        // file is the request body, so the upload route raises axum's 2MB default
+        // body limit to the attachment cap. The serve route streams any stored
+        // attachment (operator uploads and pulled Jira attachments alike) by id.
+        .route(
+            "/tasks/:id/attachments",
+            post(attachments::create).layer(axum::extract::DefaultBodyLimit::max(
+                attachments::MAX_ATTACHMENT_BYTES,
+            )),
+        )
+        .route("/attachments/:id", get(attachments::serve))
         .route("/agent/questions", post(questions::ask))
         .route("/questions/pending", get(questions::pending))
         .route("/questions/:id/answer", post(questions::answer))

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -10,7 +10,8 @@ use uuid::Uuid;
 
 use super::ApiResult;
 use crate::db::models::{
-    EnvSuggestion, Event, Question, SourceKind, Task, TaskColumn, TaskPullRequest, TaskScreenshot,
+    EnvSuggestion, Event, Question, SourceKind, Task, TaskAttachment, TaskColumn, TaskPullRequest,
+    TaskScreenshot,
 };
 use crate::db::queries;
 use crate::git;
@@ -62,6 +63,10 @@ pub struct TaskDetail {
     /// Screenshots the agent captured during the task (issue #248), newest first,
     /// metadata only; the bytes stream from `/screenshots/:id`.
     pub screenshots: Vec<TaskScreenshot>,
+    /// Attachments on the ticket (issue #291): operator uploads and pulled
+    /// source-ticket files, oldest first, metadata only; the bytes stream from
+    /// `/attachments/:id`.
+    pub attachments: Vec<TaskAttachment>,
 }
 
 /// `GET /api/v1/tasks/:id` - the card, its conversation events, its environment
@@ -82,6 +87,7 @@ pub async fn get_task(
     let questions = queries::list_questions_for_task(&state.db, id).await?;
     let pull_requests = queries::list_task_prs(&state.db, id).await?;
     let screenshots = queries::list_screenshots_for_task(&state.db, id).await?;
+    let attachments = queries::list_attachments_for_task(&state.db, id).await?;
     Ok(Json(TaskDetail {
         task,
         events,
@@ -89,6 +95,7 @@ pub async fn get_task(
         questions,
         pull_requests,
         screenshots,
+        attachments,
     })
     .into_response())
 }

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -216,6 +216,19 @@ pub struct JiraIssue {
     pub description: String,
 }
 
+/// One attachment on a Jira issue (issue #291), as listed by the REST API. The
+/// bytes are fetched separately from `content` with the configured auth.
+#[derive(Debug, Clone)]
+pub struct JiraAttachment {
+    /// The Jira attachment id, used to dedupe re-pulls.
+    pub id: String,
+    pub filename: String,
+    pub mime_type: String,
+    pub size: i64,
+    /// The authenticated download URL for the raw bytes.
+    pub content_url: String,
+}
+
 // --- The async REST client ---------------------------------------------------
 
 /// A configured Jira client. Built on demand from the stored connection so a
@@ -447,6 +460,77 @@ impl JiraClient {
             url: format!("{}/browse/{}", self.config.base_url, created.key),
             key: created.key,
         })
+    }
+
+    /// Lists an issue's attachments (issue #291): filename, MIME, size, and the
+    /// authenticated download URL for each. Empty when the issue has none.
+    pub async fn list_attachments(&self, issue_key: &str) -> Result<Vec<JiraAttachment>> {
+        #[derive(Deserialize)]
+        struct IssueAttachments {
+            fields: AttachmentField,
+        }
+        #[derive(Deserialize)]
+        struct AttachmentField {
+            #[serde(default)]
+            attachment: Vec<RawAttachment>,
+        }
+        #[derive(Deserialize)]
+        struct RawAttachment {
+            id: String,
+            #[serde(default)]
+            filename: String,
+            #[serde(rename = "mimeType", default)]
+            mime_type: String,
+            #[serde(default)]
+            size: i64,
+            #[serde(default)]
+            content: String,
+        }
+
+        let url = format!(
+            "{}{}/issue/{issue_key}?fields=attachment",
+            self.config.base_url,
+            self.config.api_base()
+        );
+        let issue: IssueAttachments = self.get_json(&url).await?;
+        Ok(issue
+            .fields
+            .attachment
+            .into_iter()
+            .map(|raw| JiraAttachment {
+                id: raw.id,
+                filename: raw.filename,
+                mime_type: raw.mime_type,
+                size: raw.size,
+                content_url: raw.content,
+            })
+            .collect())
+    }
+
+    /// Downloads an attachment's raw bytes from its `content` URL with the
+    /// configured auth, returning the bytes and the server-reported content type.
+    pub async fn download_attachment(&self, content_url: &str) -> Result<(Vec<u8>, String)> {
+        let response = self
+            .http
+            .get(content_url)
+            .header("Authorization", self.config.auth_header())
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(eyre!(
+                "Jira attachment download {content_url} failed ({status}): {body}"
+            ));
+        }
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("application/octet-stream")
+            .to_string();
+        let bytes = response.bytes().await?;
+        Ok((bytes.to_vec(), content_type))
     }
 }
 

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -682,14 +682,16 @@ pub async fn upsert_jira_issue(
     // key is globally unique, so existence and the placement are both keyed on the
     // key alone. An already-tracked card is left to the operator's curation. With
     // no placement (the common case) the default upsert runs exactly as before.
-    let pending = match queries::find_jira_task(&state.db, &issue.key).await? {
-        Some(_) => None,
-        None => {
-            queries::take_pending_placement(&state.db, SourceKind::Jira, None, &issue.key).await?
-        }
+    let is_new = queries::find_jira_task(&state.db, &issue.key)
+        .await?
+        .is_none();
+    let pending = if is_new {
+        queries::take_pending_placement(&state.db, SourceKind::Jira, None, &issue.key).await?
+    } else {
+        None
     };
 
-    match placement::resolve(pending.as_ref()) {
+    let task = match placement::resolve(pending.as_ref()) {
         placement::Placement::Default => {
             queries::upsert_jira_task(
                 &state.db,
@@ -703,7 +705,7 @@ pub async fn upsert_jira_issue(
                 column,
                 position,
             )
-            .await?;
+            .await?
         }
         placement::Placement::Placed {
             column: placed_column,
@@ -726,8 +728,16 @@ pub async fn upsert_jira_issue(
                 placed_position,
                 railway_id,
             )
-            .await?;
+            .await?
         }
+    };
+
+    // On the ticket's first sync, pull its attachments into ticket data (issue
+    // #291) so its screenshots/logs are stored and viewable on the board without a
+    // manual Jira fetch. Deduped and best-effort; only on first sync so a steady-
+    // state poll never re-lists attachments for every tracked ticket.
+    if is_new {
+        capture_jira_attachments(state, &task).await;
     }
     Ok(())
 }
@@ -1425,6 +1435,201 @@ async fn load_target_repos(state: &AppState, task: &Task) -> Vec<Repository> {
     repos
 }
 
+/// Assembles the fresh-work brief for a task: its discussion, target repos,
+/// stacked dependencies, and attachments (operator uploads plus any pulled from a
+/// Jira ticket, issue #291), all of which are best-effort and never block the
+/// turn. Extracted from `work_fresh` to keep that function focused.
+async fn build_fresh_prompt(
+    state: &AppState,
+    settings: &crate::db::models::Settings,
+    repo: &Repository,
+    task: &Task,
+    branch: &str,
+) -> String {
+    let comments = fetch_issue_comments(state, repo, task).await;
+    let target_repos = load_target_repos(state, task).await;
+    // Stack the ticket on any open (unmerged) dependency PR branches it names, so
+    // the agent merges them in rather than rediscovering and re-implementing them
+    // (issue #256).
+    let dependencies = resolve_dependency_branches(state, task).await;
+    // Pull a Jira ticket's attachments into ticket data (issue #291) so the brief
+    // carries its screenshots/logs, then load every stored attachment (operator
+    // uploads and pulled ones alike) for the prompt.
+    capture_jira_attachments(state, task).await;
+    let attachments = load_attachments(state, task).await;
+    prompt::build(
+        settings,
+        repo,
+        task,
+        branch,
+        &comments,
+        &target_repos,
+        &dependencies,
+        &attachments,
+    )
+}
+
+/// The byte budget for inlining a text/log attachment's content into the brief
+/// (issue #291). Beyond this the content is head/tail truncated with a marker;
+/// far larger files are listed as fetchable refs instead of inlined at all.
+const ATTACHMENT_INLINE_TEXT_CAP: usize = 40 * 1024;
+
+/// Loads a task's stored attachments for the prompt (issue #291): metadata for
+/// every attachment, with small text/log files inlined (head/tail capped) so the
+/// agent reads them directly and images/binaries left as fetchable refs.
+///
+/// Best-effort: a list or read failure drops attachments (or their inline text)
+/// rather than failing the turn.
+async fn load_attachments(state: &AppState, task: &Task) -> Vec<prompt::Attachment> {
+    let metas = match queries::list_attachments_for_task(&state.db, task.id).await {
+        Ok(metas) => metas,
+        Err(error) => {
+            warn!(error = %error, task_id = %task.id, "could not list task attachments for the prompt");
+            return Vec::new();
+        }
+    };
+
+    let mut attachments = Vec::with_capacity(metas.len());
+    for meta in metas {
+        let inline_text = if is_inlineable_text(&meta.file_name, &meta.mime, meta.byte_size) {
+            match queries::get_attachment_data(&state.db, meta.id).await {
+                Ok(Some((data, _, _))) => Some(inline_attachment_text(&data)),
+                Ok(None) => None,
+                Err(error) => {
+                    warn!(error = %error, attachment = %meta.id, "could not read an attachment for inlining");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        attachments.push(prompt::Attachment {
+            file_name: meta.file_name,
+            mime: meta.mime,
+            byte_size: meta.byte_size,
+            id: meta.id.to_string(),
+            inline_text,
+        });
+    }
+    attachments
+}
+
+/// Whether an attachment is small, text-like content worth inlining into the brief
+/// rather than listing as a fetchable ref (issue #291). Reads a little past the
+/// inline cap so a slightly-over file still contributes its head/tail; anything
+/// far larger is treated as a ref.
+fn is_inlineable_text(file_name: &str, mime: &str, byte_size: i64) -> bool {
+    let read_cap = i64::try_from(ATTACHMENT_INLINE_TEXT_CAP.saturating_mul(4)).unwrap_or(i64::MAX);
+    if byte_size > read_cap {
+        return false;
+    }
+    let extension = std::path::Path::new(file_name)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase);
+    mime.starts_with("text/")
+        || matches!(mime, "application/json" | "application/xml")
+        || matches!(extension.as_deref(), Some("log" | "txt" | "csv" | "json"))
+}
+
+/// Decodes attachment bytes to text and, when longer than the inline cap, keeps
+/// the head and tail with a truncation marker between them, so a long log still
+/// shows its start and end. Slices on char counts so multi-byte UTF-8 is never
+/// split mid-character.
+fn inline_attachment_text(data: &[u8]) -> String {
+    let text = String::from_utf8_lossy(data);
+    if text.len() <= ATTACHMENT_INLINE_TEXT_CAP {
+        return text.into_owned();
+    }
+    let chars: Vec<char> = text.chars().collect();
+    let head_chars = ATTACHMENT_INLINE_TEXT_CAP * 6 / 10;
+    let tail_chars = ATTACHMENT_INLINE_TEXT_CAP - head_chars;
+    if chars.len() <= head_chars + tail_chars {
+        return text.into_owned();
+    }
+    let head: String = chars[..head_chars].iter().collect();
+    let tail: String = chars[chars.len() - tail_chars..].iter().collect();
+    let elided = chars.len() - head_chars - tail_chars;
+    format!("{head}\n\n...[truncated {elided} characters]...\n\n{tail}")
+}
+
+/// Pulls a Jira ticket's attachments into ticket data (issue #291): lists them and
+/// downloads + stores each one not already captured (deduped by the Jira
+/// attachment id), so the agent sees its screenshots/logs without a manual Jira
+/// fetch. Best-effort and Jira-only: a non-Jira task, unconfigured Jira, an
+/// oversized file, or any per-attachment failure is logged and skipped, never
+/// failing the caller.
+async fn capture_jira_attachments(state: &AppState, task: &Task) {
+    if task.source_kind != SourceKind::Jira || task.external_id.trim().is_empty() {
+        return;
+    }
+    let jira = match state.jira().await {
+        Ok(Some(jira)) => jira,
+        Ok(None) => return,
+        Err(error) => {
+            warn!(error = %error, task_id = %task.id, "could not build a Jira client for attachments");
+            return;
+        }
+    };
+    let attachments = match jira.list_attachments(&task.external_id).await {
+        Ok(attachments) => attachments,
+        Err(error) => {
+            warn!(error = %error, task_id = %task.id, "could not list Jira attachments");
+            return;
+        }
+    };
+
+    let cap = i64::try_from(crate::http::attachments::MAX_ATTACHMENT_BYTES).unwrap_or(i64::MAX);
+    for attachment in attachments {
+        // Skip ones already stored (deduped by the Jira attachment id), so a re-pull
+        // is cheap and never re-downloads.
+        match queries::source_attachment_exists(&state.db, task.id, "jira", &attachment.id).await {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(error) => {
+                warn!(error = %error, task_id = %task.id, "could not check an existing Jira attachment");
+                continue;
+            }
+        }
+        // Store images/logs/binaries up to the cap; skip anything larger (declared
+        // size first, so we never start the download).
+        if attachment.size > cap {
+            info!(task_id = %task.id, file = %attachment.filename, "skipping oversized Jira attachment");
+            continue;
+        }
+        let (data, content_type) = match jira.download_attachment(&attachment.content_url).await {
+            Ok(downloaded) => downloaded,
+            Err(error) => {
+                warn!(error = %error, task_id = %task.id, "could not download a Jira attachment");
+                continue;
+            }
+        };
+        if data.len() > crate::http::attachments::MAX_ATTACHMENT_BYTES {
+            info!(task_id = %task.id, file = %attachment.filename, "skipping oversized Jira attachment");
+            continue;
+        }
+        // Prefer Jira's declared MIME; fall back to the download's content type.
+        let mime = if attachment.mime_type.is_empty() {
+            content_type.as_str()
+        } else {
+            attachment.mime_type.as_str()
+        };
+        if let Err(error) = queries::create_attachment(
+            &state.db,
+            task.id,
+            "jira",
+            Some(&attachment.id),
+            &attachment.filename,
+            mime,
+            &data,
+        )
+        .await
+        {
+            warn!(error = %error, task_id = %task.id, "could not store a Jira attachment");
+        }
+    }
+}
+
 /// Resolves the open (unmerged) dependency PR branches a fresh ticket should build
 /// on top of (issue #256).
 ///
@@ -1558,21 +1763,7 @@ async fn work_fresh(
         queries::acknowledge_answers(&state.db, task.id).await?;
         prompt
     } else {
-        let comments = fetch_issue_comments(state, &repo, &task).await;
-        let target_repos = load_target_repos(state, &task).await;
-        // Stack the ticket on any open (unmerged) dependency PR branches it names,
-        // so the agent merges them in rather than rediscovering and re-implementing
-        // them (issue #256).
-        let dependencies = resolve_dependency_branches(state, &task).await;
-        prompt::build(
-            &settings,
-            &repo,
-            &task,
-            &branch,
-            &comments,
-            &target_repos,
-            &dependencies,
-        )
+        build_fresh_prompt(state, &settings, &repo, &task, &branch).await
     };
     let outcome = run_agent_turn(state, handle, &settings, &task, prompt).await?;
     persist_session(state, handle, &outcome).await?;

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -1041,6 +1041,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         );
 
         assert!(prompt.contains("Work Jira ticket BUG-42: Crash on empty input"));

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -22,6 +22,21 @@ pub struct DependencyBranch {
     pub repos: Vec<String>,
 }
 
+/// A ticket attachment surfaced to the agent in the brief (issue #291).
+///
+/// `inline_text` is `Some` for a small text/log attachment whose content is
+/// inlined directly (already head/tail capped by the loader); it is `None` for an
+/// image or binary, which is listed as an openable ref the agent fetches by `id`
+/// (`GET $SERAPHIM_API_URL/api/v1/attachments/<id>`).
+#[derive(Debug, Clone)]
+pub struct Attachment {
+    pub file_name: String,
+    pub mime: String,
+    pub byte_size: i64,
+    pub id: String,
+    pub inline_text: Option<String>,
+}
+
 /// Builds the instruction text for working `task` fresh on a new `branch`.
 ///
 /// `comments` is the issue's discussion thread (empty when there is none or it
@@ -34,6 +49,13 @@ pub struct DependencyBranch {
 /// `dependencies` are open dependency PR branches the ticket builds on top of
 /// (issue #256); when present, the agent is told to merge them in first rather
 /// than discovering and re-implementing them.
+/// `attachments` are the ticket's attachments (issue #291): small text/log files
+/// are inlined into the brief and images/binaries are listed as openable refs.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the fresh-work brief genuinely composes from all of these inputs; \
+              grouping them into a struct would only move the noise"
+)]
 pub fn build(
     settings: &Settings,
     repo: &Repository,
@@ -42,9 +64,10 @@ pub fn build(
     comments: &[IssueComment],
     target_repos: &[Repository],
     dependencies: &[DependencyBranch],
+    attachments: &[Attachment],
 ) -> String {
     let repo_path = format!("/workspace/{}", repo_dir_name(&repo.full_name));
-    let mut prompt = context_header(settings, repo, task, comments);
+    let mut prompt = context_header(settings, repo, task, comments, attachments);
 
     // A GitHub task's PR should reference its issue (so it links/closes on merge);
     // an internal task has no upstream issue, so the PR is opened without one.
@@ -161,7 +184,7 @@ pub fn build_ci_fix(
     } else {
         failing_checks.join(", ")
     };
-    let mut prompt = context_header(settings, repo, task, comments);
+    let mut prompt = context_header(settings, repo, task, comments, &[]);
 
     prompt.push_str(&format!(
         "# Fixing CI\n\
@@ -214,7 +237,7 @@ pub fn build_merge_conflict(
     } else {
         reason.trim().to_string()
     };
-    let mut prompt = context_header(settings, repo, task, comments);
+    let mut prompt = context_header(settings, repo, task, comments, &[]);
 
     prompt.push_str(&format!(
         "# Resolving a merge conflict\n\
@@ -264,7 +287,7 @@ pub fn build_revisit(
     } else {
         reason.trim().to_string()
     };
-    let mut prompt = context_header(settings, repo, task, comments);
+    let mut prompt = context_header(settings, repo, task, comments, &[]);
 
     prompt.push_str(&format!(
         "# Revisiting a stuck pull request\n\
@@ -314,7 +337,7 @@ pub fn build_address_review(
     comments: &[IssueComment],
 ) -> String {
     let repo_path = format!("/workspace/{}", repo_dir_name(&repo.full_name));
-    let mut prompt = context_header(settings, repo, task, comments);
+    let mut prompt = context_header(settings, repo, task, comments, &[]);
 
     prompt.push_str(&format!(
         "# Addressing pull request review comments\n\
@@ -428,6 +451,7 @@ fn context_header(
     repo: &Repository,
     task: &Task,
     comments: &[IssueComment],
+    attachments: &[Attachment],
 ) -> String {
     let mut prompt = String::new();
 
@@ -472,6 +496,10 @@ fn context_header(
     // The full discussion (when any), so the agent treats comments as part of the
     // brief rather than only the title and description.
     prompt.push_str(&render_discussion(comments));
+
+    // Ticket attachments (issue #291): inlined logs and openable image/file refs,
+    // so a UI bug or a log-driven bug can be worked from the ticket alone.
+    prompt.push_str(&render_attachments(attachments));
 
     // Shared by every mode: noticing missing tooling can happen on any run, so
     // the recommend-improvements guidance lives in the common header.
@@ -537,6 +565,67 @@ fn render_discussion(comments: &[IssueComment]) -> String {
     }
 
     section
+}
+
+/// Renders the ticket's attachments for the brief (issue #291).
+///
+/// A small text/log attachment is inlined verbatim (its content already head/tail
+/// capped by the loader) so the agent reads it directly; an image or binary is
+/// listed as an openable ref the agent fetches from the API by id. Returns an
+/// empty string when there are no attachments, so a plain ticket's brief is
+/// unchanged.
+fn render_attachments(attachments: &[Attachment]) -> String {
+    if attachments.is_empty() {
+        return String::new();
+    }
+
+    let mut section = format!(
+        "# Attachments\n\
+         This ticket has {count} attachment{plural}. Text and log files are inlined below. \
+         Image and binary files are stored in Seraphim; fetch one into your workspace with \
+         `curl -fsS \"$SERAPHIM_API_URL/api/v1/attachments/<id>\" -o <file>`, using the id given \
+         per file. A UI bug's screenshots and a crash's logs are part of the brief: review them.\n\n",
+        count = attachments.len(),
+        plural = if attachments.len() == 1 { "" } else { "s" },
+    );
+
+    for attachment in attachments {
+        // Build each entry as a local string, then push it: this keeps the loop off
+        // the `push_str(&format!(...))` form clippy flags as `format_push_string`.
+        let entry = match &attachment.inline_text {
+            Some(text) => format!(
+                "## {name} ({mime}, {size})\n```\n{text}\n```\n\n",
+                name = attachment.file_name,
+                mime = attachment.mime,
+                size = human_size(attachment.byte_size),
+            ),
+            None => format!(
+                "- {name} ({mime}, {size}) - id `{id}`: \
+                 `curl -fsS \"$SERAPHIM_API_URL/api/v1/attachments/{id}\" -o \"{name}\"`\n",
+                name = attachment.file_name,
+                mime = attachment.mime,
+                size = human_size(attachment.byte_size),
+                id = attachment.id,
+            ),
+        };
+        section.push_str(&entry);
+    }
+    section.push('\n');
+    section
+}
+
+/// A compact human-readable byte size (e.g. `4 KB`, `2 MB`), for the attachment
+/// listing. Integer division keeps it free of float casts.
+fn human_size(bytes: i64) -> String {
+    const KB: i64 = 1024;
+    const MB: i64 = 1024 * 1024;
+    if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 /// Guidance, shared by the conflict-resolution prompts, on keeping database
@@ -888,6 +977,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         );
 
         // An internal ticket has no upstream issue, so the brief and the PR step
@@ -910,6 +1000,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         );
         assert!(prompt.contains("Work issue #57"));
         assert!(prompt.contains("referencing issue #57"));
@@ -925,6 +1016,7 @@ mod tests {
             &sample_repo(),
             &sample_task(),
             "seraphim/issue-57",
+            &[],
             &[],
             &[],
             &[],
@@ -957,6 +1049,7 @@ mod tests {
             &[],
             &targets,
             &[],
+            &[],
         );
 
         assert!(prompt.contains("This ticket targets multiple repositories"));
@@ -974,8 +1067,64 @@ mod tests {
             &[],
             &[sample_repo()],
             &[],
+            &[],
         );
         assert!(!prompt.contains("targets multiple repositories"));
+    }
+
+    #[test]
+    fn attachments_inline_logs_and_list_image_refs() {
+        // Issue #291: a text/log attachment is inlined verbatim so the agent reads
+        // it directly, while an image is listed with a fetch recipe keyed by id.
+        let attachments = [
+            Attachment {
+                file_name: "crash.log".to_string(),
+                mime: "text/plain".to_string(),
+                byte_size: 42,
+                id: "11111111-1111-1111-1111-111111111111".to_string(),
+                inline_text: Some("panic: index out of bounds".to_string()),
+            },
+            Attachment {
+                file_name: "screen.png".to_string(),
+                mime: "image/png".to_string(),
+                byte_size: 2048,
+                id: "22222222-2222-2222-2222-222222222222".to_string(),
+                inline_text: None,
+            },
+        ];
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &[],
+            &attachments,
+        );
+
+        assert!(prompt.contains("# Attachments"));
+        // The log is inlined verbatim.
+        assert!(prompt.contains("crash.log"));
+        assert!(prompt.contains("panic: index out of bounds"));
+        // The image is a fetchable ref by id, not inlined.
+        assert!(prompt.contains("22222222-2222-2222-2222-222222222222"));
+        assert!(prompt.contains("$SERAPHIM_API_URL/api/v1/attachments/"));
+    }
+
+    #[test]
+    fn no_attachments_means_no_attachments_section() {
+        let prompt = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[sample_repo()],
+            &[],
+            &[],
+        );
+        assert!(!prompt.contains("# Attachments"));
     }
 
     #[test]
@@ -993,6 +1142,7 @@ mod tests {
             &[],
             &[sample_repo()],
             &dependencies,
+            &[],
         );
 
         assert!(prompt.contains("Stacked on unmerged dependencies"));
@@ -1015,6 +1165,7 @@ mod tests {
             &[],
             &[sample_repo()],
             &[],
+            &[],
         );
         assert!(!prompt.contains("Stacked on unmerged dependencies"));
     }
@@ -1031,6 +1182,7 @@ mod tests {
             "seraphim/issue-57",
             &[],
             &[sample_repo()],
+            &[],
             &[],
         );
         assert!(prompt.contains("seraphim-ask <<'JSON'"));
@@ -1053,6 +1205,7 @@ mod tests {
             &[],
             &[sample_repo()],
             &[],
+            &[],
         );
         assert!(prompt.contains("computed-style checks"));
         assert!(prompt.contains("/usr/local/share/seraphim/visual-checks.md"));
@@ -1074,6 +1227,7 @@ mod tests {
             &[],
             &[sample_repo()],
             &[],
+            &[],
         );
         assert!(prompt.contains("/usr/local/share/seraphim/visual-regression.md"));
         assert!(prompt.contains("opt-in per repo"));
@@ -1091,6 +1245,7 @@ mod tests {
             "seraphim/issue-57",
             &[],
             &[sample_repo()],
+            &[],
             &[],
         );
         assert!(prompt.contains("layout primitives"));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,6 +37,7 @@ import type {
   TailscaleActionResponse,
   TailscaleStatus,
   Task,
+  TaskAttachment,
   TaskColumn,
   TaskDetail
 } from './types'
@@ -101,6 +102,19 @@ export function createInternalTask(body: {
 // valid for internal tickets. Returns the updated task.
 export function setTaskRepos(taskId: string, repoIds: string[]) {
   return apiClient.post(`tasks/${taskId}/repo`, { json: { repo_ids: repoIds } }).json<Task>()
+}
+
+// Upload one attachment to a ticket (issue #291). The raw file is the request
+// body and its type becomes the stored MIME; the file name rides as a query param.
+// One call per file. Returns the new attachment's metadata.
+export function uploadTaskAttachment(taskId: string, file: File) {
+  return apiClient
+    .post(`tasks/${taskId}/attachments`, {
+      body: file,
+      headers: { 'Content-Type': file.type || 'application/octet-stream' },
+      searchParams: { filename: file.name }
+    })
+    .json<TaskAttachment>()
 }
 
 // --- Live statistics ---------------------------------------------------------

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -549,6 +549,19 @@ export type TaskScreenshot = {
   created_at: string
 }
 
+// A ticket attachment (issue #291): an operator upload on an internal ticket, or
+// a source-ticket file (e.g. Jira) pulled into the ticket. Metadata only; the
+// bytes stream from `/attachments/:id`. `source` is 'operator' | 'jira' | 'github'.
+export type TaskAttachment = {
+  id: string
+  task_id: string
+  source: string
+  file_name: string
+  mime: string
+  byte_size: number
+  created_at: string
+}
+
 export type TaskDetail = {
   task: Task
   events: AgentEvent[]
@@ -556,6 +569,7 @@ export type TaskDetail = {
   questions: Question[]
   pull_requests: TaskPullRequest[]
   screenshots: TaskScreenshot[]
+  attachments: TaskAttachment[]
 }
 
 // The kanban lanes, in display order, with human-readable labels.

--- a/frontend/src/routes/issues/new/+page.svelte
+++ b/frontend/src/routes/issues/new/+page.svelte
@@ -5,7 +5,7 @@
   import { goto } from '$app/navigation'
   import { toast } from 'svelte-sonner'
 
-  import { createInternalTask, listRepos } from '$lib/api'
+  import { createInternalTask, listRepos, uploadTaskAttachment } from '$lib/api'
   import * as Card from '$lib/components/ui/card'
   import { Button, buttonVariants } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
@@ -24,6 +24,14 @@
   let saving = $state(false)
   let repos = $state<Repository[]>([])
   let selectedRepoIds = $state<string[]>([])
+  // Files the operator attached (issue #291); uploaded to the ticket once it is
+  // created (attachments key on a task id, which only exists after creation).
+  let attachmentFiles = $state<File[]>([])
+
+  function onAttachmentsChange(event: Event) {
+    const input = event.target as HTMLInputElement
+    attachmentFiles = input.files ? Array.from(input.files) : []
+  }
 
   onMount(async () => {
     repos = await listRepos()
@@ -62,6 +70,10 @@
         state: open ? 'open' : 'closed',
         repo_ids: selectedRepoIds
       })
+      // Upload any attached files to the freshly created ticket (issue #291).
+      for (const file of attachmentFiles) {
+        await uploadTaskAttachment(task.id, file)
+      }
       toast.success('Issue created')
       goto(`/task/${task.id}`)
     } catch {
@@ -97,6 +109,24 @@
           bind:value={description}
           class="resize-y"
         />
+      </div>
+
+      <div class="grid gap-2">
+        <Label for="attachments">Attachments</Label>
+        <input
+          id="attachments"
+          type="file"
+          multiple
+          onchange={onAttachmentsChange}
+          class="text-sm file:mr-3 file:rounded-md file:border file:border-input file:bg-background file:px-3 file:py-1.5 file:text-sm hover:file:bg-accent"
+        />
+        <span class="text-xs text-muted-foreground">
+          Attach screenshots or log files. The agent sees images as openable refs and inlines small
+          text/log files into its brief. Uploaded when the ticket is created.
+          {#if attachmentFiles.length}
+            <span class="text-foreground">{attachmentFiles.length} selected.</span>
+          {/if}
+        </span>
       </div>
 
       <div class="grid gap-2">

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -6,6 +6,7 @@
     Question,
     Repository,
     Task,
+    TaskAttachment,
     TaskPullRequest,
     TaskScreenshot
   } from '$lib/types'
@@ -21,6 +22,7 @@
     ExternalLink,
     GitPullRequest,
     NotebookPen,
+    Paperclip,
     Pause,
     Play,
     RotateCcw
@@ -35,7 +37,8 @@
     setTaskBlocking,
     setTaskHold,
     setTaskNotes,
-    setTaskRepos
+    setTaskRepos,
+    uploadTaskAttachment
   } from '$lib/api'
   import { STATUS_BADGE, STATUS_LABELS } from '$lib/types'
   import { PaneGroup, type PaneGroupAPI } from 'paneforge'
@@ -75,6 +78,9 @@
   let questions = $state<Question[]>([])
   let pullRequests = $state<TaskPullRequest[]>([])
   let screenshots = $state<TaskScreenshot[]>([])
+  let attachments = $state<TaskAttachment[]>([])
+  // Operator attachment upload (issue #291): in-flight flag for the file picker.
+  let uploadingAttachments = $state(false)
   let eventSource: EventSource | null = null
 
   // The fullscreen screenshot viewer (issue #249): the set to page through and the
@@ -117,6 +123,42 @@
     task = await setTaskRepos(task.id, targetRepoIds)
     targetRepoIds = [...task.target_repo_ids]
     toast.success(targetRepoIds.length ? 'Target repos saved' : 'Target repos cleared')
+  }
+
+  // Operator attachment upload (issue #291): each selected file is uploaded as its
+  // own request (matching the backend's one-file-per-request route), then appended
+  // to the list so it shows immediately without a full reload.
+  async function uploadAttachments(event: Event) {
+    const input = event.target as HTMLInputElement
+    const files = input.files
+    if (!task || !files?.length) {
+      return
+    }
+    uploadingAttachments = true
+    try {
+      for (const file of Array.from(files)) {
+        const stored = await uploadTaskAttachment(task.id, file)
+        attachments = [...attachments, stored]
+      }
+      toast.success(files.length === 1 ? 'Attachment uploaded' : `${files.length} attachments uploaded`)
+    } catch {
+      toast.error('Could not upload the attachment')
+    } finally {
+      uploadingAttachments = false
+      // Clear the picker so re-selecting the same file fires the change event again.
+      input.value = ''
+    }
+  }
+
+  // A compact human-readable byte size for the attachment list.
+  function formatBytes(bytes: number): string {
+    if (bytes >= 1024 * 1024) {
+      return `${Math.round(bytes / (1024 * 1024))} MB`
+    }
+    if (bytes >= 1024) {
+      return `${Math.round(bytes / 1024)} KB`
+    }
+    return `${bytes} B`
   }
 
   // A one-word status for a PR row, combining its lifecycle and (while open) its
@@ -350,6 +392,7 @@
     questions = detail.questions
     pullRequests = detail.pull_requests
     screenshots = detail.screenshots
+    attachments = detail.attachments
     // Seed the notepad once, and open it if there is already something to read.
     if (!notesInitialized) {
       notes = detail.task.notes
@@ -656,6 +699,85 @@
         '🧹 Follow-up work',
         'Work the agent noticed but kept out of this task (dead code, tech debt, security, deprecations). Check one off, or one-click it into a ticket; unchecked ones stay loud on the board.'
       )}
+    {/if}
+
+    {#if attachments.length || task.source_kind === 'internal'}
+      <!-- Ticket attachments (issue #291): operator uploads on an internal ticket
+           and source-ticket files (e.g. Jira) pulled in on sync. Metadata rides in
+           the task payload; the bytes stream from a dedicated endpoint and are
+           lazy-loaded. Images preview as thumbnails; other files are download
+           links. The agent gets the same content in its prompt. -->
+      <section class="rounded-lg border border-border bg-card p-3">
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="flex items-center gap-1.5 text-sm font-semibold">
+            <Paperclip class="size-4 text-muted-foreground" />
+            Attachments
+            {#if attachments.length}
+              <span class="text-xs font-normal text-muted-foreground">({attachments.length})</span>
+            {/if}
+          </h2>
+          {#if task.source_kind === 'internal'}
+            <label
+              class={buttonVariants({ variant: 'outline', size: 'sm' }) + ' cursor-pointer'}
+              title="Attach images or files to this ticket"
+            >
+              {uploadingAttachments ? 'Uploading…' : 'Add files'}
+              <input
+                type="file"
+                multiple
+                class="hidden"
+                disabled={uploadingAttachments}
+                onchange={uploadAttachments}
+              />
+            </label>
+          {/if}
+        </div>
+        {#if task.source_kind === 'internal' && !attachments.length}
+          <p class="mt-1 text-xs text-muted-foreground">
+            Attach a screenshot or a log file. The agent sees images as openable refs and inlines
+            small text/log files into its brief.
+          </p>
+        {/if}
+        {#if attachments.length}
+          <ul class="mt-2 flex flex-col gap-2">
+            {#each attachments as attachment (attachment.id)}
+              <li class="flex items-center gap-2">
+                {#if attachment.mime.startsWith('image/')}
+                  <a
+                    href={`/api/v1/attachments/${attachment.id}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    class="block flex-none overflow-hidden rounded border border-border hover:border-primary"
+                  >
+                    <img
+                      src={`/api/v1/attachments/${attachment.id}`}
+                      alt={attachment.file_name}
+                      loading="lazy"
+                      class="size-10 bg-muted object-cover"
+                    />
+                  </a>
+                {:else}
+                  <Paperclip class="size-4 flex-none text-muted-foreground" />
+                {/if}
+                <a
+                  href={`/api/v1/attachments/${attachment.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  class="min-w-0 flex-1 truncate text-sm hover:underline"
+                  title={attachment.file_name}
+                >
+                  {attachment.file_name}
+                </a>
+                <span class="flex-none text-xs text-muted-foreground">
+                  {formatBytes(attachment.byte_size)}{attachment.source !== 'operator'
+                    ? ` · ${attachment.source}`
+                    : ''}
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
     {/if}
 
     {#if screenshots.length}


### PR DESCRIPTION
Closes #291. Complements #290 (auto-pull/work Jira tickets).

Captures attachments into ticket data so the agent sees them: operator uploads on internal tickets, and Jira ticket attachments pulled in on sync/work. Today a UI bug's screenshots live only on Jira and a crash's log never reaches the agent; this fixes both.

## Storage (mirrors `task_screenshots`)
- **Migration 0046** `task_attachments`: one shared table keyed by `task_id`, bytes as `bytea`, with a `source` (`operator` | `jira` | `github`) and, for pulled files, the tracker's `external_id` (deduped via a partial unique index so a re-pull never duplicates). Bytes are **never** in board/task JSON; metadata-only `TaskAttachment` rides in `TaskDetail`, and `GET /attachments/:id` streams the bytes (immutable cache, `Content-Disposition` carries the file name).
- **Operator upload** `POST /tasks/:id/attachments`: raw file as the body (Content-Type = MIME, `?filename=`), one file per request, no multipart dependency (like the screenshot upload). The route raises axum's 2MB body limit to 25MB.

## Jira capture
- `JiraClient::list_attachments` (`GET issue?fields=attachment`) + `download_attachment` (auth'd content fetch).
- `orchestrator::capture_jira_attachments` lists and downloads + stores each not-already-stored attachment (deduped on the Jira attachment id), on a Jira ticket's **first sync** (so it is viewable on the board) and again **when the agent works it** (so the prompt is fresh). Best-effort and Jira-only; oversized files are skipped.

## Prompt
- `prompt::build` renders an `# Attachments` section: small **text/log files are inlined** head/tail-capped (40 KB), **images/binaries are listed as openable refs** the agent fetches with `curl "$SERAPHIM_API_URL/api/v1/attachments/<id>"`. The loader inlines text by extension/MIME and reads bytes only for those.

## Frontend
- The task page shows attachments (image thumbnails + download links) with an "Add files" control on internal tickets; the create-issue form uploads selected files right after the ticket is created.

## Acceptance criteria
- [x] Operator can attach an image/file to an internal ticket; it shows in the task view and reaches the prompt.
- [x] Syncing a Jira ticket with attachments brings them in: logs inlined (size-capped), images stored and viewable, no manual Jira CLI fetch.
- [x] The prompt includes attachment content (inlined logs + openable image refs).
- [x] Large attachments are stored, not inlined; bytes never returned in board/task JSON.

## Verification
- `cargo +1.88 fmt`/`clippy` clean (55 warnings = develop baseline, **zero new**), 165 backend tests pass (3 new). Frontend `check` 0/0 and `build` pass.
- Migration applies on a fresh PG17; the dedup unique index (Jira re-pull is a no-op; operator dupes allowed) and metadata-only SELECT validated against it.

## Visual review
Skipped: the Playwright browser is not installed in this environment (`browser_resize` reports `chrome-for-testing` not installed). The new UI reuses the existing screenshot-gallery `<section>` primitives class-for-class and standard shadcn/Tailwind inputs; `svelte-check` is 0/0 and the build passes.

## Notes
- This branch is cut from `develop`, where Jira tickets are not yet auto-worked (that is #290). So the **first-sync** Jira capture delivers value on `develop` today (attachments stored + viewable), and the **work-time** capture + prompt inlining light up once #290 lands.