### PR TITLE
Stop the stuck-PR sweep looping on empty BLOCKED draft PRs (#304)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,21 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    pushes nothing (genuinely unresolvable) or the budget is exhausted, it falls
    back to `ci_blocked` for a human. The single-PR case is just a one-row set, so
    its behavior is unchanged.
+   - **Parked empty PRs (issue #304):** when the agent hits a cross-repo blocker it
+     cannot resolve in scope, it parks the ticket by opening a **draft PR with a
+     single empty commit** documenting the blocker. GitHub cannot squash-merge a
+     zero-change PR, so the sweep used to read the merge failure as a conflict and
+     re-dispatch the ticket forever. The refresh now records each PR's `is_draft` /
+     `is_empty` shape (`git::pr_status` reads `draft` + `changed_files`), and a PR
+     with an **empty net diff** maps to a new `review::PrReview::Parked` (in
+     `pr_review_of`, ahead of the CI/review checks): it is never merge-attempted,
+     CI-fixed, addressed, or re-dispatched, just **held in review** until a human or
+     an unblock event acts on it (`review::decide` keeps the task out of Done while
+     a parked PR remains). `merge_task_prs` also treats a `failed to squash-merge`
+     on a now-empty PR as benign ("nothing to merge", leave parked), not a conflict.
+     An empty PR that is NOT a draft is unexpected, so it is surfaced as an anomaly
+     (a warning) and still held rather than merged. Non-empty drafts and real PRs
+     follow the normal review-gate + auto-merge flow.
    - **Review-comment gate (issues #255, #270):** a green PR is NEVER squash-merged
      while it carries review work, no matter its approval state. The merge gate is
      exactly **CI green AND zero unresolved review threads AND no outstanding

--- a/api/migrations/0047_task_pr_merge_meta.sql
+++ b/api/migrations/0047_task_pr_merge_meta.sql
@@ -1,0 +1,16 @@
+-- Track, per tracked pull request, whether it is a draft and whether its net diff
+-- vs base is empty (zero changed files), so the review sweep can recognize a
+-- parked-by-design empty draft PR (issue #304).
+--
+-- When the agent hits a cross-repo blocker it cannot resolve in scope, it parks
+-- the ticket by opening a draft PR with a single empty commit documenting the
+-- blocker. GitHub cannot squash-merge a zero-change PR, so the auto-merge fails;
+-- the review sweep used to read that as a conflict and re-dispatch the ticket
+-- forever. Recording these flags lets the sweep leave such a PR parked in review
+-- instead of merge-attempting and re-dispatching it.
+--
+-- Both default FALSE, so existing rows keep the normal review/auto-merge flow
+-- until the next refresh fills in their true values.
+ALTER TABLE task_pull_requests
+    ADD COLUMN is_draft BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN is_empty BOOLEAN NOT NULL DEFAULT FALSE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -607,6 +607,15 @@ pub struct TaskPullRequest {
     pub head_sha: String,
     pub ci_state: String,
     pub pr_state: String,
+    /// Whether the PR is a draft. GitHub will not merge a draft, so the review
+    /// sweep never auto-merges one (issue #304).
+    pub is_draft: bool,
+    /// Whether the PR's net diff vs its base is empty (zero changed files). An
+    /// empty draft is a parked-by-design blocker the agent documented and could not
+    /// resolve in scope; an empty non-draft is an anomaly. Either way GitHub cannot
+    /// squash-merge it, so the review sweep leaves it parked in review rather than
+    /// merge-attempting and re-dispatching it forever (issue #304).
+    pub is_empty: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -2471,6 +2471,11 @@ pub async fn next_event_seq(pool: &PgPool, turn_id: Uuid) -> sqlx::Result<i32> {
 }
 
 /// Records (or refreshes) a task's pull request, keyed by `(task, repo, number)`.
+///
+/// `is_draft` / `is_empty` capture the PR's shape for the review sweep's
+/// parked-empty-draft handling (issue #304); callers that do not inspect the diff
+/// (initial detection, a merge, a reset close) pass `false` for both, and the
+/// review refresh fills in the true values from the live PR.
 #[allow(clippy::too_many_arguments)]
 pub async fn upsert_task_pr(
     pool: &PgPool,
@@ -2482,14 +2487,18 @@ pub async fn upsert_task_pr(
     head_sha: &str,
     ci_state: &str,
     pr_state: &str,
+    is_draft: bool,
+    is_empty: bool,
 ) -> sqlx::Result<TaskPullRequest> {
     sqlx::query_as::<_, TaskPullRequest>(
         "INSERT INTO task_pull_requests \
-           (task_id, repo_id, repo_full_name, pr_number, pr_url, head_sha, ci_state, pr_state) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+           (task_id, repo_id, repo_full_name, pr_number, pr_url, head_sha, ci_state, pr_state, \
+            is_draft, is_empty) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
          ON CONFLICT (task_id, repo_full_name, pr_number) DO UPDATE SET \
            repo_id = EXCLUDED.repo_id, pr_url = EXCLUDED.pr_url, head_sha = EXCLUDED.head_sha, \
-           ci_state = EXCLUDED.ci_state, pr_state = EXCLUDED.pr_state, updated_at = now() \
+           ci_state = EXCLUDED.ci_state, pr_state = EXCLUDED.pr_state, \
+           is_draft = EXCLUDED.is_draft, is_empty = EXCLUDED.is_empty, updated_at = now() \
          RETURNING *",
     )
     .bind(task_id)
@@ -2500,6 +2509,8 @@ pub async fn upsert_task_pr(
     .bind(head_sha)
     .bind(ci_state)
     .bind(pr_state)
+    .bind(is_draft)
+    .bind(is_empty)
     .fetch_one(pool)
     .await
 }

--- a/api/src/git/mod.rs
+++ b/api/src/git/mod.rs
@@ -202,10 +202,20 @@ pub struct PrStatus {
     pub lifecycle: PrLifecycle,
     pub title: String,
     pub head_sha: String,
+    /// Whether the PR is a draft. GitHub refuses to merge a draft.
+    pub draft: bool,
+    /// Whether the PR's net diff vs base is empty (zero changed files). GitHub
+    /// cannot squash-merge a zero-change PR, so the review sweep treats such a PR
+    /// as parked rather than merge-attempting it (issue #304).
+    pub is_empty: bool,
 }
 
 /// Looks up one PR by number, to learn whether it's still open (and its head) or
-/// was merged (counts toward the task) vs just closed (abandoned).
+/// was merged (counts toward the task) vs just closed (abandoned), plus whether it
+/// is a draft and whether its diff is empty (for the parked-empty-draft guard).
+///
+/// `draft` and `changed_files` come from the single-PR GET (the list endpoint
+/// omits the diff counts), so this is the right call to read emptiness from.
 pub async fn pr_status(octo: &Octocrab, owner: &str, repo: &str, number: u64) -> Result<PrStatus> {
     #[derive(Deserialize)]
     struct Head {
@@ -218,6 +228,10 @@ pub async fn pr_status(octo: &Octocrab, owner: &str, repo: &str, number: u64) ->
         merged: bool,
         #[serde(default)]
         title: String,
+        #[serde(default)]
+        draft: bool,
+        #[serde(default)]
+        changed_files: u64,
         head: Head,
     }
     let pull: Pull = octo
@@ -235,6 +249,8 @@ pub async fn pr_status(octo: &Octocrab, owner: &str, repo: &str, number: u64) ->
         lifecycle,
         title: pull.title,
         head_sha: pull.head.sha,
+        draft: pull.draft,
+        is_empty: pull.changed_files == 0,
     })
 }
 

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1181,6 +1181,8 @@ async fn reset_github_side(
                             &pull.head_sha,
                             "",
                             "closed",
+                            false,
+                            false,
                         )
                         .await
                         {
@@ -2606,6 +2608,22 @@ async fn review_task(
 
     let mut views = Vec::with_capacity(prs.len());
     for pr in &prs {
+        // An empty open PR is parked-by-design (a blocker the agent documented):
+        // it is never merged or re-dispatched, so skip the review-gate lookup
+        // entirely (issue #304). An empty PR that is NOT a draft is unexpected, so
+        // surface it as an anomaly rather than letting it sit silently; it is still
+        // held (never auto-merged), since GitHub cannot squash a zero-change PR.
+        if pr.pr_state == "open" && pr.is_empty {
+            if !pr.is_draft {
+                warn!(
+                    task_id = %task.id,
+                    pr = %pr.pr_url,
+                    "open pull request has no changes and is not a draft; holding it as an anomaly rather than auto-merging"
+                );
+            }
+            views.push(pr_review_of(pr, false, ReviewState::Clean));
+            continue;
+        }
         let auto_merge =
             pr_repo_policy(state, settings, pr).await? == ReviewPolicy::AutoSquashMerge;
         // Only a green, open PR is a candidate for the review gate. For any other
@@ -2707,6 +2725,8 @@ async fn merge_task_prs(
                     &pr.head_sha,
                     "",
                     "merged",
+                    false,
+                    false,
                 )
                 .await?;
                 info!(task_id = %task.id, pr = %pr.pr_url, "auto-merged a PR");
@@ -2737,6 +2757,29 @@ async fn merge_task_prs(
                 .await?;
             }
             Err(error) => {
+                // A zero-change PR cannot be squash-merged (GitHub rejects it). The
+                // review sweep already classifies empty PRs as parked and never
+                // selects them to merge, so reaching here with an empty PR means it
+                // went empty between the refresh and this merge. Treat it as benign
+                // ("nothing to merge") and leave it parked in review, rather than a
+                // conflict to re-dispatch forever (issue #304).
+                let empty = git::pr_status(github, owner, name, number)
+                    .await
+                    .map(|status| status.is_empty)
+                    .unwrap_or(false);
+                if empty {
+                    info!(
+                        task_id = %task.id,
+                        pr = %pr.pr_url,
+                        "auto-merge skipped: pull request has no changes; leaving it parked in review"
+                    );
+                    if task.status != TaskStatus::AwaitingReview {
+                        queries::set_task_status(&state.db, task.id, TaskStatus::AwaitingReview)
+                            .await?;
+                    }
+                    state.notify_board();
+                    return Ok(());
+                }
                 if task.ci_fix_attempts < MAX_CI_FIX_ATTEMPTS {
                     let note = format!(
                         "Auto-merge of {} failed: {error}. Re-engaging the agent to resolve the \
@@ -2870,6 +2913,10 @@ async fn detect_task_prs(
             &pull.head_sha,
             ci,
             "open",
+            // The list endpoint omits diff counts; the review refresh fills in the
+            // true draft/empty shape on its next pass (issue #304).
+            false,
+            false,
         )
         .await?;
         found += 1;
@@ -2953,14 +3000,16 @@ async fn refresh_task_prs(
         };
         let number = u64::try_from(pr.pr_number).unwrap_or_default();
         let status = git::pr_status(github, owner, name, number).await?;
-        let (ci, pr_state, head) = match status.lifecycle {
+        // Draft/empty only matter for an open PR (issue #304); a settled PR records
+        // false for both, since `pr_review_of` treats it as merged/closed regardless.
+        let (ci, pr_state, head, is_draft, is_empty) = match status.lifecycle {
             git::PrLifecycle::Open => {
                 let ci =
                     ci_state_label(&git::ci_status(github, owner, name, &status.head_sha).await?);
-                (ci, "open", status.head_sha)
+                (ci, "open", status.head_sha, status.draft, status.is_empty)
             }
-            git::PrLifecycle::Merged => ("", "merged", pr.head_sha.clone()),
-            git::PrLifecycle::Closed => ("", "closed", pr.head_sha.clone()),
+            git::PrLifecycle::Merged => ("", "merged", pr.head_sha.clone(), false, false),
+            git::PrLifecycle::Closed => ("", "closed", pr.head_sha.clone(), false, false),
         };
         queries::upsert_task_pr(
             &state.db,
@@ -2972,6 +3021,8 @@ async fn refresh_task_prs(
             &head,
             ci,
             pr_state,
+            is_draft,
+            is_empty,
         )
         .await?;
 
@@ -3018,10 +3069,16 @@ async fn pr_repo_policy(
 
 /// Maps a stored PR row to the pure review view. `review` is the PR's review-gate
 /// state (only computed, and only meaningful, for a green open PR).
+///
+/// An open PR with an empty net diff is mapped to `Parked` regardless of its CI or
+/// review state: GitHub cannot squash-merge a zero-change PR, so it is never a
+/// merge or fix candidate. This is the parked-by-design empty draft (a documented
+/// blocker) and keeps the sweep from re-dispatching it forever (issue #304).
 fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool, review: ReviewState) -> PrReview {
     match pr.pr_state.as_str() {
         "merged" => PrReview::Merged,
         "closed" => PrReview::Closed,
+        _ if pr.is_empty => PrReview::Parked,
         _ => PrReview::Open {
             ci: match pr.ci_state.as_str() {
                 "passing" => PrCi::Passing,
@@ -3766,6 +3823,58 @@ mod tests {
         for (a, b) in [(main, delete), (main, mv), (delete, mv), (mv, missing)] {
             assert_ne!(a, b);
         }
+    }
+
+    #[test]
+    fn pr_review_of_maps_an_empty_open_pr_to_parked() {
+        // An open PR with an empty net diff is parked-by-design (issue #304): it
+        // maps to `Parked` regardless of CI, so the review decision never merges or
+        // re-dispatches it. A non-empty open PR keeps the normal Open view, and a
+        // merged/closed PR is unaffected by emptiness.
+        let pr = |pr_state: &str, ci_state: &str, is_empty: bool| TaskPullRequest {
+            id: uuid::Uuid::new_v4(),
+            task_id: uuid::Uuid::new_v4(),
+            repo_id: None,
+            repo_full_name: "o/r".to_string(),
+            pr_number: 1,
+            pr_url: "https://example.test/pr/1".to_string(),
+            head_sha: String::new(),
+            ci_state: ci_state.to_string(),
+            pr_state: pr_state.to_string(),
+            is_draft: false,
+            is_empty,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        // Empty open PR with passing CI and auto-merge requested -> Parked, not Merge.
+        assert_eq!(
+            pr_review_of(&pr("open", "passing", true), true, ReviewState::Clean),
+            PrReview::Parked
+        );
+        // Empty open PR with failing CI is still Parked (never re-dispatched to fix).
+        assert_eq!(
+            pr_review_of(&pr("open", "failing", true), true, ReviewState::Clean),
+            PrReview::Parked
+        );
+        // A non-empty open PR is unaffected: it keeps the normal Open view.
+        assert_eq!(
+            pr_review_of(&pr("open", "passing", false), true, ReviewState::Clean),
+            PrReview::Open {
+                ci: PrCi::Passing,
+                auto_merge: true,
+                review: ReviewState::Clean,
+            }
+        );
+        // Settled PRs ignore emptiness entirely.
+        assert_eq!(
+            pr_review_of(&pr("merged", "", true), true, ReviewState::Clean),
+            PrReview::Merged
+        );
+        assert_eq!(
+            pr_review_of(&pr("closed", "", true), true, ReviewState::Clean),
+            PrReview::Closed
+        );
     }
 
     #[test]

--- a/api/src/orchestrator/review.rs
+++ b/api/src/orchestrator/review.rs
@@ -41,6 +41,12 @@ pub enum PrReview {
     Merged,
     /// Closed without merging (the agent or a human abandoned this repo's PR).
     Closed,
+    /// Open but with an empty net diff vs base (a parked-by-design empty draft
+    /// documenting a blocker, or an empty-by-accident PR). GitHub cannot squash a
+    /// zero-change PR, so it is never merged, fixed, or re-dispatched; it just
+    /// holds the task in review until a human or unblock event acts on it. This is
+    /// the guard against the empty-BLOCKED-draft re-dispatch loop (issue #304).
+    Parked,
 }
 
 /// What the review loop should do with the task this tick.
@@ -159,13 +165,18 @@ pub fn decide(prs: &[PrReview], review_attempts_remaining: bool) -> ReviewDecisi
         return ReviewDecision::Merge(to_merge);
     }
 
-    // Nothing failing/pending/auto-mergeable. Any open PR left needs a human.
-    if prs.iter().any(|pr| matches!(pr, PrReview::Open { .. })) {
+    // Nothing failing/pending/auto-mergeable. Any open PR left needs a human, and a
+    // parked (empty) PR likewise holds the task in review: it is unmergeable by
+    // design, so the task is not Done while it is unresolved (issue #304).
+    if prs
+        .iter()
+        .any(|pr| matches!(pr, PrReview::Open { .. } | PrReview::Parked))
+    {
         return ReviewDecision::Hold;
     }
 
-    // Nothing open. Done once at least one PR merged; an all-closed task just
-    // holds (no work landed) rather than being marked complete.
+    // Nothing open or parked. Done once at least one PR merged; an all-closed task
+    // just holds (no work landed) rather than being marked complete.
     if prs.iter().any(|pr| matches!(pr, PrReview::Merged)) {
         ReviewDecision::Done
     } else {
@@ -318,6 +329,31 @@ mod tests {
                 open_with_comments(PrCi::Passing, true),
             ]),
             ReviewDecision::AddressReview
+        );
+    }
+
+    #[test]
+    fn a_parked_empty_pr_holds_and_is_never_merged_or_redispatched() {
+        // A lone parked (empty draft) PR just holds in review; it is never fixed,
+        // addressed, merged, or re-dispatched, no matter what CI would say.
+        assert_eq!(decide_ready(&[PrReview::Parked]), ReviewDecision::Hold);
+        // Budget exhausted changes nothing: a parked PR has no review work to spend
+        // attempts on, so it still simply holds.
+        assert_eq!(decide(&[PrReview::Parked], false), ReviewDecision::Hold);
+    }
+
+    #[test]
+    fn a_parked_pr_does_not_block_merging_a_sibling_and_never_completes_the_task() {
+        // The real PR in another repo still merges; the parked one is left alone.
+        assert_eq!(
+            decide_ready(&[PrReview::Parked, open(PrCi::Passing, true)]),
+            ReviewDecision::Merge(vec![1])
+        );
+        // Once the sibling has merged, the task is NOT Done while a parked PR
+        // remains: it holds for a human or an unblock event to act on the park.
+        assert_eq!(
+            decide_ready(&[PrReview::Parked, PrReview::Merged]),
+            ReviewDecision::Hold
         );
     }
 


### PR DESCRIPTION
Closes #304.

## Problem

When the agent hits a cross-repo blocker it cannot resolve in scope, it correctly parks the ticket by opening a **draft PR with a single empty commit** documenting the blocker. But GitHub cannot squash-merge a zero-change PR (it returns "failed to squash-merge"), and the review / stuck-PR sweep read that failure as a conflict and **re-dispatched the ticket as a fresh stuck-PR task on every sweep, forever**, for zero progress. Observed live on the CoverageAgent B-series parked tickets.

## Fix

Recognize an empty PR (zero changed files) and treat it as parked-by-design:

- `git::pr_status` now also reads the PR's `draft` flag and `changed_files`, and the review refresh persists `is_draft` / `is_empty` on the `task_pull_requests` row (migration `0047`). Both default `false`, so existing rows keep the normal flow until the next refresh fills in their true shape.
- `pr_review_of` maps an open PR with an **empty net diff** to a new `review::PrReview::Parked`, ahead of the CI and review-gate checks, so it is never a merge / fix / address / re-dispatch candidate. `review::decide` holds such a task in review and keeps it out of Done while the parked PR remains.
- `merge_task_prs` treats a `failed to squash-merge` on a now-empty PR as **benign** ("nothing to merge", leave parked), not a conflict to re-dispatch, guarding the race where a PR goes empty between the refresh and the merge.
- An empty PR that is **not** a draft is unexpected, so it is surfaced as an anomaly (a warning) and still held rather than merged (the empty-PR-approved-and-merged gap from the issue's bonus).

Non-empty drafts and real PRs are unaffected and follow the normal review-gate + auto-merge flow.

## Acceptance criteria

- [x] An empty draft BLOCKED PR is never auto-merge-attempted and never re-dispatched; it sits parked in review until a human or unblock event acts on it.
- [x] A zero-change squash failure is logged as benign ("nothing to merge"), not a conflict/CI failure.
- [x] Non-empty draft PRs and real PRs are unaffected.
- [x] Bonus: a genuinely-empty PR that is not a deliberate park is reported as an anomaly (warning) and held, not silently merged.

## Tests

- `review::decide`: a parked PR holds and is never merged or re-dispatched (with or without addressing budget), does not block a sibling's merge, and never completes the task while it remains.
- `pr_review_of`: an empty open PR maps to `Parked` regardless of CI; a non-empty open PR is unaffected; merged/closed PRs ignore emptiness.
- Migration `0047` verified against an ephemeral Postgres (`cargo run --bin migrate`); columns present with `false` defaults.
- `cargo +1.88 fmt --check`, `clippy --all-targets --all-features` (no new warnings), full `cargo test --all-features` green (178 tests).

## Scope

Backend-only logic + a migration; no UI was touched, so visual self-review does not apply.