### PR TITLE
Surface empty/anomalous PRs on the board, not just in the log (#314)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,9 +498,15 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
      an unblock event acts on it (`review::decide` keeps the task out of Done while
      a parked PR remains). `merge_task_prs` also treats a `failed to squash-merge`
      on a now-empty PR as benign ("nothing to merge", leave parked), not a conflict.
-     An empty PR that is NOT a draft is unexpected, so it is surfaced as an anomaly
-     (a warning) and still held rather than merged. Non-empty drafts and real PRs
-     follow the normal review-gate + auto-merge flow.
+     An empty PR that is NOT a draft is unexpected, so it is held (never merged) and
+     **surfaced on the board** (issue #314), not just logged: `refresh_task_prs`
+     fires a one-time `ServerEvent::AnomalousEmptyPr` (toast + native notification)
+     on the transition into the anomaly, and the board payload carries a derived,
+     self-clearing `anomalous_empty_prs` list (`queries::list_anomalous_empty_prs`,
+     open + `is_empty` + not `is_draft`) that drives a dismissible banner, mirroring
+     the repo-sync-error banner; it drops off once the PR gains changes, closes, or
+     is marked draft. Non-empty drafts and real PRs follow the normal review-gate +
+     auto-merge flow.
    - **Review-comment gate (issues #255, #270):** a green PR is NEVER squash-merged
      while it carries review work, no matter its approval state. The merge gate is
      exactly **CI green AND zero unresolved review threads AND no outstanding

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -407,6 +407,20 @@ pub struct RepoSyncError {
     pub sync_error_at: DateTime<Utc>,
 }
 
+/// An open, non-draft pull request whose net diff is empty (issue #314): an
+/// anomaly, since GitHub cannot squash-merge a zero-change PR and the agent did
+/// not deliberately park it as a draft. Surfaced as a self-clearing board banner
+/// (it drops off once the PR gains changes, is closed, or is marked draft), so the
+/// operator sees it without scanning the logs. Carries only what the banner needs.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct AnomalousEmptyPr {
+    pub task_id: Uuid,
+    pub task_title: String,
+    pub repo_full_name: String,
+    pub pr_number: i64,
+    pub pr_url: String,
+}
+
 /// What a repository delete will purge, so the UI can spell it out before the
 /// user confirms. Counts the repo's tasks and everything that cascades from them.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,12 +12,12 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials, DependencyCandidate,
-    EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment, JiraBoard, JiraDeployment,
-    NetworkAccessLevel, PendingPlacement, PendingQuestion, Question, QuestionOption,
-    QuestionStatus, Railway, RepoDeletionImpact, RepoSyncError, Repository, ReviewPolicy, Settings,
-    SourceKind, StatsAggregate, Task, TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot,
-    TaskStatus, Turn,
+    AnomalousEmptyPr, AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials,
+    DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment,
+    JiraBoard, JiraDeployment, NetworkAccessLevel, PendingPlacement, PendingQuestion, Question,
+    QuestionOption, QuestionStatus, Railway, RepoDeletionImpact, RepoSyncError, Repository,
+    ReviewPolicy, Settings, SourceKind, StatsAggregate, Task, TaskAttachment, TaskColumn,
+    TaskPullRequest, TaskScreenshot, TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -2438,6 +2438,22 @@ pub async fn list_task_prs(pool: &PgPool, task_id: Uuid) -> sqlx::Result<Vec<Tas
 pub async fn list_open_task_prs(pool: &PgPool) -> sqlx::Result<Vec<TaskPullRequest>> {
     sqlx::query_as::<_, TaskPullRequest>(
         "SELECT * FROM task_pull_requests WHERE pr_state = 'open' ORDER BY task_id, created_at",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Open, non-draft pull requests whose net diff is empty, across all tasks, for the
+/// board's anomaly banner (issue #314). A draft empty PR is a parked-by-design
+/// blocker (issue #304) and is excluded; only the unexpected ones surface. Derived
+/// live from the tracked PR rows, so the banner clears itself the moment a PR gains
+/// changes, is closed, or is marked draft, with no separate state to reconcile.
+pub async fn list_anomalous_empty_prs(pool: &PgPool) -> sqlx::Result<Vec<AnomalousEmptyPr>> {
+    sqlx::query_as::<_, AnomalousEmptyPr>(
+        "SELECT pr.task_id, t.title AS task_title, pr.repo_full_name, pr.pr_number, pr.pr_url \
+         FROM task_pull_requests pr JOIN tasks t ON t.id = pr.task_id \
+         WHERE pr.pr_state = 'open' AND pr.is_empty = TRUE AND pr.is_draft = FALSE \
+         ORDER BY pr.updated_at DESC",
     )
     .fetch_all(pool)
     .await

--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -15,7 +15,8 @@ use tracing::{info, warn};
 
 use super::ApiResult;
 use crate::db::models::{
-    HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn, TaskStatus,
+    AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn,
+    TaskStatus,
 };
 use crate::db::queries;
 use crate::git;
@@ -38,6 +39,10 @@ pub struct BoardResponse {
     /// Repos whose last issue sync failed (issue #213), so the board can show a
     /// persistent banner naming each failing repo and why until it recovers.
     pub repo_sync_errors: Vec<RepoSyncError>,
+    /// Open, non-draft PRs whose net diff is empty (issue #314): an anomaly the
+    /// board surfaces in a banner so it does not sit only in the logs. Self-clearing
+    /// (it drops off once the PR gains changes, closes, or is marked draft).
+    pub anomalous_empty_prs: Vec<AnomalousEmptyPr>,
 }
 
 /// `GET /api/v1/board` - every card, the org/pause settings, per-card counts of
@@ -54,6 +59,7 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
         .collect();
     let heart_attacks = queries::list_unacknowledged_heart_attacks(&state.db).await?;
     let repo_sync_errors = queries::list_repo_sync_errors(&state.db).await?;
+    let anomalous_empty_prs = queries::list_anomalous_empty_prs(&state.db).await?;
     Ok(Json(BoardResponse {
         tasks,
         settings,
@@ -61,6 +67,7 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
         suggestion_counts,
         heart_attacks,
         repo_sync_errors,
+        anomalous_empty_prs,
     }))
 }
 

--- a/api/src/http/sse.rs
+++ b/api/src/http/sse.rs
@@ -31,6 +31,7 @@ pub async fn board_stream(
                     ServerEvent::Task { .. }
                     | ServerEvent::Notification { .. }
                     | ServerEvent::RepoSyncError { .. }
+                    | ServerEvent::AnomalousEmptyPr { .. }
                     | ServerEvent::HeartAttack { .. }
                     | ServerEvent::TaskFinished { .. }
                     | ServerEvent::Compose { .. }
@@ -86,6 +87,16 @@ pub async fn notification_stream(
                     let payload = serde_json::json!({ "repo": repo, "message": message });
                     let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
                     yield Ok(Event::default().event("repo_sync_error").data(data));
+                }
+                Ok(ServerEvent::AnomalousEmptyPr { task_id, task_title, pr_ref, pr_url }) => {
+                    let payload = serde_json::json!({
+                        "task_id": task_id,
+                        "task_title": task_title,
+                        "pr_ref": pr_ref,
+                        "pr_url": pr_url,
+                    });
+                    let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+                    yield Ok(Event::default().event("anomalous_empty_pr").data(data));
                 }
                 Ok(ServerEvent::Board) => {
                     yield Ok(Event::default().event("refresh").data("{}"));

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -2612,17 +2612,11 @@ async fn review_task(
     for pr in &prs {
         // An empty open PR is parked-by-design (a blocker the agent documented):
         // it is never merged or re-dispatched, so skip the review-gate lookup
-        // entirely (issue #304). An empty PR that is NOT a draft is unexpected, so
-        // surface it as an anomaly rather than letting it sit silently; it is still
-        // held (never auto-merged), since GitHub cannot squash a zero-change PR.
+        // entirely (issue #304). A non-draft empty PR is unexpected; it is still held
+        // here (never auto-merged, since GitHub cannot squash a zero-change PR) and is
+        // surfaced as a one-time board anomaly by `refresh_task_prs` (issue #314),
+        // not by a warning that repeats every review tick.
         if pr.pr_state == "open" && pr.is_empty {
-            if !pr.is_draft {
-                warn!(
-                    task_id = %task.id,
-                    pr = %pr.pr_url,
-                    "open pull request has no changes and is not a draft; holding it as an anomaly rather than auto-merging"
-                );
-            }
             views.push(pr_review_of(pr, false, ReviewState::Clean));
             continue;
         }
@@ -3048,6 +3042,33 @@ async fn refresh_task_prs(
                 multi,
             )
             .await?;
+        }
+
+        // Surface a newly-anomalous PR once (issue #314): an open PR with an empty
+        // net diff that is NOT a draft is unexpected (a draft empty PR is a
+        // parked-by-design blocker, issue #304, and never surfaces here). The board's
+        // self-clearing banner carries the ongoing state; the one-time toast fires
+        // only on the transition into the anomaly, so the operator is not pinged
+        // every review tick. `pr` holds the pre-refresh row, so comparing it to the
+        // values just written gives the transition. Nudge the board whenever the
+        // anomaly appears or clears so the banner stays in sync.
+        let was_anomalous = pr.is_empty && !pr.is_draft;
+        let now_anomalous = pr_state == "open" && is_empty && !is_draft;
+        if now_anomalous && !was_anomalous {
+            warn!(
+                task_id = %task.id,
+                pr = %pr.pr_url,
+                "open pull request has no changes and is not a draft; surfacing it as a board anomaly"
+            );
+            state.notify_anomalous_empty_pr(
+                task.id,
+                task.title.clone(),
+                format!("{}#{}", short_repo_name(&pr.repo_full_name), pr.pr_number),
+                pr.pr_url.clone(),
+            );
+        }
+        if now_anomalous != was_anomalous {
+            state.notify_board();
         }
     }
     Ok(queries::list_task_prs(&state.db, task.id).await?)

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -42,6 +42,17 @@ pub enum ServerEvent {
     /// #213); drives a one-time alert toast and native notification. The ongoing
     /// state is carried by the persistent board banner, not repeated per cycle.
     RepoSyncError { repo: String, message: String },
+    /// An open, non-draft pull request was first seen with an empty net diff (issue
+    /// #314), an anomaly. Fires once on that transition (not every review tick) to
+    /// drive a one-time toast + native notification; the ongoing state is carried by
+    /// the board's self-clearing anomaly banner.
+    AnomalousEmptyPr {
+        task_id: Uuid,
+        task_title: String,
+        /// `repo#number` of the offending PR, for the toast line.
+        pr_ref: String,
+        pr_url: String,
+    },
     /// A turn died mid-flight (a "heart attack") and the defibrillator handled it;
     /// drives an alert toast and native notification so the operator notices.
     HeartAttack {
@@ -397,6 +408,24 @@ impl AppState {
         let _ = self
             .events
             .send(ServerEvent::RepoSyncError { repo, message });
+    }
+
+    /// Announces that an open, non-draft PR was first seen empty (issue #314), so
+    /// the UI alerts the operator once on that transition. The self-clearing board
+    /// anomaly banner (driven by [`Self::notify_board`]) carries the ongoing state.
+    pub fn notify_anomalous_empty_pr(
+        &self,
+        task_id: Uuid,
+        task_title: String,
+        pr_ref: String,
+        pr_url: String,
+    ) {
+        let _ = self.events.send(ServerEvent::AnomalousEmptyPr {
+            task_id,
+            task_title,
+            pr_ref,
+            pr_url,
+        });
     }
 
     /// Announces a heart attack so the UI alerts the operator immediately, in

--- a/frontend/src/lib/components/Notifications.svelte
+++ b/frontend/src/lib/components/Notifications.svelte
@@ -26,8 +26,9 @@
     taskTitle: string
     prompt: string
     // 'question' is the agent asking for input; 'heart_attack' is a dead turn;
-    // 'repo_sync_error' is a repo whose issue sync started failing (issue #213).
-    kind: 'question' | 'heart_attack' | 'repo_sync_error'
+    // 'repo_sync_error' is a repo whose issue sync started failing (issue #213);
+    // 'anomalous_empty_pr' is an open non-draft PR with no changes (issue #314).
+    kind: 'question' | 'heart_attack' | 'repo_sync_error' | 'anomalous_empty_pr'
   }
 
   function loadIds(key: string): Set<string> {
@@ -213,6 +214,22 @@
     playSound('attention')
   }
 
+  // An open, non-draft PR was first seen with no changes (issue #314). Fires once on
+  // that transition; the board's self-clearing anomaly banner carries the ongoing
+  // state. Clicking the toast opens the task.
+  function handleAnomalousEmptyPr(event: MessageEvent) {
+    const data = JSON.parse(event.data) as {
+      task_id: string
+      task_title: string
+      pr_ref: string
+      pr_url: string
+    }
+    const detail = `${data.pr_ref} has no changes and cannot be merged; close it or push the intended changes.`
+    pushToast(data.task_id, data.task_title, detail, 'anomalous_empty_pr')
+    notifyNatively(`Empty pull request: ${data.pr_ref}`, data.task_title)
+    playSound('attention')
+  }
+
   // A task finished (auto-merged to Done). Sound-only: the board already reflects
   // it, so no toast, just the completion chime.
   function handleTaskFinished() {
@@ -234,6 +251,7 @@
     eventSource.addEventListener('notification', handleNotification)
     eventSource.addEventListener('heart_attack', handleHeartAttack)
     eventSource.addEventListener('repo_sync_error', handleRepoSyncError)
+    eventSource.addEventListener('anomalous_empty_pr', handleAnomalousEmptyPr)
     eventSource.addEventListener('task_finished', handleTaskFinished)
     eventSource.addEventListener('refresh', () => {
       refresh()
@@ -331,7 +349,7 @@
   {#each toasts as toast (toast.id)}
     <div
       class="pointer-events-auto flex items-start overflow-hidden rounded-lg border bg-card shadow-2xl {toast.kind ===
-        'heart_attack' || toast.kind === 'repo_sync_error'
+        'heart_attack' || toast.kind === 'repo_sync_error' || toast.kind === 'anomalous_empty_pr'
         ? 'border-destructive/60'
         : 'border-warning/50'}"
     >
@@ -347,6 +365,10 @@
         {:else if toast.kind === 'repo_sync_error'}
           <span class="text-[10px] font-bold uppercase tracking-wide text-destructive"
             >Issue sync failed</span
+          >
+        {:else if toast.kind === 'anomalous_empty_pr'}
+          <span class="text-[10px] font-bold uppercase tracking-wide text-destructive"
+            >Empty pull request</span
           >
         {:else}
           <span class="text-[10px] font-bold uppercase tracking-wide text-warning"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -310,6 +310,16 @@ export type RepoSyncError = {
   sync_error_at: string
 }
 
+// An open, non-draft PR with an empty net diff (issue #314): an anomaly the board
+// surfaces in a banner. Self-clearing once the PR gains changes, closes, or drafts.
+export type AnomalousEmptyPr = {
+  task_id: string
+  task_title: string
+  repo_full_name: string
+  pr_number: number
+  pr_url: string
+}
+
 // What deleting a repository will purge, shown in the delete confirmation.
 export type RepoDeletionImpact = {
   tasks: number
@@ -515,6 +525,8 @@ export type BoardResponse = {
   heart_attacks: HeartAttack[]
   // Repos whose last issue sync failed (issue #213), for a persistent banner.
   repo_sync_errors: RepoSyncError[]
+  // Open, non-draft empty PRs (issue #314), for the self-clearing anomaly banner.
+  anomalous_empty_prs: AnomalousEmptyPr[]
 }
 
 // A pull request the task has opened. A task may span several repos, so it can

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import type { DndEvent } from 'svelte-dnd-action'
-  import type { HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn } from '$lib/types'
+  import type { AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn } from '$lib/types'
 
   import { onMount, onDestroy } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
   import { dndzone } from 'svelte-dnd-action'
   import { toast } from 'svelte-sonner'
   import {
+    GitPullRequestArrow,
     HeartPulse,
     NotebookPen,
     RefreshCw,
@@ -76,6 +77,16 @@
   let dismissedSyncRepos = new SvelteSet<string>()
   const visibleSyncErrors = $derived(
     repoSyncErrors.filter((repo) => !dismissedSyncRepos.has(repo.full_name))
+  )
+  // Open, non-draft empty PRs (issue #314). Mirrors the sync-error banner: it
+  // persists while the PR is anomalous and self-clears once the PR gains changes,
+  // closes, or is marked draft; `dismissedEmptyPrs` (keyed by PR url) hides one the
+  // operator has read, and is forgotten once that PR is no longer anomalous so a
+  // later recurrence surfaces again. The one-time toast is driven via SSE.
+  let anomalousEmptyPrs = $state<AnomalousEmptyPr[]>([])
+  let dismissedEmptyPrs = new SvelteSet<string>()
+  const visibleEmptyPrs = $derived(
+    anomalousEmptyPrs.filter((pr) => !dismissedEmptyPrs.has(pr.pr_url))
   )
   // Every railway (swimlane), already ordered `main` first then by rank.
   let railways = $state<Railway[]>([])
@@ -417,6 +428,15 @@
     for (const name of dismissedSyncRepos) {
       if (!failing.has(name)) {
         dismissedSyncRepos.delete(name)
+      }
+    }
+    anomalousEmptyPrs = board.anomalous_empty_prs
+    // Same self-clearing dismissal: forget a dismissed PR once it is no longer
+    // anomalous, so a later recurrence on that PR raises the banner again.
+    const anomalous = new Set(anomalousEmptyPrs.map((pr) => pr.pr_url))
+    for (const url of dismissedEmptyPrs) {
+      if (!anomalous.has(url)) {
+        dismissedEmptyPrs.delete(url)
       }
     }
     repoNames = Object.fromEntries(repos.map((repo) => [repo.id, repo.full_name]))
@@ -957,6 +977,43 @@
         title="Dismiss"
         aria-label="Dismiss sync error"
         onclick={() => dismissedSyncRepos.add(repo.full_name)}
+      >
+        <X class="size-4" />
+      </Button>
+    </Alert.Root>
+  {/each}
+
+  {#each visibleEmptyPrs as pr (pr.pr_url)}
+    <!-- An open, non-draft PR has an empty net diff (issue #314). GitHub cannot
+         squash a zero-change PR and the agent did not deliberately park it as a
+         draft, so it is held in review and surfaced here. Self-clears when the PR
+         gains changes, is closed, or is marked draft; dismissible once read. -->
+    <Alert.Root variant="destructive" class="mx-6 mt-4 flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <Alert.Title class="flex items-center gap-1.5">
+          <GitPullRequestArrow class="size-4 flex-none" />
+          Empty pull request: {pr.repo_full_name}#{pr.pr_number}
+        </Alert.Title>
+        <Alert.Description class="break-words">
+          <span>
+            "{pr.task_title}" opened a pull request with no changes that is not a draft, so it
+            cannot be merged. It is held in review; close it or push the intended changes.
+          </span>
+          <a href={pr.pr_url} target="_blank" rel="noreferrer" class="mt-1 inline-block text-xs underline">
+            Open the pull request
+          </a>
+          <a href={`/task/${pr.task_id}`} class="mt-1 ml-3 inline-block text-xs underline">
+            Open the task
+          </a>
+        </Alert.Description>
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        class="flex-none"
+        title="Dismiss"
+        aria-label="Dismiss empty pull request anomaly"
+        onclick={() => dismissedEmptyPrs.add(pr.pr_url)}
       >
         <X class="size-4" />
       </Button>


### PR DESCRIPTION
Closes #314.

## Problem

The #304 fix reported a non-draft empty PR (an anomaly: GitHub cannot squash a zero-change PR and the agent did not deliberately park it as a draft) only via a `warn!` that repeated every review tick (~30s). It sat buried in the logs instead of being visible to the operator.

## Fix

Surface it on the board, mirroring how repo sync errors already surface: a self-clearing banner plus a one-time notification.

- **`queries::list_anomalous_empty_prs`** derives the set live from the tracked PR rows (`pr_state = open AND is_empty AND NOT is_draft`), joined to the task for its title. The board payload (`BoardResponse`) carries it as `anomalous_empty_prs`. No new table or state: the banner self-clears the moment a PR gains changes, is closed, or is marked draft.
- **Board banner** (`+page.svelte`): a dismissible destructive `Alert` per anomaly, mirroring the repo-sync-error banner. It names the offending `repo#number`, the task, why it is stuck, and links to the PR and the task. A dismissal is forgotten once the PR is no longer anomalous, so a recurrence resurfaces it.
- **One-time notification** (`refresh_task_prs`): fires `ServerEvent::AnomalousEmptyPr` (toast + native notification, handled in `Notifications.svelte`) only on the transition into the anomaly, comparing the pre-refresh row to the values just written, so the operator is not pinged every tick. It also nudges the board so the banner appears/clears promptly.
- The per-tick `warn!` in the `review_task` anomaly branch is **removed**; a single `warn!` now logs at the transition in `refresh_task_prs`.

## Visual self-review

Ran the board page through the Playwright MCP (headless) against a seeded anomalous PR, at 1280px and 375px, with computed-style checks:
- The banner renders with destructive styling, the PR icon inline-aligned with the title, both working links ("Open the pull request" / "Open the task"), and a dismiss button.
- It is **geometrically identical** to the existing config-repo / sync-error banners at both widths (same x/right/width/margins), confirmed by measuring both live.
- The 24px right-margin overflow at narrow widths is a **pre-existing** characteristic of the shared `mx-6` banner pattern (the config-repo banner measured identically), not introduced here. Flagged as a follow-up.

## Verification

- `cargo +1.88 fmt --check` clean; `clippy --all-targets --all-features` no new warnings; full API suite green (179 tests).
- `yarn check` (svelte-check) 0 errors; `yarn build` clean.

## Scope

Backend (derived query + board payload + one-time SSE event) and the board UI banner + toast. No migration (the data already lives on `task_pull_requests` from #304).