### PR TITLE
Warn when a Jira ticket has no target repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -697,7 +697,11 @@ Playwright MCP, check layout via computed styles at 375px and 1280px).
   renders the Jira key + summary + description + link, and the same branch -> PR ->
   review-gate -> merge flow runs (multi-repo: a PR per target repo, all-merge-to-
   Done via `task_pull_requests`). A repo-less Jira ticket stays on the board,
-  skipped, until a repo is assigned. On PR open and on Done the agent posts a
+  skipped, until a repo is assigned; since that skip is otherwise silent, both the
+  board card and the task view flag it (issue #337): the card shows an amber "No
+  target repo" warning label and the task's Target repositories section shows a
+  warning banner. Both are pure frontend derivations of `source_kind === 'jira'`
+  with an empty `target_repo_ids`, so nothing new is stored. On PR open and on Done the agent posts a
   comment back to the Jira issue (PR link(s) + outcome) via `JiraClient::add_comment`,
   and the agent-driven move to Done transitions the ticket through the board's
   column->status map (`orchestrator::transition_jira_to_column`, shared with the

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -20,7 +20,8 @@
     CircleSlash,
     RotateCcw,
     Trash2,
-    Search
+    Search,
+    TriangleAlert
   } from '@lucide/svelte'
   import { toast } from 'svelte-sonner'
 
@@ -145,6 +146,10 @@
 
   // The source ticket's open/closed (GitHub) or workflow (Jira) state, or null.
   const ticketState = $derived(ticketStateBadge(task))
+
+  // A Jira ticket with no target repo is skipped by the agent (it has nothing to
+  // branch in), so warn the operator that it needs a repo to be worked (issue #337).
+  const needsTargetRepo = $derived(task.source_kind === 'jira' && task.target_repo_ids.length === 0)
 
   // The label for the "open the external issue" action, per source. Internal
   // tasks have no external issue, so the item is disabled regardless of label.
@@ -357,6 +362,17 @@
       {/if}
       <div class="min-w-0 text-sm leading-snug">{task.title}</div>
     </div>
+
+    <!-- A Jira ticket without a target repo is never auto-pulled, so flag it (issue #337). -->
+    {#if needsTargetRepo}
+      <div
+        class="mt-2 flex items-center gap-1.5 rounded-md border border-warning/50 bg-warning/10 px-2 py-1 text-xs font-medium text-warning"
+        title="This Jira ticket has no target repository, so the agent will not work it. Open the task and set one."
+      >
+        <TriangleAlert class="size-3.5 flex-none" />
+        <span>No target repo — agent will skip this</span>
+      </div>
+    {/if}
 
     <!-- Loud on purpose: pulses until the user acknowledges the suggestions on the task. -->
     {#if suggestionCount > 0}

--- a/frontend/src/lib/components/ui/alert/alert.svelte
+++ b/frontend/src/lib/components/ui/alert/alert.svelte
@@ -7,6 +7,7 @@
 			variant: {
 				default: "bg-card text-card-foreground",
 				destructive: "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+				warning: "border-warning/50 text-warning bg-card *:data-[slot=alert-description]:text-warning/90 *:[svg]:text-current",
 			},
 		},
 		defaultVariants: {

--- a/frontend/src/routes/task/[id]/+page.svelte
+++ b/frontend/src/routes/task/[id]/+page.svelte
@@ -25,7 +25,8 @@
     Paperclip,
     Pause,
     Play,
-    RotateCcw
+    RotateCcw,
+    TriangleAlert
   } from '@lucide/svelte'
 
   import {
@@ -619,6 +620,18 @@
           that makes the ticket auto-pullable; the agent gets the whole list as context and opens a
           PR in each repo it changes. Leave empty to keep the ticket tracking-only.
         </p>
+        {#if task.source_kind === 'jira' && task.target_repo_ids.length === 0}
+          <!-- A synced Jira ticket lands with no repo, so the agent will not work
+               it until one is set. Surface that clearly (issue #337). -->
+          <Alert.Root variant="warning" class="mt-2">
+            <TriangleAlert />
+            <Alert.Title>No target repository set</Alert.Title>
+            <Alert.Description>
+              The agent will not work this Jira ticket until it has at least one target repo. Pick
+              the primary repo below and save to make it workable.
+            </Alert.Description>
+          </Alert.Root>
+        {/if}
         <div class="mt-2">
           <RepoMultiSelect {repos} bind:selected={targetRepoIds} />
         </div>


### PR DESCRIPTION
Closes #337.

## Why

A Jira ticket syncs onto the board with no target repository, and `pick_next_todo` only pulls Jira/internal tickets that have a `repo_id`. So a repo-less Jira ticket sits in To Do forever and the agent silently skips it, with nothing in the UI explaining why.

## What changed

Both signals are pure frontend derivations of `source_kind === 'jira'` with an empty `target_repo_ids` (the board and task payloads already carry these fields), so there is no backend or schema change.

- **Kanban card** (`Card.svelte`): an amber "No target repo — agent will skip this" label with a warning-triangle icon, shown only on repo-less Jira cards.
- **Task view** (`task/[id]/+page.svelte`): a warning banner in the existing "Target repositories" section explaining the agent will not work the ticket until a repo is set, right above the repo picker that fixes it.
- **Shared UI**: added a reusable `warning` variant to the `Alert` component (amber, using the existing `--warning` token).

## Testing

- `npm run check` (0 errors/warnings) and `npm run build`.
- Visual self-review with a live API (ephemeral Postgres) + dev server via the Playwright MCP, seeding three cards: a repo-less Jira ticket, a Jira ticket with a repo, and a GitHub issue. Confirmed the warning appears only on the repo-less Jira card and its task view, verified the warning color (`#d29922`), icon alignment, and no overflow at 375px and 1280px.