### PR TITLE
Lift the usage auto-pause manually or by raising the threshold (#292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,7 +616,17 @@ Playwright MCP, check layout via computed styles at 375px and 1280px).
   conversation panel is GitHub/internal only), and assignee write-back.
 - **MooreslabAI human-review commenting** — `GitHubSource::comment` exists but is
   unused (`#[expect(dead_code)]`).
-- **Rate-limit handling** — surface `rate_limit` events and auto-pause (planned).
+- **Subscription usage auto-pause** — when `usage_limit_pause_enabled`, a Claude
+  `rate_limit_event` that crosses `usage_limit_threshold` (or a rejected/exhausted
+  window) sets `settings.usage_paused_until` to the window's reset time (pure
+  decision in `orchestrator::usage::pause_until`); `next_actionable_task` holds all
+  new work until that time, then auto-clears it. Escape hatches (issue #292):
+  `POST /settings/usage/resume` clears the pause now (the board banner and the
+  Settings usage section each have a "Resume now" button), and every settings
+  update runs `orchestrator::reevaluate_usage_pause`, which lifts an active pause
+  when the toggle is turned off or the threshold is raised above the latest known
+  utilization (`usage::should_lift_pause`, re-judging the latest `rate_limit`
+  event). A genuinely exhausted window still stands until reset.
 
 ## Railways (planned)
 

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -155,6 +155,8 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/settings", get(settings::get).patch(settings::update))
         .route("/settings/pause", post(settings::set_pause))
+        // Manually lift an active subscription-usage auto-pause (issue #292).
+        .route("/settings/usage/resume", post(settings::resume_usage))
         .route("/notepad", get(notepad::get).put(notepad::set))
         .route("/settings/tokens", post(settings::set_tokens))
         .route(

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -17,6 +17,7 @@ use crate::db::models::{
     AvailabilityWindow, EnvVarWrite, JiraDeployment, NetworkAccessLevel, ReviewPolicy, Settings,
 };
 use crate::db::queries;
+use crate::orchestrator;
 use crate::secrets::mask;
 use crate::state::AppState;
 
@@ -103,6 +104,20 @@ pub async fn update(
         body.completion_sound_enabled,
     )
     .await?;
+    // Re-evaluate an active usage auto-pause against the change (issue #292): a
+    // disabled toggle or a threshold raised above current utilization lifts the
+    // pause now, instead of waiting for the window reset.
+    let updated = queries::get_settings(&state.db).await?;
+    orchestrator::reevaluate_usage_pause(&state, &updated).await?;
+    state.notify_board();
+    Ok(Json(settings_view(&state).await?))
+}
+
+/// `POST /api/v1/settings/usage/resume` - manually clear an active usage
+/// auto-pause (issue #292), so the operator can resume the agent from the UI
+/// without a DB edit. A no-op when nothing is paused.
+pub async fn resume_usage(State(state): State<AppState>) -> ApiResult<Json<Settings>> {
+    queries::set_usage_paused_until(&state.db, None).await?;
     state.notify_board();
     Ok(Json(settings_view(&state).await?))
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1313,6 +1313,47 @@ async fn agent_loop(state: AppState, handle: RailwayHandle) {
     }
 }
 
+/// Re-evaluates an active usage auto-pause after a settings change and lifts it if
+/// it no longer applies (issue #292).
+///
+/// The auto-pause keys only to the window reset time, so without this neither a
+/// raised `usage_limit_threshold` nor a disabled `usage_limit_pause_enabled` would
+/// take effect until the reset. Called on every settings update: when there is an
+/// active (future) pause and [`usage::should_lift_pause`] says it no longer holds
+/// (the feature was turned off, or the latest utilization is now under the raised
+/// threshold), it clears `usage_paused_until` so the agent resumes immediately. A
+/// genuinely exhausted window still stands until reset. Best-effort and idempotent;
+/// when no pause is active it does nothing.
+pub(crate) async fn reevaluate_usage_pause(
+    state: &AppState,
+    settings: &crate::db::models::Settings,
+) -> Result<()> {
+    let Some(until) = settings.usage_paused_until else {
+        return Ok(());
+    };
+    // An already-lapsed pause is cleared by the gate on the next tick; nothing to do.
+    if Utc::now() >= until {
+        return Ok(());
+    }
+    // Re-judge against the latest rate-limit signal at the current threshold. The
+    // stored payload may wrap the info under `rate_limit_info` (the event) or be the
+    // info object itself, so accept either shape.
+    let payload = queries::latest_rate_limit(&state.db).await?;
+    let info = payload
+        .as_ref()
+        .map(|value| value.get("rate_limit_info").unwrap_or(value));
+    if usage::should_lift_pause(
+        info,
+        settings.usage_limit_pause_enabled,
+        settings.usage_limit_threshold,
+    ) {
+        queries::set_usage_paused_until(&state.db, None).await?;
+        state.notify_board();
+        info!("usage auto-pause lifted after a settings change (disabled or threshold raised)");
+    }
+    Ok(())
+}
+
 /// The next card this railway should work and how, or `None` if paused, halted,
 /// outside the availability schedule, or idle.
 ///

--- a/api/src/orchestrator/usage.rs
+++ b/api/src/orchestrator/usage.rs
@@ -71,6 +71,31 @@ fn window_pause(
     }
 }
 
+/// Whether an active usage auto-pause should be lifted now (issue #292), given the
+/// latest rate-limit `info` (if any), whether the auto-pause is still `enabled`,
+/// and the operator's current `threshold`.
+///
+/// The auto-pause keys only to the window reset time, so on its own it never
+/// re-evaluates a raised threshold or a disabled toggle. This is the escape hatch:
+/// it returns `true` (lift the pause) when the pause no longer applies, i.e.
+/// - the auto-pause was disabled, or
+/// - re-evaluating the latest signal at the current threshold no longer warrants
+///   pausing (e.g. the threshold was raised above current utilization).
+///
+/// A genuinely exhausted (`rejected`) window still warrants pausing regardless of
+/// the threshold, so [`pause_until`] still returns its reset and this returns
+/// `false`: the pause stands until the window resets, as it should. With no signal
+/// to re-judge (`info` is `None`), it leaves an enabled pause in place.
+pub fn should_lift_pause(info: Option<&Value>, enabled: bool, threshold: i32) -> bool {
+    if !enabled {
+        return true;
+    }
+    match info {
+        Some(info) => pause_until(info, threshold).is_none(),
+        None => false,
+    }
+}
+
 /// Normalizes `utilization` to a 0-100 percent, accepting either a fraction
 /// (`0.82`) or an already-scaled percent (`82`).
 fn parse_utilization(value: &Value) -> Option<f64> {
@@ -127,5 +152,39 @@ mod tests {
             "overageResetsAt": 2000
         });
         assert_eq!(pause_until(&info, 80), Some(2000));
+    }
+
+    #[test]
+    fn disabling_auto_pause_lifts_the_pause() {
+        // The signal still says "over threshold", but turning the feature off must
+        // lift any active pause (issue #292), regardless of the signal.
+        let info = json!({ "status": "allowed_warning", "utilization": 90, "resetsAt": 500 });
+        assert!(should_lift_pause(Some(&info), false, 80));
+    }
+
+    #[test]
+    fn raising_threshold_above_utilization_lifts_the_pause() {
+        // Paused at 83% under an 80% threshold; raising the threshold to 95% (above
+        // current utilization) lifts it now rather than waiting for the reset.
+        let info = json!({ "status": "allowed_warning", "utilization": 83, "resetsAt": 500 });
+        assert!(should_lift_pause(Some(&info), true, 95));
+        // Still below the (lower) threshold it was paused at: stays paused.
+        assert!(!should_lift_pause(Some(&info), true, 80));
+    }
+
+    #[test]
+    fn exhausted_window_stays_paused_even_if_threshold_raised() {
+        // A rejected (exhausted) window cannot be un-exhausted by raising the
+        // threshold; the pause must stand until the window resets.
+        let info = json!({ "status": "rejected", "resetsAt": 500 });
+        assert!(!should_lift_pause(Some(&info), true, 100));
+    }
+
+    #[test]
+    fn no_signal_leaves_an_enabled_pause_in_place() {
+        // With nothing to re-judge, an enabled pause is left to auto-clear at reset.
+        assert!(!should_lift_pause(None, true, 95));
+        // But a disabled toggle still lifts it without needing a signal.
+        assert!(should_lift_pause(None, false, 95));
     }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -447,6 +447,12 @@ export function setPaused(paused: boolean) {
   return apiClient.post('settings/pause', { json: { paused } }).json<Settings>()
 }
 
+// Manually lift an active subscription-usage auto-pause (issue #292), so the agent
+// resumes now instead of waiting for the window reset. Returns the updated settings.
+export function resumeUsage() {
+  return apiClient.post('settings/usage/resume').json<Settings>()
+}
+
 export type TokensRequest = {
   claude_oauth_token?: string
   github_token?: string

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -37,6 +37,7 @@
     listRepos,
     moveTask,
     provisionWorkspace,
+    resumeUsage,
     setNotepad,
     setPaused,
     setRailwayPaused,
@@ -826,6 +827,22 @@
     }
   }
 
+  // Manually lift the subscription-usage auto-pause (issue #292), so the agent
+  // resumes now instead of waiting for the window reset.
+  let resumingUsage = $state(false)
+  async function resumeUsageNow() {
+    resumingUsage = true
+    try {
+      await resumeUsage()
+      toast.success('Resumed; the agent will pull new work')
+    } catch {
+      toast.error('Could not resume')
+    } finally {
+      await load()
+      resumingUsage = false
+    }
+  }
+
   onMount(() => {
     // Hydrate each column's saved sort before the first load so it applies at once.
     for (const column of COLUMNS) {
@@ -947,12 +964,24 @@
   {/each}
 
   {#if settings?.usage_paused_until && new Date(settings.usage_paused_until).getTime() > Date.now()}
-    <Alert.Root class="mx-6 mt-4 border-warning/40">
-      <Alert.Title>Paused: subscription usage limit reached.</Alert.Title>
-      <Alert.Description>
-        New work is on hold until the usage window resets at
-        {new Date(settings.usage_paused_until).toLocaleString()}. The agent resumes automatically.
-      </Alert.Description>
+    <Alert.Root class="mx-6 mt-4 flex items-start justify-between gap-4 border-warning/40">
+      <div class="min-w-0">
+        <Alert.Title>Paused: subscription usage limit reached.</Alert.Title>
+        <Alert.Description>
+          New work is on hold until the usage window resets at
+          {new Date(settings.usage_paused_until).toLocaleString()}, when it resumes automatically.
+          To resume sooner, raise the usage threshold in Settings or resume now.
+        </Alert.Description>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        class="flex-none"
+        disabled={resumingUsage}
+        onclick={resumeUsageNow}
+      >
+        {resumingUsage ? 'Resuming…' : 'Resume now'}
+      </Button>
     </Alert.Root>
   {/if}
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -44,6 +44,7 @@
     startClaudeOauth,
     finishClaudeOauth,
     setClaudeApiKey,
+    resumeUsage,
     testJira,
     updateJiraBoard,
     updateSettings,
@@ -485,6 +486,20 @@
       usage_limit_threshold: settings.usage_limit_threshold
     })
     usageSavedAt = new Date().toLocaleTimeString()
+  }
+
+  // Manually lift an active usage auto-pause (issue #292); the returned settings
+  // reflect the cleared pause, so the note below disappears at once.
+  async function resumeUsageNow() {
+    if (!settings) {
+      return
+    }
+    try {
+      settings = await resumeUsage()
+      toast.success('Resumed; the agent will pull new work')
+    } catch {
+      toast.error('Could not resume')
+    }
   }
 
   async function saveThoughts() {
@@ -1421,10 +1436,18 @@
           </div>
 
           {#if settings.usage_paused_until && new Date(settings.usage_paused_until).getTime() > Date.now()}
-            <div class="rounded-md border border-warning/40 bg-card p-3 text-sm">
-              Paused for usage until
-              <strong>{new Date(settings.usage_paused_until).toLocaleString()}</strong>. The agent
-              resumes automatically when the window resets.
+            <div
+              class="flex items-start justify-between gap-3 rounded-md border border-warning/40 bg-card p-3 text-sm"
+            >
+              <div class="min-w-0">
+                Paused for usage until
+                <strong>{new Date(settings.usage_paused_until).toLocaleString()}</strong>. The agent
+                resumes automatically when the window resets. Raising the threshold above current
+                usage above, or resuming now, lifts it sooner.
+              </div>
+              <Button variant="outline" size="sm" class="flex-none" onclick={resumeUsageNow}>
+                Resume now
+              </Button>
             </div>
           {/if}
         {/if}


### PR DESCRIPTION
Closes #292.

The subscription usage auto-pause keyed only to the window reset time, so raising `usage_limit_threshold`, disabling the feature, or simply wanting to resume now had no effect. The only recovery was a manual `UPDATE settings SET usage_paused_until = NULL WHERE id = 1`. This adds the manual and threshold-driven escape hatches on top of the existing auto-clear-at-reset behavior.

## What changed

**Manual "Resume now"**
- New `POST /settings/usage/resume` clears `usage_paused_until`. Surfaced as a "Resume now" button on the board's usage-pause banner and in the Settings usage section. One click resumes the agent, no DB edit.

**Re-evaluate the pause on settings change**
- Every settings update now runs `orchestrator::reevaluate_usage_pause`, which lifts an active (future) pause when:
  - `usage_limit_pause_enabled` is turned off, or
  - `usage_limit_threshold` is raised above the latest known utilization.
- The decision is the pure, unit-tested `usage::should_lift_pause`, which re-judges the latest stored `rate_limit` event at the current threshold (reusing `pause_until`). A genuinely exhausted (`rejected`) window still warrants pausing regardless of threshold, so it stands until reset.

**Banner clarity**
- The board banner now explains what lifts the pause: resets at `<time>` (auto), raise the threshold, or resume now.

The auto-pause still fires when utilization genuinely crosses the current threshold and still auto-clears at the reset time if left alone (default behavior unchanged).

## Acceptance criteria
- [x] Operator can resume from the UI while a pause is active, no DB edit.
- [x] Disabling the auto-pause clears an active pause.
- [x] Raising the threshold above current utilization resumes immediately (no wait for reset).
- [x] The pause still fires on a genuine crossing and still auto-clears at reset.
- [x] cargo fmt / clippy / test and npm run check / build pass.

## Verification
- `cargo +1.88 fmt`/`clippy` clean (53 warnings, no new ones from this change), 168 backend tests pass (4 new covering disable / raise-threshold / exhausted-stays-paused / no-signal). Frontend `check` 0/0 and `build` pass.

## Visual review
Skipped: the Playwright `chrome-for-testing` browser is not installed in this environment (same as recent tasks). The two UI additions reuse the existing banner-with-button flex pattern (copied from the sibling issue-sync-error banner) and standard `Alert`/`Button` primitives; `svelte-check` is 0/0 and the build passes.