### PR TITLE
Run DB-gated integration tests in CI: confirm + document the Test step DATABASE_URL (#317)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,12 @@ jobs:
 
       - name: Test
         if: ${{ !cancelled() }}
-        # The throwaway Postgres (below) is also handed to the test step so the
-        # DB-gated regression test for orphaned `running` turns (issue #297) runs
-        # here; it self-applies the embedded migrations and skips when DATABASE_URL
-        # is unset. Pure tests ignore this env.
+        # Hand the throwaway Postgres (below) to the test step so the DB-gated
+        # integration tests run here as real regression guards, not just locally
+        # (issue #317). Each one creates and drops its OWN throwaway database via the
+        # `postgres` maintenance DB, so they never touch the shared `seraphim_test`
+        # the Migrate step uses, and they skip when DATABASE_URL is unset. Pure tests
+        # ignore this env.
         env:
           DATABASE_URL: postgres://seraphim:seraphim@localhost:5433/seraphim_test
         run: cargo test --all-features


### PR DESCRIPTION
Closes #317.

## Status: the substantive change already landed; this PR confirms and documents it

Issue #317 asks to give the api **Test** step a `DATABASE_URL` so the DB-gated integration tests actually execute in CI instead of silently skipping.

While investigating, I found the Test step **already sets** `DATABASE_URL` — it was added as part of #297's PR (#308, the "isolate the regression test to its own database" follow-up). So the DB-gated tests already run in CI on `develop`. What was left stale is the Test step's **comment**, which still named only the single #297 test even though a second DB-gated test (`blocking_task_gates_the_queue_until_its_pr_merges`, #302) now runs there too, with more to come.

This PR therefore:
- **Generalizes the comment** to state that *all* DB-gated integration tests run in the Test step as real regression guards (issue #317), not local-only checks.
- **Records the safety rationale** inline: each test creates and drops its **own** throwaway database via the `postgres` maintenance DB, so none touches the shared `seraphim_test` the Migrate step uses; they skip cleanly when `DATABASE_URL` is unset (local runs without a DB), and pure tests ignore the env.

No behavior change (the env was already present); this is a documentation-accuracy fix that closes the loop on #317.

## Verification

- Ran both DB-gated tests with `DATABASE_URL` set (as CI does), against an ephemeral Postgres: both **run (not skip) and pass** (`orphaned_running_turns_never_race_the_clock`, `blocking_task_gates_the_queue_until_its_pr_merges`), each via its own throwaway database.
- `actionlint .github/workflows/ci.yml` clean; YAML parses.

## Scope

CI-workflow comment only. No Rust/UI changed, so no app build/test or visual review applies.