### PR TITLE
Make the top navbar responsive so it doesn't overflow on mobile (#326)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -108,8 +108,18 @@
   </main>
 {:else}
 <div class="flex h-screen flex-col">
-  <header class="flex items-center gap-4 border-b border-border bg-card px-6 py-3">
-    <a href="/" class="flex items-center gap-2 text-lg font-bold tracking-tight text-foreground">
+  <!-- The header wraps on narrow screens (issue #326) so the eight nav tabs never
+       force a page-wide horizontal scrollbar: on mobile the logo + actions sit on
+       row 1, the tab strip scrolls horizontally on row 2, and the search takes row
+       3. From `sm` up it is the original single row (the `sm:` overrides restore
+       the desktop order, widths, and padding). -->
+  <header
+    class="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-card px-4 py-3 sm:flex-nowrap sm:px-6"
+  >
+    <a
+      href="/"
+      class="flex shrink-0 items-center gap-2 text-lg font-bold tracking-tight text-foreground"
+    >
       <img
         src="/favicon.png"
         alt=""
@@ -118,11 +128,15 @@
       />
       Seraphim
     </a>
-    <nav class="flex gap-1">
+    <!-- The tab strip scrolls horizontally rather than squishing or forcing the
+         page wider: `min-w-0` lets it shrink within the row, `overflow-x-auto`
+         scrolls the `shrink-0` tabs. On mobile it is its own full-width row. -->
+    <nav class="order-2 flex w-full min-w-0 gap-1 overflow-x-auto sm:order-none sm:w-auto">
       {#each links as link}
         <a
           href={link.href}
-          class="rounded-md px-3 py-1.5 text-sm transition-colors {$page.url.pathname === link.href
+          class="shrink-0 rounded-md px-3 py-1.5 text-sm transition-colors {$page.url.pathname ===
+          link.href
             ? 'bg-secondary text-foreground'
             : 'text-muted-foreground hover:bg-secondary hover:text-foreground'}"
         >
@@ -131,12 +145,15 @@
       {/each}
     </nav>
 
-    <!-- Middle: fuzzy issue search over the live board. -->
-    <div class="flex flex-1 justify-center px-2">
+    <!-- Middle: fuzzy issue search over the live board. Its own full-width row on
+         mobile; the centered, growing middle column on desktop. -->
+    <div class="order-3 flex w-full min-w-0 justify-center sm:order-none sm:flex-1 sm:px-2">
       <SearchBar tasks={board?.tasks ?? []} />
     </div>
 
-    <div class="flex flex-none items-center gap-3">
+    <!-- Actions sit on the first row beside the logo on mobile (`order-1` +
+         `ml-auto`), and at the end of the single row on desktop. -->
+    <div class="order-1 ml-auto flex flex-none items-center gap-3 sm:order-none sm:ml-0">
       {#if status}
         <span
           class="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold {PILLS[


### PR DESCRIPTION
Closes #326.

## Problem

The header in `frontend/src/routes/+layout.svelte` laid the logo, eight nav tabs, search, and action cluster out in a single **non-wrapping** flex row. At 375px the tab strip alone is ~742px, so every page had a horizontal scrollbar on mobile (the page content itself fit).

## Fix

Make the header wrap below `sm` and turn the tab strip into a horizontally-scrollable strip. Pure Tailwind class changes to the one layout file; no logic touched.

- **header**: `flex-wrap` with `sm:flex-nowrap`, so it is the original single row from `sm` up and stacks into rows on phones. `px-4` on mobile, `sm:px-6` (the original) above.
- **nav**: `w-full overflow-x-auto min-w-0` with `shrink-0` tabs, so the tabs **scroll horizontally** instead of squishing or forcing the page wider. `min-w-0` also lets the strip shrink-and-scroll inside the desktop row, so it can never push the page wider at any width. It is its own full-width row on mobile (`sm:w-auto` on desktop).
- **order**: on mobile the actions cluster (status pill, Create issue, Notifications) sits on row 1 beside the logo (`order-1` + `ml-auto`), the nav is row 2, and the search is its own full-width row 3. `sm:order-none` restores the exact desktop order.

The fullscreen Watch layout (the `{#if fullscreen}` branch) is untouched.

## Visual self-review (Playwright MCP, headless)

- **375px (mobile):** the page no longer scrolls horizontally (`docScrollWidth == 375 == viewport`); the header is three tidy rows (logo + actions, then the tab strip, then the search); the tab strip scrolls (742px of tabs in a 343px box).
- **1280px (desktop):** unchanged single row (`flex-nowrap`, original logo → nav → search → actions order, `px-6` padding, nav at full width with no scroll, no overflow). Confirmed pixel-identical to the original via screenshot.

## Verification

- `yarn check` (svelte-check) 0 errors; `yarn build` clean.

## Scope

Frontend-only, single file (`+layout.svelte`); affects the chrome on all routes. No backend/API change.