### PR TITLE
Remove stray NUL bytes from queries.rs; document rg over grep (#295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,15 @@ Playwright MCP, check layout via computed styles at 375px and 1280px).
 
 ## Conventions & gotchas
 
+- **Search with `rg`, not `grep` (issue #295).** The agent shell's `grep` is a
+  Claude Code wrapper backed by ripgrep with `-I` (skip files it deems binary) and
+  `--ignore-files` (respect `.gitignore`). So `grep` silently returns no matches
+  for a file with a stray NUL byte (it looks binary) or any ignored file, which
+  reads as "empty" when it is not. Prefer `rg` for code search; if a file ever
+  looks un-searchable, check it for NUL bytes
+  (`python3 -c "print(open(p,'rb').read().count(0))"`) rather than trusting an
+  empty `grep`. A literal NUL in a `.rs`/`.ts` source is a defect (usually a paste
+  artifact in a comment or string) and should be removed, not worked around.
 - **Rust toolchain is pinned to 1.88** (`api/rust-toolchain.toml`) because some
   transitive deps ship edition2024 crates. The host default may be older — always
   use `cargo +1.88`.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -2731,7 +2731,7 @@ pub async fn append_event(
     event_type: &str,
     mut payload: Value,
 ) -> sqlx::Result<()> {
-    // Postgres JSONB rejects the NUL escape ( ), so a tool result carrying a
+    // Postgres JSONB rejects the NUL escape (\0), so a tool result carrying a
     // null byte (e.g. binary output) would otherwise fail the insert and abort
     // the whole turn. Strip NULs from every string first.
     strip_nul(&mut payload);
@@ -2745,7 +2745,7 @@ pub async fn append_event(
     Ok(())
 }
 
-/// Removes NUL (` `) characters from every string in a JSON value.
+/// Removes NUL (`\0`) characters from every string in a JSON value.
 ///
 /// Postgres JSONB (and TEXT) cannot store NUL, and Claude's tool output can
 /// carry one (binary reads, odd command output). Dropping them keeps the event


### PR DESCRIPTION
Closes #295.

## Root cause
The agent shell's `grep` is a Claude Code wrapper backed by ripgrep with `-I` (skip files it deems binary) and `--ignore-files`. `api/src/db/queries.rs` had **two literal NUL bytes** pasted into comments, where the author meant the escape *text*:
- `// Postgres JSONB rejects the NUL escape (<NUL>), so ...` (meant `(\0)`)
- `/// Removes NUL (`<NUL>`) characters ...` (meant `` `\0` ``)

A NUL byte makes ripgrep treat the whole file as binary, so `grep`/`rg` silently returned **no matches** for `queries.rs` — which is exactly the file I was searching when I filed this. It looked empty when it was not.

## Fix
- Replace the two literal NUL bytes with the intended text `\0`. The change is **comment-only**, so behavior is unchanged; the file is plain text again and searchable: `grep -c "async fn" api/src/db/queries.rs` now returns `189` (was nothing, exit 1). A byte scan confirms no other source file (`.rs`/`.ts`/`.svelte`/`.sql`) contains a NUL.
- Document the gotcha in `CLAUDE.md` "Conventions & gotchas": prefer `rg` for code search; the `grep` wrapper's skip-binary (`-I`) and respect-`.gitignore` (`--ignore-files`) behavior is permanent, so it will silently skip any binary-looking or ignored file. A literal NUL in source is a defect to remove, not work around.

The real `grep` binary at `/usr/bin/grep` is fine; the wrapper is the Claude Code harness `grep` shell function, which the repo cannot remove, hence the documented "prefer rg" guidance plus removing the one corrupted file that actually broke search.

## Verification
- `cargo +1.88 fmt --check` clean, `clippy --all-targets --all-features` no errors (53 warnings = develop baseline), 170 backend tests pass.
- No frontend or UI change, so the frontend build is unaffected and visual review is N/A.