### PR TITLE
CI guard: reject NUL bytes and control chars in source files (#305)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,23 @@ permissions:
   contents: read
 
 jobs:
-  # The three jobs are independent, so a failure in one never short-circuits the
-  # others ("no fail fast"). Within a job, checks use `if: ${{ !cancelled() }}`
-  # so a formatting failure still lets the tests run and report.
+  # The jobs are independent, so a failure in one never short-circuits the others
+  # ("no fail fast"). Within a job, checks use `if: ${{ !cancelled() }}` so a
+  # formatting failure still lets the tests run and report.
+
+  # Repo-wide, language-agnostic guard: reject NUL bytes (and other stray control
+  # characters) committed into a text source. A literal NUL compiles fine but makes
+  # git/grep/ripgrep treat the file as binary and silently skip it in code search
+  # (issue #295). Fast (checkout + a stdlib Python scan), so it gates every PR
+  # cheaply. The same script runs locally: `python3 scripts/check-control-chars.py`.
+  hygiene:
+    name: Source hygiene
+    runs-on: [self-hosted, Linux, X64, fedora]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject NUL bytes and control characters in tracked sources
+        run: python3 scripts/check-control-chars.py
 
   api:
     name: API (Rust)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,7 +612,12 @@ Playwright MCP, check layout via computed styles at 375px and 1280px).
   looks un-searchable, check it for NUL bytes
   (`python3 -c "print(open(p,'rb').read().count(0))"`) rather than trusting an
   empty `grep`. A literal NUL in a `.rs`/`.ts` source is a defect (usually a paste
-  artifact in a comment or string) and should be removed, not worked around.
+  artifact in a comment or string) and should be removed, not worked around. CI now
+  guards against this regressing (issue #305): the **Source hygiene** job runs
+  `scripts/check-control-chars.py`, which fails the PR if any tracked text file
+  (binary assets and the vendored `.yarn/` bundle excluded) contains a NUL byte or
+  other control character besides tab / newline / carriage return. Run it locally
+  the same way: `python3 scripts/check-control-chars.py`.
 - **Rust toolchain is pinned to 1.88** (`api/rust-toolchain.toml`) because some
   transitive deps ship edition2024 crates. The host default may be older — always
   use `cargo +1.88`.

--- a/scripts/check-control-chars.py
+++ b/scripts/check-control-chars.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fail if any tracked text source contains a NUL byte or other control char.
+
+A literal NUL byte pasted into a source file compiles fine but makes git, grep,
+and ripgrep treat the whole file as binary, so code search silently returns no
+matches for it (issue #295 was exactly this: two stray NULs in a Rust comment).
+Other C0 control characters are the same class of paste artifact. This guard runs
+in CI to catch them at PR time instead of after they quietly break code search.
+
+It cannot be done with `git grep`: the shell cannot pass a NUL on the command
+line, and git would classify the offending file as binary and skip it anyway. So
+this reads the raw bytes of every tracked, non-binary file itself.
+
+Run from the repository root:
+
+    python3 scripts/check-control-chars.py
+
+Exits 0 when clean, 1 (with a report of each offending file) when not.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# Control bytes that are legitimate in text: tab, line feed, carriage return.
+_ALLOWED_CONTROL_BYTES = frozenset({0x09, 0x0A, 0x0D})
+
+# Extensions for files that are binary by nature, so control bytes are expected
+# and must not be flagged. Everything else tracked is treated as text and scanned,
+# including extensionless scripts (Dockerfiles, the workspace `seraphim-*` helpers).
+_BINARY_EXTENSIONS = frozenset(
+    {
+        b".wav",
+        b".mp3",
+        b".mp4",
+        b".png",
+        b".jpg",
+        b".jpeg",
+        b".gif",
+        b".ico",
+        b".webp",
+        b".bmp",
+        b".pdf",
+        b".woff",
+        b".woff2",
+        b".ttf",
+        b".otf",
+        b".eot",
+        b".zip",
+        b".gz",
+        b".bz2",
+        b".xz",
+        b".tar",
+        b".bin",
+        b".wasm",
+    }
+)
+
+# Vendored third-party tooling that is not our source. Yarn Berry commits its
+# release bundle here (a minified bundle that embeds control bytes inside string
+# literals), and we neither author nor edit it, so it is out of scope for this guard.
+_EXCLUDED_PREFIXES = (b".yarn/",)
+
+
+def _tracked_files() -> list[bytes]:
+    """Return every tracked file path as raw bytes (NUL-delimited from git)."""
+    # `-z` keeps paths intact even with newlines or non-UTF-8 bytes in them, and
+    # lets us read each file by its exact bytes regardless of locale.
+    output = subprocess.run(
+        ["git", "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return [path for path in output.split(b"\x00") if path]
+
+
+def _is_scanned(path: bytes) -> bool:
+    """Whether a tracked path should be scanned (a text source, not vendored/binary)."""
+    if path.startswith(_EXCLUDED_PREFIXES):
+        return False
+    _, extension = os.path.splitext(path)
+    return extension.lower() not in _BINARY_EXTENSIONS
+
+
+def _first_violation(data: bytes) -> tuple[int, int] | None:
+    """Return (offset, byte) of the first disallowed control byte, or None if clean."""
+    for offset, byte in enumerate(data):
+        # DEL (0x7F) and the C0 controls below 0x20, minus the allowed whitespace.
+        if byte == 0x7F or (byte < 0x20 and byte not in _ALLOWED_CONTROL_BYTES):
+            return offset, byte
+    return None
+
+
+def main() -> int:
+    """Scan every tracked text source and report any control-byte contamination."""
+    failures: list[str] = []
+    for path in _tracked_files():
+        if not _is_scanned(path):
+            continue
+        with open(path, "rb") as handle:
+            data = handle.read()
+        violation = _first_violation(data)
+        if violation is None:
+            continue
+        offset, byte = violation
+        line = data.count(b"\n", 0, offset) + 1
+        column = offset - data.rfind(b"\n", 0, offset)
+        label = "NUL" if byte == 0x00 else f"0x{byte:02x}"
+        display_path = os.fsdecode(path)
+        failures.append(
+            f"{display_path}:{line}:{column}: disallowed control byte {label} "
+            f"(byte offset {offset})"
+        )
+
+    if failures:
+        print("Control-byte check failed: source files must not contain NUL bytes")
+        print("or other control characters (tab, newline, and carriage return are")
+        print("allowed). These are usually paste artifacts that silently break code")
+        print("search (issue #295). Offending files:")
+        print()
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+
+    print("Control-byte check passed: no NUL bytes or stray control characters found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #305.

## Problem

A literal NUL byte pasted into a source file compiles fine but makes git, grep, and ripgrep treat the whole file as binary, so code search silently returns no matches for it. Issue #295 was exactly this (two stray NULs in a comment in `api/src/db/queries.rs`) and it went unnoticed until search quietly broke. Other C0 control characters are the same class of paste artifact.

## Fix

A fast, repo-wide CI guard that catches this at PR time instead of after it silently breaks code search.

- **`scripts/check-control-chars.py`** (stdlib only): reads the raw bytes of every tracked text file and fails on any NUL byte or other control character (everything below `0x20` except tab / newline / carriage return, plus DEL `0x7f`). It reads bytes itself rather than using `git grep`, because the shell cannot pass a NUL on the command line and git would classify the offending file as binary and skip it anyway (the exact reason the bug hid). It reports each offending file with `path:line:column` and the byte.
  - **Excluded:** binary assets by extension (`.wav`, `.png`, fonts, archives, ...) and the vendored `.yarn/` Yarn Berry bundle (third-party, embeds control bytes in string literals, not our source). Extensionless scripts and Dockerfiles **are** scanned.
- **New `Source hygiene` CI job** runs the script on checkout. It is independent of the api/frontend/images jobs (no fail-fast) and cheap (checkout + a stdlib scan).
- Documented in `CLAUDE.md` next to the existing #295 `rg`/`grep` note; the same script runs locally via `python3 scripts/check-control-chars.py`.

## Verification

- Passes on the current clean tree (302 tracked text files scanned).
- Fails on a planted NUL in a `.rs` comment (reports `:1:9: disallowed control byte NUL`) and on an ESC (`0x1b`) byte.
- Skips a NUL planted in a `.png` (binary) and the vendored `.yarn/` bundle (which contains control bytes but no NUL).
- `ci.yml` validated as well-formed YAML; the new job and step parse correctly.

## Scope

CI/tooling + docs only; no Rust or frontend code changed, so there is no UI to review and the app build/test/lint surface is unaffected.