### PR TITLE
Do not auto-merge-attempt draft PRs, of any size (#315)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,21 +486,23 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
    pushes nothing (genuinely unresolvable) or the budget is exhausted, it falls
    back to `ci_blocked` for a human. The single-PR case is just a one-row set, so
    its behavior is unchanged.
-   - **Parked empty PRs (issue #304):** when the agent hits a cross-repo blocker it
-     cannot resolve in scope, it parks the ticket by opening a **draft PR with a
-     single empty commit** documenting the blocker. GitHub cannot squash-merge a
-     zero-change PR, so the sweep used to read the merge failure as a conflict and
-     re-dispatch the ticket forever. The refresh now records each PR's `is_draft` /
-     `is_empty` shape (`git::pr_status` reads `draft` + `changed_files`), and a PR
-     with an **empty net diff** maps to a new `review::PrReview::Parked` (in
-     `pr_review_of`, ahead of the CI/review checks): it is never merge-attempted,
-     CI-fixed, addressed, or re-dispatched, just **held in review** until a human or
-     an unblock event acts on it (`review::decide` keeps the task out of Done while
-     a parked PR remains). `merge_task_prs` also treats a `failed to squash-merge`
-     on a now-empty PR as benign ("nothing to merge", leave parked), not a conflict.
-     An empty PR that is NOT a draft is unexpected, so it is surfaced as an anomaly
-     (a warning) and still held rather than merged. Non-empty drafts and real PRs
-     follow the normal review-gate + auto-merge flow.
+   - **Parked unmergeable PRs (issues #304, #315):** an open PR GitHub cannot
+     squash-merge is **held in review**, never merge-attempted or re-dispatched, so
+     the merge-fails-then-flagged-a-conflict loop can't happen. Two cases qualify: an
+     **empty net diff** (e.g. the agent parks a cross-repo blocker by opening a draft
+     PR with a single empty commit documenting it, issue #304) and a **draft of any
+     size** (GitHub refuses to merge a draft until it is marked ready, issue #315).
+     The refresh records each PR's `is_draft` / `is_empty` shape (`git::pr_status`
+     reads `draft` + `changed_files`), and `pr_review_of` maps either to
+     `review::PrReview::Parked` ahead of the CI/review checks: it is never
+     merge-attempted, CI-fixed, addressed, or re-dispatched, just held until a human
+     or unblock event (a non-empty diff, a "ready for review") acts on it
+     (`review::decide` keeps the task out of Done while a parked PR remains).
+     `merge_task_prs` also treats a `failed to squash-merge` on a now-empty-or-draft
+     PR as benign ("not mergeable yet", leave parked), not a conflict. An empty PR
+     that is NOT a draft is unexpected, so it is also surfaced as an anomaly (a
+     warning). Non-empty, non-draft (ready) PRs follow the normal review-gate +
+     auto-merge flow.
    - **Review-comment gate (issues #255, #270):** a green PR is NEVER squash-merged
      while it carries review work, no matter its approval state. The merge gate is
      exactly **CI green AND zero unresolved review threads AND no outstanding

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -2610,13 +2610,14 @@ async fn review_task(
 
     let mut views = Vec::with_capacity(prs.len());
     for pr in &prs {
-        // An empty open PR is parked-by-design (a blocker the agent documented):
-        // it is never merged or re-dispatched, so skip the review-gate lookup
-        // entirely (issue #304). An empty PR that is NOT a draft is unexpected, so
-        // surface it as an anomaly rather than letting it sit silently; it is still
-        // held (never auto-merged), since GitHub cannot squash a zero-change PR.
-        if pr.pr_state == "open" && pr.is_empty {
-            if !pr.is_draft {
+        // A PR GitHub cannot squash-merge is parked and held in review, never merged
+        // or re-dispatched, so skip the review-gate lookup entirely: an empty net
+        // diff (issue #304) or a draft (issue #315, GitHub refuses to merge a draft).
+        // An empty PR that is NOT a draft is unexpected, so surface it as an anomaly
+        // rather than letting it sit silently; a draft is a deliberate "not ready",
+        // so it just holds quietly until it is marked ready or a human acts.
+        if pr.pr_state == "open" && (pr.is_empty || pr.is_draft) {
+            if pr.is_empty && !pr.is_draft {
                 warn!(
                     task_id = %task.id,
                     pr = %pr.pr_url,
@@ -2759,21 +2760,21 @@ async fn merge_task_prs(
                 .await?;
             }
             Err(error) => {
-                // A zero-change PR cannot be squash-merged (GitHub rejects it). The
-                // review sweep already classifies empty PRs as parked and never
-                // selects them to merge, so reaching here with an empty PR means it
-                // went empty between the refresh and this merge. Treat it as benign
-                // ("nothing to merge") and leave it parked in review, rather than a
-                // conflict to re-dispatch forever (issue #304).
-                let empty = git::pr_status(github, owner, name, number)
+                // GitHub refuses to squash-merge a zero-change PR (issue #304) or any
+                // draft (issue #315). The review sweep already classifies both as
+                // parked and never selects them to merge, so reaching here means the
+                // PR changed shape (went empty, or was re-drafted) between the refresh
+                // and this merge. Treat it as benign ("not mergeable yet") and leave
+                // it parked in review, rather than a conflict to re-dispatch forever.
+                let unmergeable = git::pr_status(github, owner, name, number)
                     .await
-                    .map(|status| status.is_empty)
+                    .map(|status| status.is_empty || status.draft)
                     .unwrap_or(false);
-                if empty {
+                if unmergeable {
                     info!(
                         task_id = %task.id,
                         pr = %pr.pr_url,
-                        "auto-merge skipped: pull request has no changes; leaving it parked in review"
+                        "auto-merge skipped: pull request is a draft or has no changes; leaving it parked in review"
                     );
                     if task.status != TaskStatus::AwaitingReview {
                         queries::set_task_status(&state.db, task.id, TaskStatus::AwaitingReview)
@@ -3072,15 +3073,17 @@ async fn pr_repo_policy(
 /// Maps a stored PR row to the pure review view. `review` is the PR's review-gate
 /// state (only computed, and only meaningful, for a green open PR).
 ///
-/// An open PR with an empty net diff is mapped to `Parked` regardless of its CI or
-/// review state: GitHub cannot squash-merge a zero-change PR, so it is never a
-/// merge or fix candidate. This is the parked-by-design empty draft (a documented
-/// blocker) and keeps the sweep from re-dispatching it forever (issue #304).
+/// An open PR that GitHub cannot squash-merge is mapped to `Parked` regardless of
+/// its CI or review state, so it is never a merge or fix candidate, just held in
+/// review. Two cases qualify: an empty net diff (a parked-by-design blocker or an
+/// empty-by-accident PR, issue #304) and a draft (any draft, which GitHub refuses
+/// to merge until it is marked ready, issue #315). Both otherwise fall through to a
+/// merge attempt that fails and gets misread as a conflict to re-dispatch forever.
 fn pr_review_of(pr: &TaskPullRequest, auto_merge: bool, review: ReviewState) -> PrReview {
     match pr.pr_state.as_str() {
         "merged" => PrReview::Merged,
         "closed" => PrReview::Closed,
-        _ if pr.is_empty => PrReview::Parked,
+        _ if pr.is_empty || pr.is_draft => PrReview::Parked,
         _ => PrReview::Open {
             ci: match pr.ci_state.as_str() {
                 "passing" => PrCi::Passing,
@@ -3828,12 +3831,12 @@ mod tests {
     }
 
     #[test]
-    fn pr_review_of_maps_an_empty_open_pr_to_parked() {
-        // An open PR with an empty net diff is parked-by-design (issue #304): it
-        // maps to `Parked` regardless of CI, so the review decision never merges or
-        // re-dispatches it. A non-empty open PR keeps the normal Open view, and a
-        // merged/closed PR is unaffected by emptiness.
-        let pr = |pr_state: &str, ci_state: &str, is_empty: bool| TaskPullRequest {
+    fn pr_review_of_parks_an_unmergeable_open_pr() {
+        // An open PR GitHub cannot squash-merge maps to `Parked` regardless of CI, so
+        // the review decision never merges or re-dispatches it: an empty net diff
+        // (issue #304) or a draft of any size (issue #315). A non-empty, ready PR
+        // keeps the normal Open view, and a merged/closed PR is unaffected.
+        let pr = |pr_state: &str, ci_state: &str, is_draft: bool, is_empty: bool| TaskPullRequest {
             id: uuid::Uuid::new_v4(),
             task_id: uuid::Uuid::new_v4(),
             repo_id: None,
@@ -3843,38 +3846,60 @@ mod tests {
             head_sha: String::new(),
             ci_state: ci_state.to_string(),
             pr_state: pr_state.to_string(),
-            is_draft: false,
+            is_draft,
             is_empty,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
 
-        // Empty open PR with passing CI and auto-merge requested -> Parked, not Merge.
+        // Empty open PR (passing or failing CI) -> Parked, never merged or fixed.
         assert_eq!(
-            pr_review_of(&pr("open", "passing", true), true, ReviewState::Clean),
+            pr_review_of(
+                &pr("open", "passing", false, true),
+                true,
+                ReviewState::Clean
+            ),
             PrReview::Parked
         );
-        // Empty open PR with failing CI is still Parked (never re-dispatched to fix).
         assert_eq!(
-            pr_review_of(&pr("open", "failing", true), true, ReviewState::Clean),
+            pr_review_of(
+                &pr("open", "failing", false, true),
+                true,
+                ReviewState::Clean
+            ),
             PrReview::Parked
         );
-        // A non-empty open PR is unaffected: it keeps the normal Open view.
+        // A non-empty DRAFT PR is also unmergeable (issue #315) -> Parked, even with
+        // passing CI and auto-merge requested, so it is never merge-attempted.
         assert_eq!(
-            pr_review_of(&pr("open", "passing", false), true, ReviewState::Clean),
+            pr_review_of(
+                &pr("open", "passing", true, false),
+                true,
+                ReviewState::Clean
+            ),
+            PrReview::Parked
+        );
+        // A non-empty, non-draft (ready) PR is unaffected: it keeps the normal Open
+        // view and flows through the usual merge gate.
+        assert_eq!(
+            pr_review_of(
+                &pr("open", "passing", false, false),
+                true,
+                ReviewState::Clean
+            ),
             PrReview::Open {
                 ci: PrCi::Passing,
                 auto_merge: true,
                 review: ReviewState::Clean,
             }
         );
-        // Settled PRs ignore emptiness entirely.
+        // Settled PRs ignore draft/empty entirely.
         assert_eq!(
-            pr_review_of(&pr("merged", "", true), true, ReviewState::Clean),
+            pr_review_of(&pr("merged", "", true, true), true, ReviewState::Clean),
             PrReview::Merged
         );
         assert_eq!(
-            pr_review_of(&pr("closed", "", true), true, ReviewState::Clean),
+            pr_review_of(&pr("closed", "", true, false), true, ReviewState::Clean),
             PrReview::Closed
         );
     }

--- a/api/src/orchestrator/review.rs
+++ b/api/src/orchestrator/review.rs
@@ -41,11 +41,13 @@ pub enum PrReview {
     Merged,
     /// Closed without merging (the agent or a human abandoned this repo's PR).
     Closed,
-    /// Open but with an empty net diff vs base (a parked-by-design empty draft
-    /// documenting a blocker, or an empty-by-accident PR). GitHub cannot squash a
-    /// zero-change PR, so it is never merged, fixed, or re-dispatched; it just
-    /// holds the task in review until a human or unblock event acts on it. This is
-    /// the guard against the empty-BLOCKED-draft re-dispatch loop (issue #304).
+    /// Open but not mergeable by GitHub, so it is never merged, fixed, or
+    /// re-dispatched; it just holds the task in review until a human or unblock
+    /// event acts on it. Two cases: an empty net diff vs base (a parked-by-design
+    /// empty draft documenting a blocker, or an empty-by-accident PR, issue #304),
+    /// and a draft of any size (GitHub refuses to merge a draft until it is marked
+    /// ready, issue #315). Both guard against the same merge-fails-then-re-dispatch
+    /// loop.
     Parked,
 }
 
@@ -166,8 +168,8 @@ pub fn decide(prs: &[PrReview], review_attempts_remaining: bool) -> ReviewDecisi
     }
 
     // Nothing failing/pending/auto-mergeable. Any open PR left needs a human, and a
-    // parked (empty) PR likewise holds the task in review: it is unmergeable by
-    // design, so the task is not Done while it is unresolved (issue #304).
+    // parked PR (empty, issue #304, or draft, issue #315) likewise holds the task in
+    // review: it is unmergeable, so the task is not Done while it is unresolved.
     if prs
         .iter()
         .any(|pr| matches!(pr, PrReview::Open { .. } | PrReview::Parked))


### PR DESCRIPTION
Closes #315.

## Problem

GitHub refuses to squash-merge **any** draft PR, not only zero-change ones. #304 parked empty PRs but deliberately left non-empty drafts out of scope, so a non-empty draft with the auto-squash-merge policy still flowed to `merge_task_prs`, where the squash fails and gets misread as a `merge_conflict` and re-dispatched, the same loop class as #304 with a different trigger.

## Fix

The refresh already persists `is_draft` on `task_pull_requests` (from #304), so gate the merge on it: treat an open draft PR as not-yet-mergeable and hold it in review.

- **`pr_review_of`** now maps an open PR that is empty **or** draft to `review::PrReview::Parked` (ahead of the CI/review checks), so a draft is never a merge, fix, or re-dispatch candidate, just held until it is marked ready (or a human acts). `review::decide` already keeps a parked task out of Done and never merges it.
- **`review_task`** skips the GraphQL review-gate lookup for any empty-or-draft PR (it cannot merge anyway); the empty-non-draft anomaly warning is unchanged.
- **`merge_task_prs`'s** defensive branch treats a `failed to squash-merge` on a now-empty-**or**-draft PR as benign (`not mergeable yet`, leave parked), not a conflict, covering the race where a PR is re-drafted between the refresh and the merge.

A non-empty, non-draft (ready) PR is **unaffected** and flows through the normal review-gate + auto-merge path. Once a draft is marked ready for review, the next refresh sees `is_draft = false` and it merges normally.

## Tests

- The `pr_review_of` mapping test now covers a non-empty **draft** -> `Parked` (with passing CI + auto-merge requested) alongside the empty cases and the ready-PR pass-through.
- The existing `review::decide` `Parked` tests already lock the hold / never-merge / never-complete-the-task behavior (a draft is represented as `Parked`, so they apply unchanged).
- `cargo +1.88 fmt --check` clean; `clippy --all-targets --all-features` no new warnings; full suite green (179 tests).

## Scope

Backend-only orchestrator logic (and the matching `CLAUDE.md` doc); no UI, so visual self-review does not apply.