### PR TITLE
Bake the full Chromium the Playwright MCP launches, not just the shell (#299)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,17 +372,22 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   build arg, pinned `0.0.76`) is installed globally and its `playwright-mcp` bin
   symlinked onto `/usr/local/bin`. The MCP bundles its OWN Playwright, pinned to a
   DIFFERENT Chromium than the #215 stable build (alpha -> revision 1226, vs 1228), so
-  the Dockerfile bakes the matching `chromium-headless-shell` (rev 1226) with the
-  MCP's own Playwright into `/ms-playwright`; a turn never downloads a browser at
-  runtime. Only the headless shell is baked (`--headless` uses it), and only its own
-  dir is chmod-ed (a recursive chmod over `/ms-playwright` would copy #215's browsers
-  up into the layer and add ~650MB). Net image delta: **~290MB**. The entrypoint
-  registers the server at **user scope** in `CLAUDE_CONFIG_DIR/.claude.json`
+  the Dockerfile bakes that exact build (rev 1226) with the MCP's own Playwright into
+  `/ms-playwright`; a turn never downloads a browser at runtime. It must be the FULL
+  Chromium build, not the headless shell (issue #299): in this MCP/Playwright version
+  `--browser chromium` resolves to the `chrome-for-testing` channel, which launches
+  the full Chrome-for-Testing build (`chromium-1226`) even under `--headless`, so a
+  shell-only bake left it failing at runtime with `Browser "chrome-for-testing" is
+  not installed` and visual self-review was skipped. It is installed via the MCP's
+  own `playwright-mcp install-browser chrome-for-testing` (the command its own error
+  prescribes), and only that browser dir is chmod-ed (a recursive chmod over
+  `/ms-playwright` would copy #215's browsers up into the layer and add ~650MB). The
+  entrypoint registers the server at **user scope** in `CLAUDE_CONFIG_DIR/.claude.json`
   (`claude mcp add -s user playwright -- playwright-mcp --headless --browser chromium
   --no-sandbox --isolated`), idempotently (remove-then-add), so `claude -p
   --permission-mode bypassPermissions` loads it with NO per-task approval gate (a
   project `.mcp.json` would sit unapproved). A build-time gate fails the image if the
-  bin or the rev-1226 browser is missing. `docker compose build workspace` needs a
+  bin or the rev-1226 full build is missing. `docker compose build workspace` needs a
   populated `.env` (the compose volume interpolation), so a bare checkout builds the
   image directly with `docker build ./workspace`.
 ### The orchestrator loops (`api/src/orchestrator/mod.rs`)

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -151,34 +151,41 @@ RUN npx -y "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium \
 #
 # The MCP bundles its OWN Playwright, pinned to a different Chromium than the #215
 # stable build: `@playwright/mcp@0.0.76` -> playwright 1.61.0-alpha -> Chromium
-# revision 1226, NOT the 1228 baked above. The matching headless shell is baked here
-# with the MCP's own Playwright, so a turn never downloads a browser at runtime
-# (offline / network-restricted safe). Only the headless shell is needed: the MCP
-# runs `--headless`, which uses the shell, so the full chromium-1226 build is skipped
-# to keep the image lean. Size delta: ~280MB (262MB browser + ~18MB of packages).
+# revision 1226, NOT the 1228 baked above. We bake that exact build here with the
+# MCP's own Playwright, so a turn never downloads a browser at runtime (offline /
+# network-restricted safe).
+#
+# It must be the FULL chromium build, not the headless shell (issue #299): in this
+# MCP/Playwright version `--browser chromium` resolves to the `chrome-for-testing`
+# channel, which launches the full Chrome-for-Testing build (dir `chromium-1226`)
+# even under `--headless`. An earlier revision of this file baked only
+# `chromium-headless-shell-1226`, so the MCP failed at runtime with
+# `Browser "chrome-for-testing" is not installed` and visual self-review was
+# skipped. We install via the MCP's own `install-browser` (the command its error
+# prescribes) so we get exactly what it launches. Size delta vs the shell-only bake
+# is ~70MB; correctness wins. Bumping PLAYWRIGHT_MCP_VERSION may change the revision
+# asserted below.
 ARG PLAYWRIGHT_MCP_VERSION=0.0.76
 USER codespace
 RUN bash -lc "npm install -g @playwright/mcp@${PLAYWRIGHT_MCP_VERSION} && npm cache clean --force"
 USER root
 RUN node_dir="$(runuser -l codespace -c 'command -v node' | xargs dirname)" \
     && ln -sf "$node_dir/playwright-mcp" /usr/local/bin/playwright-mcp \
-    && groot="$(runuser -l codespace -c 'npm root -g')" \
-    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
-       node "$groot/@playwright/mcp/node_modules/playwright-core/cli.js" install chromium-headless-shell \
+    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright playwright-mcp install-browser chrome-for-testing \
     # Only the newly-installed browser dir is chmod-ed, NOT all of /ms-playwright:
     # a recursive chmod over #215's browsers (from an earlier layer) would copy them
     # up into this layer and add ~650MB of duplicate bloat. The shared path itself is
     # already world-writable from #215, so a later version bump can still download.
-    && chmod -R a+w /ms-playwright/chromium_headless_shell-1226 \
+    && chmod -R a+w /ms-playwright/chromium-1226 \
     && rm -rf /home/codespace/.npm/_npx /tmp/*
 
 # Fail the build if the MCP bin didn't land on PATH (a dangling symlink) or the
-# matching Chromium 1226 headless shell wasn't baked, so a broken wiring can't ship
+# matching Chromium 1226 full build wasn't baked, so a broken wiring can't ship
 # silently (mirrors the actionlint gate above). The pinned revision is coupled to
 # PLAYWRIGHT_MCP_VERSION; bumping the MCP means updating the revision asserted here.
 RUN test -x /usr/local/bin/playwright-mcp \
     && runuser -l codespace -c 'command -v playwright-mcp >/dev/null' \
-    && ls -d /ms-playwright/chromium_headless_shell-1226 >/dev/null
+    && ls -d /ms-playwright/chromium-1226 >/dev/null
 
 # --- Seraphim agent helpers (post to the API; env injected per turn) ---------
 COPY seraphim-suggest /usr/local/bin/seraphim-suggest


### PR DESCRIPTION
Closes #299.

## Root cause
The workspace image baked only `chromium-headless-shell-1226` for the Playwright MCP, on the (now-wrong) assumption that `--browser chromium --headless` uses the headless shell. In `@playwright/mcp@0.0.76` (bundled playwright-core 1.61.0-alpha), `--browser chromium` resolves to the **`chrome-for-testing` channel**, which launches the **full Chrome-for-Testing build** (`chromium-1226`) even under `--headless`. The full build was never baked, so the MCP failed at runtime with `Browser "chrome-for-testing" is not installed. Run npx @playwright/mcp install-browser chrome-for-testing`, and visual self-review was silently skipped.

I traced this in the running workspace: the MCP and the `chromium_headless_shell-1226` are both present, yet it still demanded `chrome-for-testing`; the bundled playwright-core's `coreBundle.js` maps the chromium browser to `channel: "chrome-for-testing"`, and `/ms-playwright` was missing the full `chromium-1226` build.

## Fix (Dockerfile)
- Install the full build via the MCP's own installer, the exact command its error prescribes: `playwright-mcp install-browser chrome-for-testing` (replacing the `install chromium-headless-shell` line; the now-unused `groot` helper is dropped).
- Update the chmod and the build-time assertion from `chromium_headless_shell-1226` to `chromium-1226`.
- Rewrite the comments (the "only the headless shell is needed" claim was wrong) and update CLAUDE.md's Playwright MCP section to match.

Size delta vs the shell-only bake is ~70MB; the entrypoint's `--browser chromium --headless` registration is unchanged (it now finds the baked full build).

## Verification
- Ran `playwright-mcp install-browser chrome-for-testing` into a temp `PLAYWRIGHT_BROWSERS_PATH`: it downloaded the full ~177MB Chromium build into `chromium-1226` (not the shell), confirming the target dir the chmod/assertion use.
- `docker build --check -f workspace/Dockerfile workspace` passes (no syntax/lint issues).
- The full image build runs in CI's Docker job (`docker compose build api frontend workspace`), where the build-time gate `ls -d /ms-playwright/chromium-1226` now asserts the correct build is present.
- No Rust/frontend/app code changed, so those jobs are unaffected; no app UI changed, so visual self-review is N/A (this PR is what re-enables it).