### PR TITLE
Add a Suggestions tab to manage recommendations in bulk (#324)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,13 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   Follow-ups get a light de-dup: a normalized-title check (`suggestions::already_queued`,
   unit-tested) drops any whose title matches a task still on the board, so the agent
   never re-recommends queued work. Both standing instructions live in the shared
-  prompt header (`ENVIRONMENT_SUGGESTIONS`, `FOLLOW_UP_SUGGESTIONS`).
+  prompt header (`ENVIRONMENT_SUGGESTIONS`, `FOLLOW_UP_SUGGESTIONS`). Beyond the
+  per-task checkboxes, a top-nav **Suggestions** tab (`/suggestions`, issue #324)
+  aggregates every recommendation across all tasks for bulk triage:
+  `GET /suggestions` (`queries::list_all_suggestions`) returns each suggestion plus
+  its task's title/source/repo link (`AggregatedSuggestion`), and the page reuses
+  the same ack and create-issue actions, with open items on top and acknowledged
+  ones in a greyed, hover-revealed bottom section.
 - **`questions`** — decisions the agent escalated to the user, stored on the task
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -717,6 +717,28 @@ pub struct EnvSuggestion {
     pub acknowledged_at: Option<DateTime<Utc>>,
 }
 
+/// One suggestion plus the context of the task it came from, for the aggregated
+/// "Suggestions" management view (issue #324). Superset of [`EnvSuggestion`]: the
+/// extra fields let the list link back to the originating task and drive the same
+/// one-click create-issue button without a per-task fetch.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct AggregatedSuggestion {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub title: String,
+    pub detail: String,
+    pub kind: String,
+    pub acknowledged: bool,
+    pub created_at: DateTime<Utc>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+    /// The originating task's title, so the row names where the suggestion came from.
+    pub task_title: String,
+    /// The originating task's source, so the create-issue button defaults correctly.
+    pub task_source: SourceKind,
+    /// Whether that task has a linked repo (a GitHub issue needs one).
+    pub task_repo_linked: bool,
+}
+
 /// A recorded "heart attack": a turn that died mid-flight (the agent hung with no
 /// output, its stream broke, or the turn aborted internally). The defibrillator
 /// records one so the operator is alerted and the diagnostic detail survives for

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -12,12 +12,12 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::{
-    AnomalousEmptyPr, AnswerKind, AutomationRule, AvailabilityWindow, ClaudeUsageCredentials,
-    DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment,
-    JiraBoard, JiraDeployment, NetworkAccessLevel, PendingPlacement, PendingQuestion, Question,
-    QuestionOption, QuestionStatus, Railway, RepoDeletionImpact, RepoSyncError, Repository,
-    ReviewPolicy, Settings, SourceKind, StatsAggregate, Task, TaskAttachment, TaskColumn,
-    TaskPullRequest, TaskScreenshot, TaskStatus, Turn,
+    AggregatedSuggestion, AnomalousEmptyPr, AnswerKind, AutomationRule, AvailabilityWindow,
+    ClaudeUsageCredentials, DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack,
+    InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingPlacement,
+    PendingQuestion, Question, QuestionOption, QuestionStatus, Railway, RepoDeletionImpact,
+    RepoSyncError, Repository, ReviewPolicy, Settings, SourceKind, StatsAggregate, Task,
+    TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot, TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -2916,6 +2916,23 @@ pub async fn list_suggestions_for_task(
         "SELECT * FROM environment_suggestions WHERE task_id = $1 ORDER BY created_at",
     )
     .bind(task_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// Every suggestion across all tasks, joined to its task for context, for the
+/// aggregated "Suggestions" management view (issue #324). Newest first; the page
+/// splits open vs done and greys out the done section. A suggestion whose task was
+/// deleted is dropped (the inner join), matching the per-task view.
+pub async fn list_all_suggestions(pool: &PgPool) -> sqlx::Result<Vec<AggregatedSuggestion>> {
+    sqlx::query_as::<_, AggregatedSuggestion>(
+        "SELECT s.id, s.task_id, s.title, s.detail, s.kind, s.acknowledged, \
+                s.created_at, s.acknowledged_at, \
+                t.title AS task_title, t.source_kind AS task_source, \
+                (t.repo_id IS NOT NULL) AS task_repo_linked \
+         FROM environment_suggestions s JOIN tasks t ON t.id = s.task_id \
+         ORDER BY s.created_at DESC",
+    )
     .fetch_all(pool)
     .await
 }

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -106,6 +106,7 @@ pub fn router(state: AppState) -> Router {
         .route("/compose/bulk-create", post(compose::bulk_create))
         .route("/compose/stats", get(stats::compose))
         .route("/compose/stream", get(sse::compose_stream))
+        .route("/suggestions", get(suggestions::list_all))
         .route("/agent/suggestions", post(suggestions::create))
         .route("/suggestions/:id/ack", post(suggestions::acknowledge))
         .route("/suggestions/:id/create", post(suggestions::create_issue))

--- a/api/src/http/suggestions.rs
+++ b/api/src/http/suggestions.rs
@@ -16,13 +16,23 @@ use serde_json::json;
 use uuid::Uuid;
 
 use super::ApiResult;
-use crate::db::models::{EnvSuggestion, EnvSuggestionWrite, Task, TaskColumn};
+use crate::db::models::{
+    AggregatedSuggestion, EnvSuggestion, EnvSuggestionWrite, Task, TaskColumn,
+};
 use crate::db::queries;
 use crate::git;
 use crate::state::AppState;
 
 /// The most suggestions a single post may record, to bound a runaway agent.
 const MAX_SUGGESTIONS: usize = 10;
+
+/// `GET /api/v1/suggestions` - every recommendation across all tasks, each with its
+/// originating task's title / source / repo link, for the aggregated "Suggestions"
+/// management view (issue #324). The same per-task ack and create-issue endpoints
+/// act on individual rows.
+pub async fn list_all(State(state): State<AppState>) -> ApiResult<Json<Vec<AggregatedSuggestion>>> {
+    Ok(Json(queries::list_all_suggestions(&state.db).await?))
+}
 
 #[derive(Debug, Deserialize)]
 pub struct SuggestRequest {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@
 import ky from 'ky'
 
 import type {
+  AggregatedSuggestion,
   AnswerKind,
   AutomationRule,
   AutomationTrigger,
@@ -257,6 +258,12 @@ export function hardResetTask(taskId: string) {
 }
 
 // --- Environment suggestions -------------------------------------------------
+
+// Every recommendation across all tasks, for the aggregated Suggestions tab
+// (issue #324). Each carries its originating task's title / source / repo link.
+export function listAllSuggestions() {
+  return apiClient.get('suggestions').json<AggregatedSuggestion[]>()
+}
 
 export function acknowledgeSuggestion(suggestionId: string, acknowledged: boolean) {
   return apiClient

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -411,6 +411,15 @@ export type EnvSuggestion = {
   acknowledged_at: string | null
 }
 
+// A suggestion plus its originating task's context, for the aggregated
+// "Suggestions" management view (issue #324). A superset of EnvSuggestion, so it
+// can be passed straight to the shared create-issue button.
+export type AggregatedSuggestion = EnvSuggestion & {
+  task_title: string
+  task_source: SourceKind
+  task_repo_linked: boolean
+}
+
 // A decision the agent escalated to the user.
 export type QuestionStatus = 'pending' | 'answered' | 'declined'
 export type AnswerKind = 'option' | 'custom' | 'declined'

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 
   const links = [
     { href: '/', label: 'Board' },
+    { href: '/suggestions', label: 'Suggestions' },
     { href: '/watch', label: 'Watch' },
     { href: '/compose', label: 'Compose' },
     { href: '/automation', label: 'Automation' },

--- a/frontend/src/routes/suggestions/+page.svelte
+++ b/frontend/src/routes/suggestions/+page.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  // The Suggestions hub (issue #324): every recommendation the agent has made,
+  // across every task, in one aggregated list so the operator manages them in bulk
+  // instead of jumping ticket to ticket. Each row keeps the same one-click controls
+  // as the task view: check it off as done, or turn it into a tracked issue. Done
+  // items drop to a greyed-out bottom section (revealed on hover) and all are shown.
+  import type { AggregatedSuggestion } from '$lib/types'
+
+  import { onMount, onDestroy } from 'svelte'
+
+  import { acknowledgeSuggestion, listAllSuggestions } from '$lib/api'
+  import { Switch } from '$lib/components/ui/switch'
+  import SuggestionCreateButton from '$lib/components/SuggestionCreateButton.svelte'
+
+  let suggestions = $state<AggregatedSuggestion[]>([])
+  let loading = $state(true)
+  let eventSource: EventSource | null = null
+
+  // Open recommendations first (newest first), the done ones in their own section
+  // (most recently done first). Acting on a row flips `acknowledged`, which moves it
+  // between the two derived lists automatically.
+  const open = $derived(
+    suggestions
+      .filter((suggestion) => !suggestion.acknowledged)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at))
+  )
+  const done = $derived(
+    suggestions
+      .filter((suggestion) => suggestion.acknowledged)
+      .sort((a, b) =>
+        (b.acknowledged_at ?? b.created_at).localeCompare(a.acknowledged_at ?? a.created_at)
+      )
+  )
+
+  async function load() {
+    try {
+      suggestions = await listAllSuggestions()
+    } catch (error) {
+      console.debug('failed to load suggestions', error)
+    } finally {
+      loading = false
+    }
+  }
+
+  async function toggle(suggestion: AggregatedSuggestion) {
+    // Optimistically flip so the switch feels instant, then persist; revert on
+    // failure so the UI never lies about what was actually saved (mirrors the task
+    // view). Toggling `acknowledged` re-sorts the row into the right section.
+    const next = !suggestion.acknowledged
+    suggestion.acknowledged = next
+    suggestion.acknowledged_at = next ? new Date().toISOString() : null
+    try {
+      await acknowledgeSuggestion(suggestion.id, next)
+    } catch (error) {
+      console.debug('failed to update suggestion, reverting', error)
+      suggestion.acknowledged = !next
+      suggestion.acknowledged_at = !next ? new Date().toISOString() : null
+    }
+  }
+
+  // The create-issue button marks the suggestion done on the server; reflect that
+  // locally so the row drops to the done section without waiting for a refetch.
+  function onCreated(updated: { id: string; acknowledged_at: string | null }) {
+    const match = suggestions.find((suggestion) => suggestion.id === updated.id)
+    if (match) {
+      match.acknowledged = true
+      match.acknowledged_at = updated.acknowledged_at
+    }
+  }
+
+  onMount(() => {
+    load()
+    // Every suggestion action calls notify_board on the server, and the agent posts
+    // new ones as it works, so refetch on each board tick to stay current.
+    eventSource = new EventSource('/api/v1/board/stream')
+    eventSource.addEventListener('board', () => load())
+  })
+
+  onDestroy(() => eventSource?.close())
+</script>
+
+{#snippet row(suggestion: AggregatedSuggestion)}
+  <li
+    class="flex items-start justify-between gap-3 py-2 {suggestion.acknowledged
+      ? 'opacity-60 transition-opacity hover:opacity-100'
+      : ''}"
+  >
+    <button
+      type="button"
+      role="switch"
+      aria-checked={suggestion.acknowledged}
+      onclick={() => toggle(suggestion)}
+      class="flex min-w-0 flex-1 cursor-pointer items-start gap-2 text-left"
+    >
+      <Switch
+        checked={suggestion.acknowledged}
+        tabindex={-1}
+        aria-hidden="true"
+        class="mt-0.5 pointer-events-none"
+      />
+      <span class="flex min-w-0 flex-col gap-0.5">
+        <span class="flex flex-wrap items-center gap-2">
+          <span
+            class="text-sm font-medium {suggestion.acknowledged
+              ? 'text-muted-foreground line-through'
+              : ''}"
+          >
+            {suggestion.title}
+          </span>
+          <span class="rounded border border-border px-1.5 py-0 text-[10px] text-muted-foreground">
+            {suggestion.kind === 'follow_up' ? '🧹 Follow-up' : '💡 Environment'}
+          </span>
+        </span>
+        {#if suggestion.detail}
+          <span class="whitespace-pre-wrap text-xs text-muted-foreground">{suggestion.detail}</span>
+        {/if}
+      </span>
+    </button>
+    <div class="flex flex-none flex-col items-end gap-1.5">
+      <a
+        href={`/task/${suggestion.task_id}`}
+        title={suggestion.task_title}
+        class="max-w-[10rem] truncate text-xs text-muted-foreground underline hover:text-foreground"
+      >
+        {suggestion.task_title}
+      </a>
+      {#if !suggestion.acknowledged}
+        <SuggestionCreateButton
+          {suggestion}
+          source={suggestion.task_source}
+          repoLinked={suggestion.task_repo_linked}
+          oncreated={onCreated}
+        />
+      {/if}
+    </div>
+  </li>
+{/snippet}
+
+<div class="mx-auto flex max-w-3xl flex-col gap-4 p-6">
+  <header>
+    <h1 class="text-xl font-bold tracking-tight">Suggestions</h1>
+    <p class="mt-0.5 text-sm text-muted-foreground">
+      Every recommendation the agent has made across all tasks. Check one off once you have handled
+      it, or one-click it into a tracked issue.
+    </p>
+  </header>
+
+  {#if loading}
+    <p class="text-sm text-muted-foreground">Loading…</p>
+  {:else if suggestions.length === 0}
+    <p class="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+      No suggestions yet. The agent records environment tips and follow-up work as it runs.
+    </p>
+  {:else}
+    <section class="rounded-lg border border-warning/50 bg-card p-3">
+      <h2 class="text-sm font-semibold">Open ({open.length})</h2>
+      {#if open.length === 0}
+        <p class="mt-1 text-xs text-muted-foreground">Nothing open. Everything has been handled.</p>
+      {:else}
+        <ul class="mt-2 divide-y divide-border">
+          {#each open as suggestion (suggestion.id)}
+            {@render row(suggestion)}
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    {#if done.length}
+      <section class="rounded-lg border border-border bg-card p-3">
+        <h2 class="text-sm font-semibold text-muted-foreground">Done ({done.length})</h2>
+        <ul class="mt-2 divide-y divide-border">
+          {#each done as suggestion (suggestion.id)}
+            {@render row(suggestion)}
+          {/each}
+        </ul>
+      </section>
+    {/if}
+  {/if}
+</div>


### PR DESCRIPTION
Closes #324.

## Problem

With 20+ suggestions spread across 100+ tasks, acting on them means jumping ticket to ticket. The operator wants one aggregated place to see and manage them all, keeping the same one-click "create issue" and "mark done" controls, with done items moved to a greyed-out bottom section.

## What changed

A new top-nav **Suggestions** tab (`/suggestions`) that aggregates every recommendation (environment tips + follow-up work) across all tasks.

**Backend:**
- `AggregatedSuggestion` model + `queries::list_all_suggestions`: each suggestion joined to its task for context (task title, source, whether a repo is linked), newest first.
- `GET /api/v1/suggestions` (`suggestions::list_all`) returns them. The existing per-row endpoints, `POST /suggestions/:id/ack` (mark done) and `POST /suggestions/:id/create` (one-click into a tracked issue), act on individual rows unchanged.

**Frontend:**
- New `/suggestions` route page: **open** recommendations on top, each with the done toggle and the shared `SuggestionCreateButton` (Seraphim/GitHub/Jira split button); **done** items drop to a greyed-out bottom section that reveals on hover (`opacity-60 hover:opacity-100`) and shows all of them, with strike-through titles. Each row links back to its originating task and shows a kind badge (💡 Environment / 🧹 Follow-up). Optimistic toggle mirrors the task view; the page refetches on board SSE ticks (every suggestion action + new agent suggestion fires `notify_board`).
- `AggregatedSuggestion` type + `listAllSuggestions()` in the api client; the nav tab in `+layout.svelte`.

## Visual self-review

Ran the page through the Playwright MCP (headless) with seeded data, at 1280px and 1280→375px, using computed-style checks:
- Open (3) / Done (2) sections render with correct counts; done rows are greyed (`opacity: 0.6`) with strike-through titles; create buttons appear only on open rows; the nav "Suggestions" tab is active; no horizontal overflow at desktop.
- At 375px the page content fits within the viewport (the only horizontal scroll is the **pre-existing** non-wrapping navbar, which is app-wide and unchanged by this page — bubbled up as a follow-up).

Desktop and mobile screenshots were captured and reviewed.

## Verification

- `cargo +1.88 fmt --check` clean; `clippy --all-targets --all-features` no new warnings (49/50 baseline); backend suite green (180).
- `yarn check` (svelte-check) 0 errors; `yarn build` clean.
- Updated `CLAUDE.md` (the `environment_suggestions` data-model entry).