### PR TITLE
Store GitHub issue/comment image attachments into task_attachments (#300)

### DIFF
--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -1038,11 +1038,153 @@ pub async fn add_issue_comment(
     Ok(comment)
 }
 
+// --- GitHub attachment capture (issue #300) ----------------------------------
+
+/// An image/file attachment referenced in issue or comment Markdown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentLink {
+    /// The canonical attachment URL as authored in the Markdown (stable, so it
+    /// dedupes cleanly across re-syncs).
+    pub url: String,
+    /// A display/file name: the link's alt or label text when present (GitHub sets
+    /// it to the original filename on upload), else the URL's last path segment.
+    pub file_name: String,
+}
+
+/// Whether a URL points at a GitHub-hosted attachment (issue #300).
+///
+/// Covers the modern `github.com/user-attachments/...` scheme (both pasted images
+/// and uploaded files) and the legacy user-image CDNs. Deliberately narrow so it
+/// never captures ordinary links (an issue/PR/blob URL is not an attachment).
+fn is_github_attachment_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.starts_with("https://github.com/user-attachments/")
+        || lower.starts_with("https://user-images.githubusercontent.com/")
+        || lower.starts_with("https://private-user-images.githubusercontent.com/")
+}
+
+/// The file name for a captured attachment: the link's label/alt text when it is
+/// usable, else the URL's last path segment, else a generic fallback. Any path
+/// separators or quotes are stripped so it is safe as a stored file name.
+fn attachment_file_name(label: &str, url: &str) -> String {
+    let from_label = label.trim();
+    let candidate = if from_label.is_empty() {
+        url.rsplit('/')
+            .next()
+            .unwrap_or("")
+            .split(['?', '#'])
+            .next()
+            .unwrap_or("")
+    } else {
+        from_label
+    };
+    let cleaned: String = candidate
+        .chars()
+        .filter(|c| !matches!(c, '/' | '\\' | '"' | '\'') && !c.is_control())
+        .collect();
+    let cleaned = cleaned.trim();
+    if cleaned.is_empty() {
+        "github-attachment".to_string()
+    } else {
+        cleaned.to_string()
+    }
+}
+
+/// Extracts GitHub-hosted attachment links from issue/comment Markdown (issue
+/// #300), so their bytes can be downloaded and stored like Jira's.
+///
+/// Recognizes Markdown image/link syntax `![alt](url)` / `[label](url)` and HTML
+/// `<img src="url">`, keeping only URLs on GitHub's attachment hosts (see
+/// [`is_github_attachment_url`]). Deduplicates by URL, preserving first-seen order.
+/// Hand-rolled (no regex dependency), matching the rest of this crate.
+pub fn extract_attachment_urls(markdown: &str) -> Vec<AttachmentLink> {
+    let mut links: Vec<AttachmentLink> = Vec::new();
+    let mut push = |url: &str, label: &str| {
+        let url = url.trim();
+        if !is_github_attachment_url(url) {
+            return;
+        }
+        if links.iter().any(|existing| existing.url == url) {
+            return;
+        }
+        links.push(AttachmentLink {
+            url: url.to_string(),
+            file_name: attachment_file_name(label, url),
+        });
+    };
+
+    let bytes = markdown.as_bytes();
+    // Markdown link/image form: `](URL)`, optionally `[label]` or `![label]` before
+    // it. The URL runs until the closing `)`, whitespace, or a `"`-quoted title.
+    let mut search = 0;
+    while let Some(rel) = markdown[search..].find("](") {
+        let close_bracket = search + rel; // index of ']'
+        let url_start = close_bracket + 2; // just past `](`
+        let url_end = markdown[url_start..]
+            .find([')', ' ', '\t', '\n', '"'])
+            .map_or(markdown.len(), |offset| url_start + offset);
+        let url = &markdown[url_start..url_end];
+        // The label is between the matching `[` and this `]`.
+        let label = markdown[..close_bracket]
+            .rfind('[')
+            .map_or("", |open| &markdown[open + 1..close_bracket]);
+        push(url, label);
+        search = url_end;
+    }
+
+    // HTML image form: `<img ... src="URL" ...>` (single or double quoted).
+    for marker in ["src=\"", "src='"] {
+        let quote = marker.as_bytes()[marker.len() - 1];
+        let mut search = 0;
+        while let Some(rel) = markdown[search..].find(marker) {
+            let url_start = search + rel + marker.len();
+            let url_end = bytes[url_start..]
+                .iter()
+                .position(|&b| b == quote)
+                .map_or(markdown.len(), |offset| url_start + offset);
+            push(&markdown[url_start..url_end], "");
+            search = url_end;
+        }
+    }
+
+    links
+}
+
+/// Downloads a GitHub attachment (an image/file embedded in issue or comment
+/// Markdown) with the token, following the redirect to the signed blob URL, and
+/// returns the bytes plus the response content type (issue #300).
+///
+/// `reqwest` strips the `Authorization` header on a cross-host redirect, so the
+/// token only ever reaches `github.com`, never the CDN it redirects to. Returns
+/// `None` on any failure (a dead, private, or rate-limited link), so capture stays
+/// best-effort.
+pub async fn download_attachment(token: &str, url: &str) -> Option<(Vec<u8>, String)> {
+    let response = reqwest::Client::new()
+        .get(url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("User-Agent", "seraphim")
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        tracing::debug!(status = %response.status(), url, "github attachment not downloadable");
+        return None;
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let bytes = response.bytes().await.ok()?;
+    Some((bytes.to_vec(), content_type))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        review_status_from_response, strip_log_timestamp, ReviewThreadsResponse,
-        REVIEW_STATUS_QUERY,
+        extract_attachment_urls, review_status_from_response, strip_log_timestamp,
+        ReviewThreadsResponse, REVIEW_STATUS_QUERY,
     };
     use serde_json::{from_value, json};
 
@@ -1198,5 +1340,50 @@ mod tests {
             strip_log_timestamp("2026-06-15T21:00:00Z Fetched 31.1 MB in 3s (12.3 MB/s)"),
             "Fetched 31.1 MB in 3s (12.3 MB/s)"
         );
+    }
+
+    #[test]
+    fn extracts_github_attachment_links_and_skips_other_urls() {
+        let markdown = "\
+            The button overflows, see ![overflow.png](https://github.com/user-attachments/assets/abc-123).\n\
+            Legacy: ![old](https://user-images.githubusercontent.com/42/screenshot.png)\n\
+            Crash log: [crash.log](https://github.com/user-attachments/files/9/crash.log)\n\
+            Unrelated link: [#5](https://github.com/JalapenoLabs/Seraphim/issues/5)\n\
+            And a normal site: [docs](https://example.com/image.png)\n\
+            <img src=\"https://github.com/user-attachments/assets/html-1\" alt=\"x\">";
+        let links = extract_attachment_urls(markdown);
+        let urls: Vec<&str> = links.iter().map(|link| link.url.as_str()).collect();
+
+        // The three GitHub attachment hosts are captured, in first-seen order.
+        assert_eq!(
+            urls,
+            vec![
+                "https://github.com/user-attachments/assets/abc-123",
+                "https://user-images.githubusercontent.com/42/screenshot.png",
+                "https://github.com/user-attachments/files/9/crash.log",
+                "https://github.com/user-attachments/assets/html-1",
+            ]
+        );
+        // Ordinary issue links and non-GitHub hosts are never treated as attachments.
+        assert!(!urls.iter().any(|url| url.contains("/issues/5")));
+        assert!(!urls.iter().any(|url| url.contains("example.com")));
+
+        // The alt/label text becomes the file name; a uuid asset keeps the alt name.
+        assert_eq!(links[0].file_name, "overflow.png");
+        // A files URL with no label falls back to its last path segment.
+        assert_eq!(links[2].file_name, "crash.log");
+    }
+
+    #[test]
+    fn dedupes_repeated_attachment_urls() {
+        let url = "https://github.com/user-attachments/assets/dup";
+        let markdown = format!("![a]({url}) and again ![b]({url})");
+        assert_eq!(extract_attachment_urls(&markdown).len(), 1);
+    }
+
+    #[test]
+    fn plain_markdown_with_no_attachments_yields_nothing() {
+        assert!(extract_attachment_urls("Just text, no images here.").is_empty());
+        assert!(extract_attachment_urls("").is_empty());
     }
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1499,10 +1499,12 @@ async fn build_fresh_prompt(
     // the agent merges them in rather than rediscovering and re-implementing them
     // (issue #256).
     let dependencies = resolve_dependency_branches(state, task).await;
-    // Pull a Jira ticket's attachments into ticket data (issue #291) so the brief
-    // carries its screenshots/logs, then load every stored attachment (operator
-    // uploads and pulled ones alike) for the prompt.
+    // Pull a Jira ticket's attachments (issue #291) and a GitHub issue's embedded
+    // image/file attachments (issue #300) into ticket data so the brief carries
+    // their screenshots/logs, then load every stored attachment (operator uploads
+    // and pulled ones alike) for the prompt.
     capture_jira_attachments(state, task).await;
+    capture_github_attachments(state, task, &comments).await;
     let attachments = load_attachments(state, task).await;
     prompt::build(
         settings,
@@ -1673,6 +1675,80 @@ async fn capture_jira_attachments(state: &AppState, task: &Task) {
         .await
         {
             warn!(error = %error, task_id = %task.id, "could not store a Jira attachment");
+        }
+    }
+}
+
+/// Pulls a GitHub issue's image/file attachments into ticket data (issue #300):
+/// parses attachment links from the issue body and every comment, then downloads +
+/// stores each one not already captured (deduped by URL), so a UI bug's
+/// screenshots are viewable in the task view and reach the prompt like Jira's,
+/// rather than only as Markdown links the agent must fetch with `gh` auth.
+///
+/// Best-effort and GitHub-only: a non-GitHub task, a missing token, an oversized
+/// file, or any per-attachment failure is logged and skipped, never failing the
+/// caller. `comments` is the already-fetched thread, so this adds no extra issue
+/// fetch.
+async fn capture_github_attachments(state: &AppState, task: &Task, comments: &[git::IssueComment]) {
+    if task.source_kind != SourceKind::Github {
+        return;
+    }
+    // Gather the Markdown to scan: the issue body plus every comment body.
+    let mut markdown = task.body_snapshot.clone();
+    for comment in comments {
+        if let Some(body) = &comment.body {
+            markdown.push('\n');
+            markdown.push_str(body);
+        }
+    }
+    let links = git::extract_attachment_urls(&markdown);
+    if links.is_empty() {
+        return;
+    }
+    let token = match queries::get_github_token(&state.db).await {
+        Ok(token) if !token.trim().is_empty() => token,
+        Ok(_) => return,
+        Err(error) => {
+            warn!(error = %error, task_id = %task.id, "could not read the GitHub token for attachments");
+            return;
+        }
+    };
+
+    for link in links {
+        // Skip ones already stored (deduped by the attachment URL), so a re-run is
+        // cheap and never re-downloads.
+        match queries::source_attachment_exists(&state.db, task.id, "github", &link.url).await {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(error) => {
+                warn!(error = %error, task_id = %task.id, "could not check an existing GitHub attachment");
+                continue;
+            }
+        }
+        let Some((data, content_type)) = git::download_attachment(&token, &link.url).await else {
+            continue;
+        };
+        // A 200 that returns HTML is a login/error page, not the asset; don't store
+        // it. (A genuine non-`image/*` attachment, e.g. a log, has its own type.)
+        if content_type.starts_with("text/html") {
+            continue;
+        }
+        if data.len() > crate::http::attachments::MAX_ATTACHMENT_BYTES {
+            info!(task_id = %task.id, file = %link.file_name, "skipping oversized GitHub attachment");
+            continue;
+        }
+        if let Err(error) = queries::create_attachment(
+            &state.db,
+            task.id,
+            "github",
+            Some(&link.url),
+            &link.file_name,
+            &content_type,
+            &data,
+        )
+        .await
+        {
+            warn!(error = %error, task_id = %task.id, "could not store a GitHub attachment");
         }
     }
 }


### PR DESCRIPTION
Closes #300. Follow-up to #291.

GitHub attachments previously reached the agent only as Markdown links in the issue/comment bodies, so the agent had to `curl` them with `gh` auth and they were not viewable in Seraphim's task view. This captures them like Jira's, reusing #291's `task_attachments` storage and prompt rendering.

## What changed (backend only)
- **`git::extract_attachment_urls`** parses attachment links from issue/comment Markdown: `![alt](url)`, `[label](url)`, and HTML `<img src>`. It keeps only GitHub attachment hosts (`github.com/user-attachments/...` plus the legacy `user-images` / `private-user-images` CDNs) so ordinary links (issue/PR/blob URLs, other sites) are never captured, and dedupes by URL preserving order. Hand-rolled (no regex dependency, matching the rest of the crate) and unit-tested.
- **`git::download_attachment`** fetches the bytes with the GitHub token, following the redirect to the signed blob URL. `reqwest` strips the `Authorization` header on the cross-host redirect, so the token only reaches `github.com`, never the CDN.
- **`orchestrator::capture_github_attachments`** runs at work time, right next to the Jira capture in `build_fresh_prompt`: it scans the issue body + the already-fetched comment thread, downloads each not-already-stored link, and stores it via the existing `create_attachment` with `source='github'` (deduped by URL via `source_attachment_exists`). Best-effort and GitHub-only; oversized files (over `MAX_ATTACHMENT_BYTES`) and HTML error pages are skipped.

Stored GitHub attachments then flow through the existing #291 plumbing unchanged: `load_attachments` inlines small text/logs and lists images as openable `curl "$SERAPHIM_API_URL/api/v1/attachments/<id>"` refs in the prompt, and the task view renders them (image thumbnails + download links) with a `github` source badge. No UI or prompt-rendering change was needed.

## Notes
- Capture runs at **work time** (when the agent needs them and to avoid adding per-poll download I/O to the sync loop), mirroring where it matters; the task view shows them once the task is worked. Pre-work board visibility would be a separate follow-up.
- Dedup is by the canonical attachment URL, which is what the API returns in the raw Markdown body (stable across renders), not the per-render signed CDN URL.

## Verification
- `cargo +1.88 fmt --check` clean, `clippy --all-targets --all-features` no errors (53 warnings = develop baseline, zero new), `cargo test --all-features` = 174 pass (3 new tests on the link parser: captures the GitHub hosts + alt/last-segment file names, skips non-attachment URLs, dedupes, and handles empty input).
- Backend-only; the task view already renders `task_attachments` source-agnostically (#291), so visual review is N/A.