### PR TITLE
Multi-select bulk editing on the repositories page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,14 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   the most recent sync succeeded; set when listing the repo's issues fails, cleared
   on the next clean sync). There is **no** separate issue-source entity; a repo
   with `sync_issues` is its own source. Bulk onboarding is the one-shot **Import
-  from org** action (`POST /repos/import-org`).
+  from org** action (`POST /repos/import-org`). The repositories page also has a
+  **multi-select bulk edit** (issue #331), modeled on the board's: a "Bulk edit"
+  toggle turns each row into a checkbox target (with a select-all header), and a
+  floating action bar bulk-edits fields (`enabled` / `sync_issues`, three-way
+  keep/on/off, `POST /repos/bulk/fields`) or deletes the selection
+  (`POST /repos/bulk/delete`, with an aggregate blast-radius preview from
+  `POST /repos/bulk/deletion-impact`). All three mirror the board's
+  `/tasks/bulk/*` handlers and notify the board once per action.
 - **`tasks`** — the cards: `source_kind`, `external_id`, `repo_id`, `title`,
   `board_column`, `position` (fractional rank), `status`, `branch`, `pr_url`,
   `error`, `hold` (agent skips this card), `blocking` (serialize the queue while

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -432,6 +432,18 @@ pub struct RepoDeletionImpact {
     pub suggestions: i64,
 }
 
+/// What deleting a selection of repositories will purge, aggregated across the
+/// set so the bulk-delete confirmation can spell out the full blast radius.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct ReposDeletionImpact {
+    pub repos: i64,
+    pub tasks: i64,
+    pub turns: i64,
+    pub events: i64,
+    pub questions: i64,
+    pub suggestions: i64,
+}
+
 /// Aggregated agent usage (for a task or globally) over turns since the reset
 /// marker. Cost and tokens sum the turns; `worked_ms` sums their elapsed time.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -16,8 +16,9 @@ use super::models::{
     ClaudeUsageCredentials, DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack,
     InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingPlacement,
     PendingQuestion, Question, QuestionOption, QuestionStatus, Railway, RepoDeletionImpact,
-    RepoSyncError, Repository, ReviewPolicy, Settings, SourceKind, StatsAggregate, Task,
-    TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot, TaskStatus, Turn,
+    RepoSyncError, ReposDeletionImpact, Repository, ReviewPolicy, Settings, SourceKind,
+    StatsAggregate, Task, TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot, TaskStatus,
+    Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -1033,6 +1034,88 @@ pub async fn delete_repository(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
         .await?;
     tx.commit().await?;
     Ok(())
+}
+
+// --- Bulk repository edit ----------------------------------------------------
+//
+// Back the repositories page's multi-select bulk actions (issue #331), mirroring
+// the board's bulk edit: each takes a set of repo ids and applies one change in a
+// single round-trip so a large selection ticks the UI once rather than per row.
+
+/// Aggregates everything deleting a set of repos would purge, so the bulk-delete
+/// confirmation can spell out the full blast radius across the selection.
+///
+/// Counts the repos themselves plus their tasks and the turns/events/questions/
+/// suggestions that cascade from them, the same subtree [`repo_deletion_impact`]
+/// reports for a single repo.
+pub async fn repos_deletion_impact(
+    pool: &PgPool,
+    ids: &[Uuid],
+) -> sqlx::Result<ReposDeletionImpact> {
+    sqlx::query_as::<_, ReposDeletionImpact>(
+        "SELECT \
+           (SELECT COUNT(*) FROM repositories WHERE id = ANY($1)) AS repos, \
+           (SELECT COUNT(*) FROM tasks WHERE repo_id = ANY($1)) AS tasks, \
+           (SELECT COUNT(*) FROM turns t \
+              JOIN tasks k ON t.task_id = k.id WHERE k.repo_id = ANY($1)) AS turns, \
+           (SELECT COUNT(*) FROM events e \
+              JOIN turns t ON e.turn_id = t.id \
+              JOIN tasks k ON t.task_id = k.id WHERE k.repo_id = ANY($1)) AS events, \
+           (SELECT COUNT(*) FROM questions q \
+              JOIN tasks k ON q.task_id = k.id WHERE k.repo_id = ANY($1)) AS questions, \
+           (SELECT COUNT(*) FROM environment_suggestions s \
+              JOIN tasks k ON s.task_id = k.id WHERE k.repo_id = ANY($1)) AS suggestions",
+    )
+    .bind(ids)
+    .fetch_one(pool)
+    .await
+}
+
+/// Sets `enabled` and/or `sync_issues` across a set of repositories. A `None`
+/// field is left as is (`COALESCE` keeps the existing value), so the caller
+/// changes only the fields the operator picked. Returns how many rows changed.
+pub async fn bulk_set_repo_fields(
+    pool: &PgPool,
+    ids: &[Uuid],
+    enabled: Option<bool>,
+    sync_issues: Option<bool>,
+) -> sqlx::Result<u64> {
+    let result = sqlx::query(
+        "UPDATE repositories SET enabled = COALESCE($2, enabled), \
+         sync_issues = COALESCE($3, sync_issues), updated_at = now() WHERE id = ANY($1)",
+    )
+    .bind(ids)
+    .bind(enabled)
+    .bind(sync_issues)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Deletes a set of repositories and everything synced from them, applying
+/// [`delete_repository`]'s cascade across the whole selection in one transaction.
+///
+/// The `tasks.repo_id` FK cascades each repo's tasks (and their turns/events/
+/// questions/suggestions); the Jira board associations are a JSON array with no
+/// FK, so each id is stripped from `jira_boards.repo_ids` first to avoid a
+/// dangling reference on the next sync. Returns how many repositories were removed.
+pub async fn delete_repositories(pool: &PgPool, ids: &[Uuid]) -> sqlx::Result<u64> {
+    let mut tx = pool.begin().await?;
+    for id in ids {
+        sqlx::query(
+            "UPDATE jira_boards SET repo_ids = repo_ids - $1, updated_at = now() \
+             WHERE jsonb_exists(repo_ids, $1)",
+        )
+        .bind(id.to_string())
+        .execute(&mut *tx)
+        .await?;
+    }
+    let result = sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+        .bind(ids)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(result.rows_affected())
 }
 
 // --- Tasks -------------------------------------------------------------------

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -141,6 +141,15 @@ pub fn router(state: AppState) -> Router {
             axum::routing::put(repos::update).delete(repos::delete),
         )
         .route("/repos/:id/deletion-impact", get(repos::deletion_impact))
+        // Bulk multi-select actions on the repositories page (issue #331). Static
+        // `bulk` beats the `:id` param at the same position, mirroring the board's
+        // `/tasks/bulk/*` alongside `/tasks/:id/*`.
+        .route("/repos/bulk/fields", post(repos::bulk_fields))
+        .route("/repos/bulk/delete", post(repos::bulk_delete))
+        .route(
+            "/repos/bulk/deletion-impact",
+            post(repos::bulk_deletion_impact),
+        )
         .route("/repos/import-org", post(repos::import_org))
         .route("/sync", post(repos::sync))
         // Railways: the parallel agent lanes (CRUD, repo assignment, per-railway

--- a/api/src/http/repos.rs
+++ b/api/src/http/repos.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use uuid::Uuid;
 
 use super::ApiResult;
-use crate::db::models::{RepoDeletionImpact, Repository, ReviewPolicy};
+use crate::db::models::{RepoDeletionImpact, ReposDeletionImpact, Repository, ReviewPolicy};
 use crate::db::queries;
 use crate::git;
 use crate::orchestrator::provision::repo_dir_name;
@@ -198,6 +198,60 @@ pub async fn delete(
     queries::delete_repository(&state.db, id).await?;
     state.notify_board();
     Ok(Json(json!({ "deleted": true })))
+}
+
+// --- Bulk edit (repositories multi-select, issue #331) -----------------------
+//
+// Back the repositories page's multi-select bar, mirroring the board's bulk edit.
+// Each takes a set of repo ids and notifies the board once at the end.
+
+#[derive(Debug, Deserialize)]
+pub struct BulkRepoIdsRequest {
+    pub ids: Vec<Uuid>,
+}
+
+/// `POST /api/v1/repos/bulk/deletion-impact` - aggregate what deleting a set of
+/// repos would purge, so the UI can spell it out before the user confirms.
+pub async fn bulk_deletion_impact(
+    State(state): State<AppState>,
+    Json(body): Json<BulkRepoIdsRequest>,
+) -> ApiResult<Json<ReposDeletionImpact>> {
+    Ok(Json(
+        queries::repos_deletion_impact(&state.db, &body.ids).await?,
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BulkRepoFieldsRequest {
+    pub ids: Vec<Uuid>,
+    /// Each is `None` ("keep as is") or `Some(value)` to set across the selection.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub sync_issues: Option<bool>,
+}
+
+/// `POST /api/v1/repos/bulk/fields` - set `enabled` and/or `sync_issues` across a
+/// selection of repos. Omitted fields are left untouched.
+pub async fn bulk_fields(
+    State(state): State<AppState>,
+    Json(body): Json<BulkRepoFieldsRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let updated =
+        queries::bulk_set_repo_fields(&state.db, &body.ids, body.enabled, body.sync_issues).await?;
+    state.notify_board();
+    Ok(Json(json!({ "updated": updated })))
+}
+
+/// `POST /api/v1/repos/bulk/delete` - delete a selection of repos and everything
+/// synced from them.
+pub async fn bulk_delete(
+    State(state): State<AppState>,
+    Json(body): Json<BulkRepoIdsRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let deleted = queries::delete_repositories(&state.db, &body.ids).await?;
+    state.notify_board();
+    Ok(Json(json!({ "deleted": deleted })))
 }
 
 #[derive(Debug, Deserialize)]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,6 +27,7 @@ import type {
   Question,
   Railway,
   RepoDeletionImpact,
+  ReposDeletionImpact,
   Repository,
   ResetSummary,
   ReviewPolicy,
@@ -342,6 +343,28 @@ export function repoDeletionImpact(repoId: string) {
 
 export function deleteRepo(repoId: string) {
   return apiClient.delete(`repos/${repoId}`).json()
+}
+
+// --- Bulk edit (repositories multi-select, issue #331) -----------------------
+
+// Set `enabled` and/or `sync_issues` across a selection of repos. Omitted fields
+// are left untouched.
+export function bulkSetRepoFields(
+  ids: string[],
+  fields: { enabled?: boolean; sync_issues?: boolean }
+) {
+  return apiClient.post('repos/bulk/fields', { json: { ids, ...fields } }).json<{ updated: number }>()
+}
+
+// Delete a selection of repos and everything synced from them.
+export function bulkDeleteRepos(ids: string[]) {
+  return apiClient.post('repos/bulk/delete', { json: { ids } }).json<{ deleted: number }>()
+}
+
+// Aggregate what deleting a selection would purge, so the bulk confirmation can
+// spell out the full blast radius first.
+export function bulkRepoDeletionImpact(ids: string[]) {
+  return apiClient.post('repos/bulk/deletion-impact', { json: { ids } }).json<ReposDeletionImpact>()
 }
 
 export function importOrg(owner: string, issueLabels: string[] = []) {

--- a/frontend/src/lib/components/RepoBulkActionBar.svelte
+++ b/frontend/src/lib/components/RepoBulkActionBar.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+  import type { ReposDeletionImpact } from '$lib/types'
+
+  import { SlidersHorizontal, Trash2, X } from '@lucide/svelte'
+
+  import { Badge } from './ui/badge'
+  import { Button } from './ui/button'
+  import * as AlertDialog from './ui/alert-dialog'
+
+  // A floating bottom bar (Jira-style) for the repositories page's multi-select
+  // mode, modeled on the board's BulkActionBar (issue #331). It owns its own
+  // modals and reports whether any is open via `dialogOpen`, so the page can let
+  // Escape close a modal first rather than exiting bulk mode.
+  let {
+    count,
+    onClear,
+    onEditFields,
+    onDelete,
+    fetchImpact,
+    dialogOpen = $bindable(false)
+  }: {
+    count: number
+    onClear: () => void
+    onEditFields: (fields: { enabled?: boolean; sync_issues?: boolean }) => Promise<void>
+    onDelete: () => Promise<void>
+    // Loads the aggregate deletion impact for the current selection, called when
+    // the delete confirmation opens so it can spell out the blast radius.
+    fetchImpact: () => Promise<ReposDeletionImpact>
+    dialogOpen?: boolean
+  } = $props()
+
+  // A three-way per-field choice in the Edit fields modal.
+  type FieldChoice = 'keep' | 'true' | 'false'
+
+  let editOpen = $state(false)
+  let deleteOpen = $state(false)
+  let busy = $state(false)
+
+  let enabledChoice = $state<FieldChoice>('keep')
+  let syncChoice = $state<FieldChoice>('keep')
+
+  // The counts a delete would purge, loaded lazily when the modal opens (null
+  // while loading), mirroring the single-repo delete confirmation.
+  let impact = $state<ReposDeletionImpact | null>(null)
+
+  // Let the page suppress its Escape-to-exit while one of our overlays is open.
+  $effect(() => {
+    dialogOpen = editOpen || deleteOpen
+  })
+
+  const noneSelected = $derived(count === 0)
+
+  function openEdit() {
+    enabledChoice = 'keep'
+    syncChoice = 'keep'
+    editOpen = true
+  }
+
+  function openDelete() {
+    impact = null
+    deleteOpen = true
+    fetchImpact()
+      .then((loaded) => {
+        // Ignore a late response if the dialog has since closed.
+        if (deleteOpen) {
+          impact = loaded
+        }
+      })
+      .catch((error) => console.debug('failed to load bulk deletion impact', error))
+  }
+
+  function choiceToBool(choice: FieldChoice): boolean | undefined {
+    if (choice === 'keep') {
+      return undefined
+    }
+    return choice === 'true'
+  }
+
+  async function saveEdit() {
+    const fields: { enabled?: boolean; sync_issues?: boolean } = {}
+    const enabled = choiceToBool(enabledChoice)
+    const syncIssues = choiceToBool(syncChoice)
+    if (enabled !== undefined) {
+      fields.enabled = enabled
+    }
+    if (syncIssues !== undefined) {
+      fields.sync_issues = syncIssues
+    }
+    // Nothing chosen: just close, don't hit the API for a no-op.
+    if (fields.enabled === undefined && fields.sync_issues === undefined) {
+      editOpen = false
+      return
+    }
+    busy = true
+    try {
+      await onEditFields(fields)
+      editOpen = false
+    }
+    finally {
+      busy = false
+    }
+  }
+
+  async function confirmDelete() {
+    busy = true
+    try {
+      await onDelete()
+      deleteOpen = false
+    }
+    finally {
+      busy = false
+    }
+  }
+</script>
+
+<div
+  class="fixed bottom-6 left-1/2 z-50 flex max-w-[calc(100vw-1rem)] -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl"
+  role="toolbar"
+  aria-label="Bulk repository actions"
+>
+  <!-- Far left: count badge + the word "selected" (label drops on narrow screens
+       so the compact bar stays within a 375px viewport). -->
+  <div class="flex items-center gap-2 pl-1 pr-1">
+    <Badge variant="default" class="tabular-nums">{count}</Badge>
+    <span class="hidden text-sm text-muted-foreground sm:inline">selected</span>
+  </div>
+
+  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+
+  <!-- Middle: the actions. -->
+  <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={openEdit}>
+    <SlidersHorizontal class="size-4" />
+    Edit fields
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="sm"
+    class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+    disabled={noneSelected || busy}
+    onclick={openDelete}
+  >
+    <Trash2 class="size-4" />
+    Delete
+  </Button>
+
+  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+
+  <!-- Far right: clear selection and exit. -->
+  <Button
+    variant="ghost"
+    size="icon"
+    title="Clear all"
+    aria-label="Clear all and exit multi-select"
+    onclick={onClear}
+  >
+    <X class="size-4" />
+  </Button>
+</div>
+
+<!-- Edit fields modal: one row per editable field, each a "keep as is / on / off"
+     dropdown. Native selects render outside the dialog's focus scope, so they
+     never fight the modal. -->
+<AlertDialog.Root bind:open={editOpen}>
+  <AlertDialog.Content class="sm:max-w-md">
+    <AlertDialog.Header>
+      <AlertDialog.Title>Edit fields</AlertDialog.Title>
+      <AlertDialog.Description>
+        Apply to {count} selected {count === 1 ? 'repository' : 'repositories'}. Leave a field on
+        "Keep as is" to not change it.
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+
+    <div class="grid grid-cols-2 items-center gap-x-4 gap-y-3 py-2">
+      <label for="bulk-repo-enabled" class="text-sm font-medium">Enabled</label>
+      <select
+        id="bulk-repo-enabled"
+        bind:value={enabledChoice}
+        class="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <option value="keep">Keep as is</option>
+        <option value="true">Enabled</option>
+        <option value="false">Disabled</option>
+      </select>
+
+      <label for="bulk-repo-sync" class="text-sm font-medium">Sync issues</label>
+      <select
+        id="bulk-repo-sync"
+        bind:value={syncChoice}
+        class="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <option value="keep">Keep as is</option>
+        <option value="true">On</option>
+        <option value="false">Off</option>
+      </select>
+    </div>
+
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel disabled={busy}>Cancel</AlertDialog.Cancel>
+      <Button onclick={saveEdit} disabled={busy}>{busy ? 'Saving…' : 'Save'}</Button>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>
+
+<!-- Delete confirmation, spelling out the aggregate impact across the selection. -->
+<AlertDialog.Root bind:open={deleteOpen}>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title>
+        Delete {count} {count === 1 ? 'repository' : 'repositories'}?
+      </AlertDialog.Title>
+      <AlertDialog.Description>
+        This permanently removes the selected {count === 1 ? 'repository' : 'repositories'} and
+        everything synced from them. The source issues on GitHub/Jira are not affected. This cannot
+        be undone.
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+
+    <div class="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+      {#if impact}
+        <p class="mb-1 font-medium">This will also delete:</p>
+        <ul class="list-disc space-y-0.5 pl-5 text-muted-foreground">
+          <li>
+            {impact.tasks}
+            {impact.tasks === 1 ? 'task' : 'tasks'} (issues on the board)
+          </li>
+          <li>
+            {impact.turns} agent {impact.turns === 1 ? 'turn' : 'turns'} with
+            {impact.events} activity log {impact.events === 1 ? 'event' : 'events'}
+          </li>
+          <li>
+            {impact.questions}
+            {impact.questions === 1 ? 'decision' : 'decisions'} and
+            {impact.suggestions} environment {impact.suggestions === 1 ? 'note' : 'notes'}
+          </li>
+        </ul>
+      {:else}
+        <p class="text-muted-foreground">Counting what will be removed…</p>
+      {/if}
+    </div>
+
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel disabled={busy}>Cancel</AlertDialog.Cancel>
+      <Button variant="destructive" onclick={confirmDelete} disabled={busy}>
+        {busy ? 'Deleting…' : 'Delete'}
+      </Button>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>

--- a/frontend/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/frontend/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { Checkbox as CheckboxPrimitive } from 'bits-ui'
+  import { Check, Minus } from '@lucide/svelte'
+  import { cn, type WithoutChildrenOrChild } from '$lib/utils.js'
+
+  let {
+    ref = $bindable(null),
+    checked = $bindable(false),
+    indeterminate = $bindable(false),
+    class: className,
+    ...restProps
+  }: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props()
+</script>
+
+<CheckboxPrimitive.Root
+  bind:ref
+  bind:checked
+  bind:indeterminate
+  data-slot="checkbox"
+  class={cn(
+    'peer size-4 shrink-0 rounded border border-input shadow-sm outline-none transition-shadow focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground',
+    className
+  )}
+  {...restProps}
+>
+  {#snippet children({ checked, indeterminate })}
+    <div class="flex items-center justify-center text-current">
+      {#if indeterminate}
+        <Minus class="size-3.5" />
+      {:else if checked}
+        <Check class="size-3.5" />
+      {/if}
+    </div>
+  {/snippet}
+</CheckboxPrimitive.Root>

--- a/frontend/src/lib/components/ui/checkbox/index.ts
+++ b/frontend/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,7 @@
+import Root from './checkbox.svelte'
+
+export {
+  Root,
+  //
+  Root as Checkbox
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -329,6 +329,17 @@ export type RepoDeletionImpact = {
   suggestions: number
 }
 
+// What deleting a selection of repositories will purge, aggregated across the
+// set, shown in the bulk-delete confirmation (issue #331).
+export type ReposDeletionImpact = {
+  repos: number
+  tasks: number
+  turns: number
+  events: number
+  questions: number
+  suggestions: number
+}
+
 // Live agent statistics (per task or global). Several fields are session/global
 // totals; Seraphim runs one shared Claude session, so they are not split per task.
 export type Stats = {

--- a/frontend/src/routes/repos/+page.svelte
+++ b/frontend/src/routes/repos/+page.svelte
@@ -3,15 +3,27 @@
   import type { UpsertRepoRequest } from '$lib/api'
 
   import { onMount } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
   import { toast } from 'svelte-sonner'
-  import { CircleCheck, CircleOff, GitBranch, Pencil, Plus, Trash2 } from '@lucide/svelte'
+  import { CircleCheck, CircleOff, GitBranch, ListChecks, Pencil, Plus, Trash2 } from '@lucide/svelte'
 
-  import { deleteRepo, importOrg, listRepos, repoDeletionImpact, updateRepo } from '$lib/api'
+  import {
+    bulkDeleteRepos,
+    bulkRepoDeletionImpact,
+    bulkSetRepoFields,
+    deleteRepo,
+    importOrg,
+    listRepos,
+    repoDeletionImpact,
+    updateRepo
+  } from '$lib/api'
   import * as Card from '$lib/components/ui/card'
   import * as AlertDialog from '$lib/components/ui/alert-dialog'
   import { Button, buttonVariants } from '$lib/components/ui/button'
+  import { Checkbox } from '$lib/components/ui/checkbox'
   import { Input } from '$lib/components/ui/input'
   import { Switch } from '$lib/components/ui/switch'
+  import RepoBulkActionBar from '$lib/components/RepoBulkActionBar.svelte'
 
   let repos = $state<Repository[]>([])
   let importOwner = $state('')
@@ -44,9 +56,83 @@
     repo.sync_issues = value
     try {
       await updateRepo(repo.id, repoToBody(repo))
-    } catch {
+    }
+    catch {
       repo.sync_issues = previous
       toast.error('Could not update issue sync')
+    }
+  }
+
+  // --- Multi-select (bulk edit, issue #331) ----------------------------------
+  // In bulk mode a row click selects a repo instead of doing nothing; the
+  // floating RepoBulkActionBar then edits or deletes the whole selection at once,
+  // mirroring the board's multi-select.
+  let bulkMode = $state(false)
+  let selected = new SvelteSet<string>()
+  // True while the bulk bar has a modal open, so Escape closes that first rather
+  // than exiting bulk mode out from under it.
+  let bulkDialogOpen = $state(false)
+
+  const allSelected = $derived(repos.length > 0 && repos.every((repo) => selected.has(repo.id)))
+  const someSelected = $derived(repos.some((repo) => selected.has(repo.id)))
+
+  // Clear the selection and leave bulk mode (the bar's X and the Escape key).
+  function exitBulkMode() {
+    bulkMode = false
+    selected.clear()
+  }
+
+  function toggleSelected(id: string) {
+    if (selected.has(id)) {
+      selected.delete(id)
+    }
+    else {
+      selected.add(id)
+    }
+  }
+
+  // The header checkbox selects every repo, or clears them when all are already
+  // selected (a partial selection fills in to all).
+  function toggleAll() {
+    if (allSelected) {
+      selected.clear()
+      return
+    }
+    for (const repo of repos) {
+      selected.add(repo.id)
+    }
+  }
+
+  // Enter toggles a row; Space does too, without scrolling the page.
+  function onRowKeydown(event: KeyboardEvent, id: string) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      toggleSelected(id)
+    }
+  }
+
+  async function applyBulkFields(fields: { enabled?: boolean; sync_issues?: boolean }) {
+    const ids = [...selected]
+    await bulkSetRepoFields(ids, fields)
+    await load()
+    toast.success(`Updated ${ids.length} ${ids.length === 1 ? 'repository' : 'repositories'}`)
+  }
+
+  async function applyBulkDelete() {
+    const ids = [...selected]
+    const { deleted } = await bulkDeleteRepos(ids)
+    selected.clear()
+    await load()
+    toast.success(`Deleted ${deleted} ${deleted === 1 ? 'repository' : 'repositories'}`)
+  }
+
+  function fetchBulkImpact() {
+    return bulkRepoDeletionImpact([...selected])
+  }
+
+  function onWindowKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && bulkMode && !bulkDialogOpen) {
+      exitBulkMode()
     }
   }
 
@@ -80,7 +166,8 @@
       deleteTarget = null
       deleteImpact = null
       await load()
-    } finally {
+    }
+    finally {
       deleting = false
     }
   }
@@ -99,12 +186,26 @@
   onMount(load)
 </script>
 
-<div class="mx-auto max-w-6xl space-y-5 px-6 py-6">
-  <div class="flex items-center justify-between gap-3">
+<svelte:window onkeydown={onWindowKeydown} />
+
+<div class="mx-auto max-w-6xl space-y-5 px-6 py-6 {bulkMode ? 'pb-24' : ''}">
+  <div class="flex flex-wrap items-center justify-between gap-3">
     <h1 class="text-2xl font-semibold">Repositories</h1>
-    <a href="/repos/new" class={buttonVariants({ variant: 'default' })}>
-      <Plus class="size-4" /> Add repository
-    </a>
+    <div class="flex items-center gap-2">
+      {#if repos.length > 0}
+        <Button
+          variant={bulkMode ? 'default' : 'outline'}
+          size="sm"
+          onclick={() => (bulkMode ? exitBulkMode() : (bulkMode = true))}
+        >
+          <ListChecks class="size-4" />
+          {bulkMode ? 'Done' : 'Bulk edit'}
+        </Button>
+      {/if}
+      <a href="/repos/new" class={buttonVariants({ variant: 'default' })}>
+        <Plus class="size-4" /> Add repository
+      </a>
+    </div>
   </div>
 
   <Card.Root>
@@ -126,7 +227,21 @@
 
   <Card.Root>
     <Card.Header>
-      <Card.Title>Managed repositories</Card.Title>
+      <div class="flex items-center justify-between gap-3">
+        <Card.Title>Managed repositories</Card.Title>
+        {#if bulkMode && repos.length > 0}
+          <!-- Select-all, with an indeterminate state for a partial selection. -->
+          <label class="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+            <Checkbox
+              checked={allSelected}
+              indeterminate={someSelected && !allSelected}
+              onCheckedChange={toggleAll}
+              aria-label="Select all repositories"
+            />
+            Select all
+          </label>
+        {/if}
+      </div>
     </Card.Header>
     <Card.Content class="divide-y divide-border">
       {#if repos.length === 0}
@@ -135,8 +250,31 @@
         </p>
       {/if}
       {#each repos as repo (repo.id)}
-        <div class="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
-          <!-- Enabled / disabled indicator, furthest left. -->
+        {@const isSelected = selected.has(repo.id)}
+        <!-- The row is a button (role + tabindex) exactly in bulk mode; the
+             checker can't prove the dynamic role, so this warning is spurious. -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <div
+          class="flex items-center gap-3 rounded-md py-3 first:pt-0 last:pb-0 {bulkMode
+            ? 'cursor-pointer px-2 -mx-2 transition-colors'
+            : ''} {bulkMode && isSelected ? 'bg-primary/10 ring-1 ring-inset ring-primary/40' : ''}"
+          role={bulkMode ? 'button' : undefined}
+          tabindex={bulkMode ? 0 : undefined}
+          aria-pressed={bulkMode ? isSelected : undefined}
+          onclick={bulkMode ? () => toggleSelected(repo.id) : undefined}
+          onkeydown={bulkMode ? (event) => onRowKeydown(event, repo.id) : undefined}
+        >
+          {#if bulkMode}
+            <!-- Visual selection indicator; the whole row is the toggle control. -->
+            <Checkbox
+              checked={isSelected}
+              tabindex={-1}
+              aria-hidden="true"
+              class="pointer-events-none flex-none"
+            />
+          {/if}
+
+          <!-- Enabled / disabled indicator. -->
           <span class="flex-none" title={repo.enabled ? 'Enabled' : 'Disabled'}>
             {#if repo.enabled}
               <CircleCheck class="size-4 text-success" aria-label="Enabled" />
@@ -145,17 +283,20 @@
             {/if}
           </span>
 
-          <!-- Quick issue-sync toggle. -->
-          <span
-            class="flex-none"
-            title={repo.sync_issues ? 'Syncing issues (toggle off)' : 'Not syncing issues (toggle on)'}
-          >
-            <Switch
-              checked={repo.sync_issues}
-              onCheckedChange={(value) => toggleSync(repo, value)}
-              aria-label="Sync issues"
-            />
-          </span>
+          <!-- Quick issue-sync toggle (hidden in bulk mode, where the whole row
+               is the selection target). -->
+          {#if !bulkMode}
+            <span
+              class="flex-none"
+              title={repo.sync_issues ? 'Syncing issues (toggle off)' : 'Not syncing issues (toggle on)'}
+            >
+              <Switch
+                checked={repo.sync_issues}
+                onCheckedChange={(value) => toggleSync(repo, value)}
+                aria-label="Sync issues"
+              />
+            </span>
+          {/if}
 
           <!-- Name + details. -->
           <div class="min-w-0 flex-1">
@@ -187,32 +328,45 @@
             {/if}
           </div>
 
-          <!-- Actions. -->
-          <div class="flex flex-none gap-1">
-            <a
-              href={`/repos/${repo.id}/edit`}
-              title="Edit"
-              aria-label="Edit"
-              class={buttonVariants({ variant: 'ghost', size: 'icon' })}
-            >
-              <Pencil class="size-4" />
-            </a>
-            <Button
-              variant="ghost"
-              size="icon"
-              title="Delete"
-              aria-label="Delete"
-              class="text-destructive hover:text-destructive"
-              onclick={() => askDelete(repo)}
-            >
-              <Trash2 class="size-4" />
-            </Button>
-          </div>
+          <!-- Actions (hidden in bulk mode to keep the row a single toggle). -->
+          {#if !bulkMode}
+            <div class="flex flex-none gap-1">
+              <a
+                href={`/repos/${repo.id}/edit`}
+                title="Edit"
+                aria-label="Edit"
+                class={buttonVariants({ variant: 'ghost', size: 'icon' })}
+              >
+                <Pencil class="size-4" />
+              </a>
+              <Button
+                variant="ghost"
+                size="icon"
+                title="Delete"
+                aria-label="Delete"
+                class="text-destructive hover:text-destructive"
+                onclick={() => askDelete(repo)}
+              >
+                <Trash2 class="size-4" />
+              </Button>
+            </div>
+          {/if}
         </div>
       {/each}
     </Card.Content>
   </Card.Root>
 </div>
+
+{#if bulkMode}
+  <RepoBulkActionBar
+    count={selected.size}
+    bind:dialogOpen={bulkDialogOpen}
+    onClear={exitBulkMode}
+    onEditFields={applyBulkFields}
+    onDelete={applyBulkDelete}
+    fetchImpact={fetchBulkImpact}
+  />
+{/if}
 
 <AlertDialog.Root
   open={deleteTarget !== null}


### PR DESCRIPTION
Closes #331.

## Why

Onboarding an org can add dozens of repositories at once (the issue's example: 88 repos imported, two thirds to remove). Curating them one row at a time was tedious. The repositories page now supports multi-selection and bulk management, modeled on the board's multi-select.

## What changed

**Repositories page multi-select**
- A "Bulk edit" toggle in the header. In bulk mode every row becomes a checkbox target (with a select-all header that shows an indeterminate state for a partial selection), and a floating action bar operates on the whole selection, mirroring the board's `BulkActionBar`.
- **Edit fields** modal: three-way keep/on/off for `Enabled` and `Sync issues`.
- **Delete**: a confirmation that spells out the aggregate blast radius (repos, tasks, agent turns, activity events, decisions, notes) before removing the selection.

**Backend** (parallels the existing `/tasks/bulk/*` handlers)
- `POST /repos/bulk/fields` sets `enabled` and/or `sync_issues` across a set, `COALESCE`-keeping the fields the operator left alone.
- `POST /repos/bulk/delete` deletes a selection, cascading each repo's tasks and stripping the ids from Jira board associations in one transaction.
- `POST /repos/bulk/deletion-impact` returns the aggregate impact for the confirmation.

**Shared UI**
- New `RepoBulkActionBar` component and a shadcn-style `Checkbox` primitive (wrapping bits-ui) added to `components/ui`.

## Testing

- `cargo +1.88 fmt --check`, `clippy --all-targets`, `test` (180 pass).
- `npm run check` (0 errors/warnings) and `npm run build`.
- Visual self-review with a live API (ephemeral Postgres) + dev server via the Playwright MCP: verified row selection, the select-all indeterminate state, the floating bar (centered, within viewport), the edit-fields modal, and the end-to-end bulk field-edit and delete against the API. Confirmed layout at 375px and 1280px (the header wraps and the bar stays within the mobile viewport).