### PR TITLE
In-app Jira comment-thread view (#294)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,8 +612,14 @@ Playwright MCP, check layout via computed styles at 375px and 1280px).
   comment back to the Jira issue (PR link(s) + outcome) via `JiraClient::add_comment`,
   and the agent-driven move to Done transitions the ticket through the board's
   column->status map (`orchestrator::transition_jira_to_column`, shared with the
-  manual board-move path). **Not yet:** an in-app Jira comment-thread view (the
-  conversation panel is GitHub/internal only), and assignee write-back.
+  manual board-move path). The task page's conversation view also renders a Jira
+  ticket's discussion (issue #294): `GET /tasks/:id/issue` reads the issue +
+  comments from the Jira REST API (`JiraClient::fetch_thread`) into the same
+  `IssueThread` shape GitHub/internal use, and a reply posts back to Jira via the
+  existing `add_comment` path. The thread shows the workflow status verbatim (Jira
+  has no open/closed binary) and offers only the comment box (status is changed by
+  moving the card on the board, not from the thread). **Not yet:** assignee
+  write-back.
 - **MooreslabAI human-review commenting** — `GitHubSource::comment` exists but is
   unused (`#[expect(dead_code)]`).
 - **Subscription usage auto-pause** — when `usage_limit_pause_enabled`, a Claude

--- a/api/src/http/tasks.rs
+++ b/api/src/http/tasks.rs
@@ -48,6 +48,44 @@ fn internal_issue_detail(task: &Task, state: &str) -> IssueDetail {
     }
 }
 
+/// An `IssueUser` for a Jira participant, identified by display name (issue #294);
+/// Jira's avatar/profile URLs are not surfaced here.
+fn jira_user(display_name: String) -> IssueUser {
+    let login = if display_name.trim().is_empty() {
+        "Jira user".to_string()
+    } else {
+        display_name
+    };
+    IssueUser {
+        login,
+        avatar_url: String::new(),
+        html_url: String::new(),
+    }
+}
+
+/// The issue header for a Jira ticket, built from a fetched [`crate::jira::JiraThread`].
+/// `number` is 0 (Jira keys are not numeric; the UI shows the key from the task),
+/// and `state` carries the workflow status name rather than open/closed.
+fn jira_issue_detail(task: &Task, thread: &crate::jira::JiraThread) -> IssueDetail {
+    let title = if thread.summary.trim().is_empty() {
+        task.title.clone()
+    } else {
+        thread.summary.clone()
+    };
+    IssueDetail {
+        number: 0,
+        title,
+        state: thread.status.clone(),
+        user: jira_user(thread.reporter.clone()),
+        body: Some(thread.description.clone()),
+        created_at: thread.created.clone(),
+        author_association: String::new(),
+        labels: Vec::new(),
+        assignees: Vec::new(),
+        milestone: None,
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct TaskDetail {
     pub task: Task,
@@ -286,6 +324,31 @@ pub async fn get_issue(State(state): State<AppState>, Path(id): Path<Uuid>) -> A
                 comments,
             };
             return Ok(Json(thread).into_response());
+        }
+        // Jira: read the issue + comments from the Jira REST API so the operator
+        // sees the discussion in the UI like a GitHub thread (issue #294). Replies
+        // post back to Jira via the existing `add_comment` path.
+        if task.source_kind == SourceKind::Jira {
+            let Some(jira) = state.jira().await? else {
+                return Ok((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "error": "Jira is not configured" })),
+                )
+                    .into_response());
+            };
+            let fetched = jira.fetch_thread(&task.external_id).await?;
+            let issue = jira_issue_detail(&task, &fetched);
+            let comments = fetched
+                .comments
+                .into_iter()
+                .map(|comment| IssueComment {
+                    user: jira_user(comment.author),
+                    body: Some(comment.body),
+                    created_at: comment.created,
+                    author_association: String::new(),
+                })
+                .collect();
+            return Ok(Json(IssueThread { issue, comments }).into_response());
         }
     }
 

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -216,6 +216,30 @@ pub struct JiraIssue {
     pub description: String,
 }
 
+/// A Jira issue plus its comments, for the in-app conversation view (issue #294).
+/// Timestamps are normalized to RFC 3339; the description and comment bodies are
+/// flattened to plain text (ADF on Cloud, plain on Server).
+#[derive(Debug, Clone)]
+pub struct JiraThread {
+    pub summary: String,
+    /// The workflow status name (e.g. `In Progress`), shown verbatim since Jira
+    /// has no open/closed binary.
+    pub status: String,
+    pub description: String,
+    /// The reporter's display name, or empty when Jira omits it.
+    pub reporter: String,
+    pub created: String,
+    pub comments: Vec<JiraComment>,
+}
+
+/// One comment on a Jira issue, for [`JiraThread`].
+#[derive(Debug, Clone)]
+pub struct JiraComment {
+    pub author: String,
+    pub body: String,
+    pub created: String,
+}
+
 // --- The async REST client ---------------------------------------------------
 
 /// A configured Jira client. Built on demand from the stored connection so a
@@ -437,6 +461,47 @@ impl JiraClient {
         Ok(())
     }
 
+    /// Fetches an issue plus its comments for the in-app conversation view (issue
+    /// #294), so the operator can read a Jira ticket's discussion in the UI like a
+    /// GitHub thread. Comments come back oldest first (Jira's default order), in a
+    /// single inline page, matching the GitHub thread view's first-page approach.
+    pub async fn fetch_thread(&self, issue_key: &str) -> Result<JiraThread> {
+        let url = format!(
+            "{}{}/issue/{issue_key}?fields=summary,status,description,reporter,created,comment",
+            self.config.base_url,
+            self.config.api_base()
+        );
+        let raw: RawThreadIssue = self.get_json(&url).await?;
+        let fields = raw.fields;
+
+        let comments = fields
+            .comment
+            .map(|page| page.comments)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|comment| JiraComment {
+                author: comment
+                    .author
+                    .and_then(|user| user.display_name)
+                    .unwrap_or_default(),
+                body: description_to_text(comment.body.as_ref()),
+                created: normalize_timestamp(&comment.created.unwrap_or_default()),
+            })
+            .collect();
+
+        Ok(JiraThread {
+            summary: fields.summary.unwrap_or_default(),
+            status: fields.status.map(|status| status.name).unwrap_or_default(),
+            description: description_to_text(fields.description.as_ref()),
+            reporter: fields
+                .reporter
+                .and_then(|user| user.display_name)
+                .unwrap_or_default(),
+            created: normalize_timestamp(&fields.created.unwrap_or_default()),
+            comments,
+        })
+    }
+
     /// Creates a `Task`-type issue in `project_key` and returns its key + URL.
     /// Cloud (REST v3) takes the description as Atlassian Document Format; Server
     /// (v2) takes plain text, so the description is encoded per deployment.
@@ -543,6 +608,14 @@ fn description_to_text(value: Option<&serde_json::Value>) -> String {
     }
 }
 
+/// Normalizes a Jira timestamp (e.g. `2026-06-18T19:10:53.873+0000`) to RFC 3339
+/// so the browser's `Date` parses it reliably; returns the input unchanged when it
+/// does not match Jira's format (so a surprise shape still renders something).
+fn normalize_timestamp(raw: &str) -> String {
+    chrono::DateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S%.3f%z")
+        .map_or_else(|_| raw.to_string(), |when| when.to_rfc3339())
+}
+
 // --- Wire DTOs (private) -----------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -604,6 +677,40 @@ struct IssueStatus {
 }
 
 #[derive(Debug, Deserialize)]
+struct RawThreadIssue {
+    fields: ThreadFields,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadFields {
+    summary: Option<String>,
+    status: Option<IssueStatus>,
+    description: Option<serde_json::Value>,
+    reporter: Option<RawUser>,
+    created: Option<String>,
+    comment: Option<RawCommentPage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawUser {
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCommentPage {
+    #[serde(default)]
+    comments: Vec<RawComment>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawComment {
+    author: Option<RawUser>,
+    body: Option<serde_json::Value>,
+    created: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct TransitionsResponse {
     #[serde(default)]
     transitions: Vec<Transition>,
@@ -648,6 +755,17 @@ mod tests {
         let server = config(JiraDeployment::Server);
         assert_eq!(server.api_base(), "/rest/api/2");
         assert_eq!(server.auth_header(), "Bearer secret-token");
+    }
+
+    #[test]
+    fn normalizes_jira_timestamp_to_rfc3339() {
+        // Jira's `+0000` offset (no colon) is not reliably parsed by JS `Date`, so
+        // the thread view normalizes it to RFC 3339 (issue #294).
+        let normalized = normalize_timestamp("2026-06-18T19:10:53.873+0000");
+        assert!(normalized.starts_with("2026-06-18T19:10:53.873"));
+        assert!(chrono::DateTime::parse_from_rfc3339(&normalized).is_ok());
+        // A non-Jira / surprise shape is returned unchanged so it still renders.
+        assert_eq!(normalize_timestamp("not a date"), "not a date");
     }
 
     #[test]

--- a/frontend/src/lib/components/IssueView.svelte
+++ b/frontend/src/lib/components/IssueView.svelte
@@ -57,9 +57,14 @@
   let posting = $state(false)
 
   const isGithub = $derived(task.source_kind === 'github')
-  // GitHub and internal tickets both render the conversation view (the backend
-  // synthesizes a thread for internal tickets from our DB). Jira stays body-only.
-  const hasThread = $derived(task.source_kind === 'github' || task.source_kind === 'internal')
+  const isJira = $derived(task.source_kind === 'jira')
+  // GitHub, internal, and Jira tickets all render the conversation view: GitHub
+  // and Jira are read from their REST APIs, internal from our DB (issue #294).
+  const hasThread = $derived(
+    task.source_kind === 'github' ||
+      task.source_kind === 'internal' ||
+      task.source_kind === 'jira'
+  )
 
   // Everyone who appears in the thread, de-duplicated, for the Participants list.
   const participants = $derived.by(() => {
@@ -189,7 +194,9 @@
         <SourceIcon source={task.source_kind} class="size-5 flex-none text-muted-foreground" />
         <span class="min-w-0">
           {(thread?.issue.title ?? task.title)}
-          <span class="font-normal text-muted-foreground">#{task.external_id}</span>
+          <span class="font-normal text-muted-foreground">
+            {isJira ? task.external_id : `#${task.external_id}`}
+          </span>
         </span>
       </h1>
       <div class="flex flex-none items-center gap-2">
@@ -212,7 +219,12 @@
     </div>
     {#if thread}
       <div class="mt-3 flex flex-wrap items-center gap-3">
-        {#if thread.issue.state === 'open'}
+        {#if isJira}
+          <!-- Jira has no open/closed binary; show the workflow status verbatim. -->
+          <span class="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-sm font-medium text-muted-foreground">
+            <CircleDot class="size-4" /> {thread.issue.state}
+          </span>
+        {:else if thread.issue.state === 'open'}
           <span class="inline-flex items-center gap-1.5 rounded-full bg-success px-3 py-1 text-sm font-medium text-success-foreground">
             <CircleDot class="size-4" /> Open
           </span>
@@ -262,7 +274,11 @@
             class="resize-y font-mono text-sm"
           />
           <div class="mt-2 flex flex-wrap items-center justify-end gap-2">
-            {#if thread.issue.state === 'open' && !isGithub}
+            <!-- Jira status is changed by moving the card on the board, not here, so
+                 a Jira thread offers only the comment box (issue #294). -->
+            {#if isJira}
+              <!-- no close/reopen control -->
+            {:else if thread.issue.state === 'open' && !isGithub}
               <!-- Internal tickets close plainly; no GitHub "reason" choices. -->
               <Button
                 variant="outline"


### PR DESCRIPTION
Closes #294.

After #290 the agent posts comments back to Jira and Jira tickets are auto-worked, but the task page's conversation view (`GET /tasks/:id/issue`) only handled GitHub and internal tickets; a Jira task fell through to GitHub issue coords and couldn't render its thread. This reads a Jira ticket's issue + comments from the Jira REST API so the operator can read and reply to the discussion in the UI, matching the GitHub thread view.

## Backend
- **`JiraClient::fetch_thread`**: `GET /rest/api/{2,3}/issue/{key}?fields=summary,status,description,reporter,created,comment` returns the summary, workflow status, reporter, the flattened description (ADF on Cloud, plain on Server, via the existing `description_to_text`), and the inline comment page (oldest first, matching the GitHub thread's first-page approach). Jira timestamps (`...+0000`) are normalized to RFC 3339 so the browser's `Date` parses them reliably.
- **`GET /tasks/:id/issue`** gains a Jira branch mapping the fetched thread into the same `IssueThread` / `IssueDetail` / `IssueComment` shape GitHub and internal already use. Replies post back to Jira through the existing `add_comment` path (no new write endpoint needed).

## Frontend (`IssueView`)
- `hasThread` now includes Jira, so the conversation renders for a Jira task.
- The header drops the `#` prefix for a Jira key (`BUG-42`, not `#BUG-42`).
- The status badge shows the Jira workflow status verbatim (Jira has no open/closed binary), instead of forcing Open/Closed.
- Close/reopen controls are hidden for Jira (status is changed by moving the card on the board, and `setIssueState` is GitHub/internal-only); the comment box stays so the operator can reply.

## Verification
- `cargo +1.88 fmt`/`clippy --all-targets --all-features` clean (53 warnings = develop baseline, **zero new**), 169 backend tests pass (1 new covering `normalize_timestamp`). Frontend `check` 0/0 and `build` pass.

## Visual review
Skipped: the Playwright `chrome-for-testing` browser is not installed in this environment (as in recent tasks). The view reuses the existing thread-rendering primitives (the shared `commentCard` snippet, header, and comment box that GitHub/internal threads already use); the only Jira-specific additions are a neutral status badge variant and hiding the close/reopen control. `svelte-check` is 0/0 and the build passes.

## Notes
- Comment pagination: like the GitHub thread view, this fetches the first inline comment page, which covers any realistic discussion and bounds the payload.