### PR TITLE
Let the agent edit its own setup scripts via an MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,24 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   its task's title/source/repo link (`AggregatedSuggestion`), and the page reuses
   the same ack and create-issue actions, with open items on top and acknowledged
   ones in a greyed, hover-revealed bottom section.
+- **`setup_script_changes`** (issue #340) — setup-script edits the agent made to
+  **itself** through the **Seraphim MCP** (`workspace/seraphim-mcp`), so it can
+  apply an environment optimization it spots (e.g. "add `cd frontend && yarn
+  install` so UI tasks build immediately") instead of only recommending it via
+  `seraphim-suggest`. The MCP is a hand-rolled zero-dep stdio server (like the
+  `seraphim-*` helpers), registered at user scope by the entrypoint alongside the
+  Playwright MCP, and exposes `list_setup_scripts`, `update_repo_setup_script`, and
+  `update_base_setup_script`, backed by `GET /agent/setup-scripts` and
+  `POST /agent/setup-scripts/{repo,base}` (`http/setup_scripts.rs`). Every edit
+  replaces a repo's `setup_script` or the global `base_setup_script` and records a
+  row here with the before/after, `target` (`repo`|`base`), `summary` (the agent's
+  one-line why), and the `task_id` it was working. The change is **never silent**:
+  the board shows the unacknowledged ones in a banner (via the board payload) and a
+  one-time toast + native notification fires (`ServerEvent::SetupScriptChanged`),
+  cleared by `POST /setup-changes/:id/ack`. No-op edits are rejected so the audit
+  holds only real changes; a base change takes effect on the next provision/recreate.
+  A standing prompt instruction (`prompt::SETUP_SCRIPT_AUTONOMY`) tells the agent it
+  can apply the change itself, with accountability.
 - **`questions`** — decisions the agent escalated to the user, stored on the task
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and

--- a/api/migrations/0048_setup_script_changes.sql
+++ b/api/migrations/0048_setup_script_changes.sql
@@ -1,0 +1,29 @@
+-- Setup-script changes the agent made to itself (issue #340). The agent can edit
+-- a repo's `setup_script` or the global `base_setup_script` through the Seraphim
+-- MCP when it spots an environment optimization (e.g. "add `yarn install` so UI
+-- tasks build immediately"). Every change is recorded here so it is never silent:
+-- the board surfaces the unacknowledged ones in a banner and a one-time
+-- notification, and the row keeps the before/after for a full audit + manual revert.
+--
+-- `task_id` is the task the agent was working when it made the change (SET NULL if
+-- that task is later deleted, so the audit outlives it). `target` is 'repo' or
+-- 'base'; for a repo change, `repo_id` links the repo (SET NULL on delete) and
+-- `repo_full_name` snapshots the name so the record reads even after a rename/delete.
+CREATE TABLE setup_script_changes (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id        UUID REFERENCES tasks(id) ON DELETE SET NULL,
+    target         TEXT NOT NULL CHECK (target IN ('repo', 'base')),
+    repo_id        UUID REFERENCES repositories(id) ON DELETE SET NULL,
+    repo_full_name TEXT,
+    old_script     TEXT NOT NULL,
+    new_script     TEXT NOT NULL,
+    -- The agent's one-line "why", shown to the operator so the change is explained.
+    summary        TEXT NOT NULL DEFAULT '',
+    acknowledged   BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The board reads the unacknowledged ones newest-first for its banner.
+CREATE INDEX setup_script_changes_unacked_idx
+    ON setup_script_changes (created_at DESC)
+    WHERE acknowledged = FALSE;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -407,6 +407,32 @@ pub struct RepoSyncError {
     pub sync_error_at: DateTime<Utc>,
 }
 
+/// A setup-script edit the agent made to itself through the Seraphim MCP (issue
+/// #340). Recorded so the change is never silent: the board banner shows the
+/// unacknowledged ones and the row keeps the before/after for audit and revert.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct SetupScriptChange {
+    pub id: Uuid,
+    /// The task the agent was working when it made the change; `None` once that
+    /// task is deleted.
+    pub task_id: Option<Uuid>,
+    /// `"repo"` (a repository's `setup_script`) or `"base"` (the global
+    /// `base_setup_script`, the environment setup).
+    pub target: String,
+    /// The repo whose script changed, for a `"repo"` target; `None` for `"base"`
+    /// or once the repo is deleted.
+    pub repo_id: Option<Uuid>,
+    /// The repo's `owner/name` at the time, snapshotted so the record still reads
+    /// after a rename or delete. `None` for a `"base"` change.
+    pub repo_full_name: Option<String>,
+    pub old_script: String,
+    pub new_script: String,
+    /// The agent's one-line reason, shown to the operator so the change is explained.
+    pub summary: String,
+    pub acknowledged: bool,
+    pub created_at: DateTime<Utc>,
+}
+
 /// An open, non-draft pull request whose net diff is empty (issue #314): an
 /// anomaly, since GitHub cannot squash-merge a zero-change PR and the agent did
 /// not deliberately park it as a draft. Surfaced as a self-clearing board banner

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -16,9 +16,9 @@ use super::models::{
     ClaudeUsageCredentials, DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack,
     InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingPlacement,
     PendingQuestion, Question, QuestionOption, QuestionStatus, Railway, RepoDeletionImpact,
-    RepoSyncError, ReposDeletionImpact, Repository, ReviewPolicy, Settings, SourceKind,
-    StatsAggregate, Task, TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot, TaskStatus,
-    Turn,
+    RepoSyncError, ReposDeletionImpact, Repository, ReviewPolicy, Settings, SetupScriptChange,
+    SourceKind, StatsAggregate, Task, TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot,
+    TaskStatus, Turn,
 };
 use crate::automation::{RuleAction, RuleGroup, Trigger};
 
@@ -1116,6 +1116,96 @@ pub async fn delete_repositories(pool: &PgPool, ids: &[Uuid]) -> sqlx::Result<u6
         .await?;
     tx.commit().await?;
     Ok(result.rows_affected())
+}
+
+/// Replaces a single repo's `setup_script`, leaving everything else untouched.
+///
+/// Used by the agent's self-service setup-script MCP (issue #340), which sends
+/// only the new script, so this is a targeted update rather than the full
+/// [`update_repository`] upsert. Returns the updated row.
+pub async fn update_repo_setup_script(
+    pool: &PgPool,
+    id: Uuid,
+    setup_script: &str,
+) -> sqlx::Result<Repository> {
+    sqlx::query_as::<_, Repository>(
+        "UPDATE repositories SET setup_script = $2, updated_at = now() \
+         WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(setup_script)
+    .fetch_one(pool)
+    .await
+}
+
+// --- Setup-script self-edits (agent MCP, issue #340) -------------------------
+//
+// The agent edits its own setup scripts through the Seraphim MCP; each edit is
+// recorded here so the change is surfaced to the operator (board banner + a
+// one-time notification) and kept for audit and manual revert.
+
+/// Replaces the global `base_setup_script` (the environment setup that runs once
+/// per provision), leaving every other setting untouched. Returns the new settings.
+pub async fn update_base_setup_script(pool: &PgPool, setup_script: &str) -> sqlx::Result<Settings> {
+    sqlx::query_as::<_, Settings>(&format!(
+        "UPDATE settings SET base_setup_script = $1, updated_at = now() \
+         WHERE id = 1 RETURNING {SETTINGS_COLUMNS}"
+    ))
+    .bind(setup_script)
+    .fetch_one(pool)
+    .await
+}
+
+/// Records one setup-script edit the agent made, returning the stored row.
+///
+/// `repo_id` / `repo_full_name` are set for a `"repo"` target and left `None` for a
+/// `"base"` one. `task_id` attributes the change to the task being worked.
+#[allow(clippy::too_many_arguments)]
+pub async fn record_setup_script_change(
+    pool: &PgPool,
+    task_id: Option<Uuid>,
+    target: &str,
+    repo_id: Option<Uuid>,
+    repo_full_name: Option<&str>,
+    old_script: &str,
+    new_script: &str,
+    summary: &str,
+) -> sqlx::Result<SetupScriptChange> {
+    sqlx::query_as::<_, SetupScriptChange>(
+        "INSERT INTO setup_script_changes \
+           (task_id, target, repo_id, repo_full_name, old_script, new_script, summary) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *",
+    )
+    .bind(task_id)
+    .bind(target)
+    .bind(repo_id)
+    .bind(repo_full_name)
+    .bind(old_script)
+    .bind(new_script)
+    .bind(summary)
+    .fetch_one(pool)
+    .await
+}
+
+/// Unacknowledged setup-script changes, newest first, for the board banner.
+pub async fn list_unacknowledged_setup_changes(
+    pool: &PgPool,
+) -> sqlx::Result<Vec<SetupScriptChange>> {
+    sqlx::query_as::<_, SetupScriptChange>(
+        "SELECT * FROM setup_script_changes WHERE acknowledged = FALSE ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Marks a recorded setup-script change acknowledged, clearing it from the banner.
+pub async fn acknowledge_setup_change(pool: &PgPool, id: Uuid) -> sqlx::Result<SetupScriptChange> {
+    sqlx::query_as::<_, SetupScriptChange>(
+        "UPDATE setup_script_changes SET acknowledged = TRUE WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
 }
 
 // --- Tasks -------------------------------------------------------------------

--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -15,8 +15,8 @@ use tracing::{info, warn};
 
 use super::ApiResult;
 use crate::db::models::{
-    AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn,
-    TaskStatus,
+    AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, Settings, SetupScriptChange, SourceKind,
+    Task, TaskColumn, TaskStatus,
 };
 use crate::db::queries;
 use crate::git;
@@ -43,6 +43,10 @@ pub struct BoardResponse {
     /// board surfaces in a banner so it does not sit only in the logs. Self-clearing
     /// (it drops off once the PR gains changes, closes, or is marked draft).
     pub anomalous_empty_prs: Vec<AnomalousEmptyPr>,
+    /// Setup-script edits the agent made to itself (issue #340), unacknowledged,
+    /// newest first, so the board banner shows what changed until the operator
+    /// clears it.
+    pub setup_script_changes: Vec<SetupScriptChange>,
 }
 
 /// `GET /api/v1/board` - every card, the org/pause settings, per-card counts of
@@ -60,6 +64,7 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
     let heart_attacks = queries::list_unacknowledged_heart_attacks(&state.db).await?;
     let repo_sync_errors = queries::list_repo_sync_errors(&state.db).await?;
     let anomalous_empty_prs = queries::list_anomalous_empty_prs(&state.db).await?;
+    let setup_script_changes = queries::list_unacknowledged_setup_changes(&state.db).await?;
     Ok(Json(BoardResponse {
         tasks,
         settings,
@@ -68,6 +73,7 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
         heart_attacks,
         repo_sync_errors,
         anomalous_empty_prs,
+        setup_script_changes,
     }))
 }
 

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -19,6 +19,7 @@ mod railways;
 mod repos;
 mod screenshots;
 mod settings;
+mod setup_scripts;
 mod sse;
 mod stats;
 mod suggestions;
@@ -130,6 +131,19 @@ pub fn router(state: AppState) -> Router {
             )),
         )
         .route("/attachments/:id", get(attachments::serve))
+        // The agent editing its own setup scripts through the Seraphim MCP (issue
+        // #340): read the current scripts, update a repo's or the base script, and
+        // let the operator acknowledge a recorded change from the board banner.
+        .route("/agent/setup-scripts", get(setup_scripts::list))
+        .route(
+            "/agent/setup-scripts/repo",
+            post(setup_scripts::update_repo),
+        )
+        .route(
+            "/agent/setup-scripts/base",
+            post(setup_scripts::update_base),
+        )
+        .route("/setup-changes/:id/ack", post(setup_scripts::acknowledge))
         .route("/agent/questions", post(questions::ask))
         .route("/questions/pending", get(questions::pending))
         .route("/questions/:id/answer", post(questions::answer))

--- a/api/src/http/setup_scripts.rs
+++ b/api/src/http/setup_scripts.rs
@@ -1,0 +1,314 @@
+//! The agent editing its own setup scripts (issue #340).
+//!
+//! Backs the Seraphim MCP (`workspace/seraphim-mcp`): the agent lists the current
+//! scripts, then updates a repo's `setup_script` or the global `base_setup_script`
+//! when it spots an environment optimization (e.g. "add `yarn install` so UI tasks
+//! build immediately"). Every edit is recorded in `setup_script_changes` and
+//! surfaced to the operator, so the agent's autonomy is never silent: a persistent
+//! board banner (via the board payload) plus a one-time toast + native notification
+//! (`ServerEvent::SetupScriptChanged`). The `:id/ack` route clears the banner once
+//! the operator has seen the change.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
+
+use super::ApiResult;
+use crate::db::models::{Repository, SetupScriptChange};
+use crate::db::queries;
+use crate::state::AppState;
+
+/// Upper bound on a submitted script, so a runaway agent cannot store an enormous
+/// blob. Setup scripts are a handful of shell lines; 64 KiB is generous headroom.
+const MAX_SETUP_SCRIPT_BYTES: usize = 64 * 1024;
+
+/// One repo's setup-script state, for the agent to read before it edits.
+#[derive(Debug, Serialize)]
+pub struct RepoSetupScript {
+    pub id: Uuid,
+    pub full_name: String,
+    pub setup_script: String,
+    /// Whether the script re-runs before every task, not just on first clone
+    /// (issue #275). Tells the agent whether an edit takes effect next task.
+    pub setup_script_always_run: bool,
+    pub enabled: bool,
+}
+
+impl From<Repository> for RepoSetupScript {
+    fn from(repo: Repository) -> Self {
+        Self {
+            id: repo.id,
+            full_name: repo.full_name,
+            setup_script: repo.setup_script,
+            setup_script_always_run: repo.setup_script_always_run,
+            enabled: repo.enabled,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetupScriptsResponse {
+    /// The global environment setup, run once per workspace provision/recreate.
+    pub base_setup_script: String,
+    pub repos: Vec<RepoSetupScript>,
+}
+
+/// `GET /api/v1/agent/setup-scripts` - the current base + per-repo setup scripts,
+/// so the agent can read what exists before proposing an edit.
+pub async fn list(State(state): State<AppState>) -> ApiResult<Json<SetupScriptsResponse>> {
+    let settings = queries::get_settings(&state.db).await?;
+    let repos = queries::list_repositories(&state.db).await?;
+    Ok(Json(SetupScriptsResponse {
+        base_setup_script: settings.base_setup_script,
+        repos: repos.into_iter().map(RepoSetupScript::from).collect(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateRepoScriptRequest {
+    /// The task being worked, so the change is attributed to it (audit trail).
+    #[serde(default)]
+    pub task_id: Option<Uuid>,
+    /// The repo to edit: its `owner/name`, its short name, or its id.
+    pub repo: String,
+    pub setup_script: String,
+    /// A one-line reason, shown to the operator so the change is explained.
+    #[serde(default)]
+    pub summary: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetupScriptChangeResponse {
+    /// The recorded change (before/after, target, summary), so the caller can
+    /// confirm exactly what was stored.
+    pub change: SetupScriptChange,
+}
+
+/// `POST /api/v1/agent/setup-scripts/repo` - replace a repo's `setup_script`.
+///
+/// Resolves the repo by id, `owner/name`, or unambiguous short name; a no-op edit
+/// (unchanged script) is rejected so the audit log holds only real changes.
+pub async fn update_repo(
+    State(state): State<AppState>,
+    Json(body): Json<UpdateRepoScriptRequest>,
+) -> ApiResult<Response> {
+    if body.setup_script.len() > MAX_SETUP_SCRIPT_BYTES {
+        return Ok(bad_request(&format!(
+            "setup_script is too large ({} bytes; max {MAX_SETUP_SCRIPT_BYTES})",
+            body.setup_script.len()
+        )));
+    }
+
+    let repos = queries::list_repositories(&state.db).await?;
+    let repo = match resolve_repo(&repos, &body.repo) {
+        RepoMatch::One(repo) => repo.clone(),
+        RepoMatch::None => {
+            return Ok(bad_request(&format!(
+                "no repository matches '{}'. Use its owner/name or id (see the list tool).",
+                body.repo
+            )))
+        }
+        RepoMatch::Ambiguous => {
+            return Ok(bad_request(&format!(
+                "'{}' matches more than one repository; use the full owner/name or id.",
+                body.repo
+            )))
+        }
+    };
+
+    if repo.setup_script == body.setup_script {
+        return Ok(bad_request(
+            "the setup script is unchanged; edit it to something different or leave it as is.",
+        ));
+    }
+
+    let old_script = repo.setup_script.clone();
+    let updated = queries::update_repo_setup_script(&state.db, repo.id, &body.setup_script).await?;
+    let change = queries::record_setup_script_change(
+        &state.db,
+        body.task_id,
+        "repo",
+        Some(updated.id),
+        Some(&updated.full_name),
+        &old_script,
+        &updated.setup_script,
+        body.summary.trim(),
+    )
+    .await?;
+
+    announce(&state, &change, &updated.full_name);
+    Ok(Json(SetupScriptChangeResponse { change }).into_response())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateBaseScriptRequest {
+    #[serde(default)]
+    pub task_id: Option<Uuid>,
+    pub setup_script: String,
+    #[serde(default)]
+    pub summary: String,
+}
+
+/// `POST /api/v1/agent/setup-scripts/base` - replace the global `base_setup_script`
+/// (the environment setup). It takes effect on the next workspace provision/recreate.
+pub async fn update_base(
+    State(state): State<AppState>,
+    Json(body): Json<UpdateBaseScriptRequest>,
+) -> ApiResult<Response> {
+    if body.setup_script.len() > MAX_SETUP_SCRIPT_BYTES {
+        return Ok(bad_request(&format!(
+            "setup_script is too large ({} bytes; max {MAX_SETUP_SCRIPT_BYTES})",
+            body.setup_script.len()
+        )));
+    }
+
+    let settings = queries::get_settings(&state.db).await?;
+    if settings.base_setup_script == body.setup_script {
+        return Ok(bad_request(
+            "the base setup script is unchanged; edit it to something different or leave it as is.",
+        ));
+    }
+
+    let old_script = settings.base_setup_script.clone();
+    let updated = queries::update_base_setup_script(&state.db, &body.setup_script).await?;
+    let change = queries::record_setup_script_change(
+        &state.db,
+        body.task_id,
+        "base",
+        None,
+        None,
+        &old_script,
+        &updated.base_setup_script,
+        body.summary.trim(),
+    )
+    .await?;
+
+    announce(&state, &change, "environment setup");
+    Ok(Json(SetupScriptChangeResponse { change }).into_response())
+}
+
+/// `POST /api/v1/setup-changes/:id/ack` - the operator dismisses a recorded change
+/// once they have seen it, clearing it from the board banner.
+pub async fn acknowledge(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<SetupScriptChange>> {
+    let change = queries::acknowledge_setup_change(&state.db, id).await?;
+    state.notify_board();
+    Ok(Json(change))
+}
+
+/// Refreshes the board banner and fires the one-time toast + native notification.
+fn announce(state: &AppState, change: &SetupScriptChange, target_label: &str) {
+    // The banner (board payload) reflects the new unacknowledged change.
+    state.notify_board();
+    state.notify_setup_script_changed(
+        change.task_id,
+        target_label.to_string(),
+        change.summary.clone(),
+    );
+}
+
+fn bad_request(message: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))).into_response()
+}
+
+/// The outcome of resolving a user-supplied repo reference against the repo list.
+enum RepoMatch<'a> {
+    One(&'a Repository),
+    None,
+    Ambiguous,
+}
+
+/// Resolves a repo reference (`owner/name`, short name, or id) to a single repo.
+///
+/// An id or exact `owner/name` is unambiguous. A bare short name (the part after
+/// `/`) resolves only when exactly one repo has it, else it is reported ambiguous
+/// so the caller re-tries with the full name.
+fn resolve_repo<'a>(repos: &'a [Repository], reference: &str) -> RepoMatch<'a> {
+    let needle = reference.trim();
+    if needle.is_empty() {
+        return RepoMatch::None;
+    }
+    if let Ok(id) = Uuid::parse_str(needle) {
+        return match repos.iter().find(|repo| repo.id == id) {
+            Some(repo) => RepoMatch::One(repo),
+            None => RepoMatch::None,
+        };
+    }
+    if let Some(repo) = repos.iter().find(|repo| repo.full_name == needle) {
+        return RepoMatch::One(repo);
+    }
+    let mut short_matches = repos
+        .iter()
+        .filter(|repo| repo.full_name.rsplit('/').next() == Some(needle));
+    match (short_matches.next(), short_matches.next()) {
+        (Some(repo), None) => RepoMatch::One(repo),
+        (Some(_), Some(_)) => RepoMatch::Ambiguous,
+        _ => RepoMatch::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::{resolve_repo, RepoMatch};
+    use crate::db::models::Repository;
+
+    fn repo(id: Uuid, full_name: &str) -> Repository {
+        // Only the fields `resolve_repo` reads matter; the rest use cheap defaults.
+        Repository {
+            id,
+            railway_id: Uuid::nil(),
+            full_name: full_name.to_string(),
+            clone_url: String::new(),
+            default_branch: "main".to_string(),
+            branch_template: None,
+            setup_script: String::new(),
+            instructions: String::new(),
+            review_policy: None,
+            enabled: true,
+            sync_issues: false,
+            issue_labels: Vec::new(),
+            setup_script_always_run: false,
+            sync_error: None,
+            sync_error_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn resolves_by_id_full_name_and_unique_short_name() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let repos = vec![repo(a, "acme/web"), repo(b, "acme/api")];
+
+        assert!(matches!(resolve_repo(&repos, "acme/web"), RepoMatch::One(r) if r.id == a));
+        assert!(matches!(resolve_repo(&repos, &b.to_string()), RepoMatch::One(r) if r.id == b));
+        // Unique short name resolves.
+        assert!(matches!(resolve_repo(&repos, "api"), RepoMatch::One(r) if r.id == b));
+        // Unknown reference is not found.
+        assert!(matches!(
+            resolve_repo(&repos, "acme/mobile"),
+            RepoMatch::None
+        ));
+        assert!(matches!(resolve_repo(&repos, ""), RepoMatch::None));
+    }
+
+    #[test]
+    fn ambiguous_short_name_across_owners_is_reported() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let repos = vec![repo(a, "acme/web"), repo(b, "other/web")];
+        // "web" is ambiguous; the full owner/name still resolves each.
+        assert!(matches!(resolve_repo(&repos, "web"), RepoMatch::Ambiguous));
+        assert!(matches!(resolve_repo(&repos, "acme/web"), RepoMatch::One(r) if r.id == a));
+        assert!(matches!(resolve_repo(&repos, "other/web"), RepoMatch::One(r) if r.id == b));
+    }
+}

--- a/api/src/http/sse.rs
+++ b/api/src/http/sse.rs
@@ -34,6 +34,7 @@ pub async fn board_stream(
                     | ServerEvent::AnomalousEmptyPr { .. }
                     | ServerEvent::HeartAttack { .. }
                     | ServerEvent::TaskFinished { .. }
+                    | ServerEvent::SetupScriptChanged { .. }
                     | ServerEvent::Compose { .. }
                     | ServerEvent::ComposeChanged,
                 ) => {}
@@ -97,6 +98,15 @@ pub async fn notification_stream(
                     });
                     let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
                     yield Ok(Event::default().event("anomalous_empty_pr").data(data));
+                }
+                Ok(ServerEvent::SetupScriptChanged { task_id, target_label, summary }) => {
+                    let payload = serde_json::json!({
+                        "task_id": task_id,
+                        "target_label": target_label,
+                        "summary": summary,
+                    });
+                    let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+                    yield Ok(Event::default().event("setup_script_changed").data(data));
                 }
                 Ok(ServerEvent::Board) => {
                     yield Ok(Event::default().event("refresh").data("{}"));

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -517,6 +517,9 @@ fn context_header(
     // Shared by every mode: noticing missing tooling can happen on any run, so
     // the recommend-improvements guidance lives in the common header.
     prompt.push_str(ENVIRONMENT_SUGGESTIONS);
+    // The agent can also apply the setup-script optimization itself via the
+    // Seraphim MCP, not just recommend it (issue #340).
+    prompt.push_str(SETUP_SCRIPT_AUTONOMY);
     // Likewise follow-up work the agent spots while working (issue #272): bubble it
     // up at the end so the operator can one-click it into a ticket.
     prompt.push_str(FOLLOW_UP_SUGGESTIONS);
@@ -668,6 +671,25 @@ const ENVIRONMENT_SUGGESTIONS: &str = "\n\
     \x20 JSON\n\n\
     Only suggest things that genuinely help; if nothing comes to mind, skip it. \
     This does not replace opening the pull request.\n";
+
+/// Standing instruction (issue #340) letting the agent apply setup-script
+/// optimizations itself, via the Seraphim MCP, rather than only recommending them.
+///
+/// The MCP tools (`seraphim` server) read and update a repo's `setup_script` or
+/// the global environment setup; every change is recorded and shown to the operator
+/// (a board banner + a notification), so this is autonomy WITH accountability.
+const SETUP_SCRIPT_AUTONOMY: &str = "\n\
+    # Improve your own setup scripts directly\n\
+    When the improvement you would recommend above is a setup-script change (e.g. \
+    \"add `cd frontend && yarn install` so UI tasks build immediately\"), you can \
+    apply it yourself through the `seraphim` MCP instead of only suggesting it. Its \
+    tools list the current base and per-repo setup scripts and update a repo's \
+    `setup_script` or the global environment setup. Prefer editing a repo's \
+    `setup_script` for a repo-specific step and the base setup only for a truly \
+    global tool. Read the current script first, make a minimal, correct edit, and \
+    pass a one-line `summary` explaining why. Every change is recorded and surfaced \
+    to the operator, so keep edits genuine and safe; if you are unsure, recommend it \
+    with `seraphim-suggest` instead.\n";
 
 /// Guidance, appended to every task prompt, on bubbling up follow-up work (#272).
 const FOLLOW_UP_SUGGESTIONS: &str = "\n\

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -63,6 +63,18 @@ pub enum ServerEvent {
     },
     /// A task finished (auto-merged to Done); drives the completion sound.
     TaskFinished { task_id: Uuid, task_title: String },
+    /// The agent edited one of its own setup scripts through the Seraphim MCP
+    /// (issue #340); drives a one-time toast + native notification so the operator
+    /// knows. The ongoing state is carried by the board's setup-change banner.
+    SetupScriptChanged {
+        /// The task being worked when the change was made, when known.
+        task_id: Option<Uuid>,
+        /// The repo's `owner/name` for a repo change, or "environment setup" for
+        /// the base script, so the toast names what changed.
+        target_label: String,
+        /// The agent's one-line reason for the change.
+        summary: String,
+    },
     /// A streamed event from the compose assistant's turn (issue #181); the
     /// /compose page appends it to the chat transcript.
     Compose { payload: serde_json::Value },
@@ -443,6 +455,21 @@ impl AppState {
         let _ = self.events.send(ServerEvent::TaskFinished {
             task_id,
             task_title,
+        });
+    }
+
+    /// Announces that the agent edited one of its own setup scripts (issue #340),
+    /// so the notifications sidebar can toast and notify natively.
+    pub fn notify_setup_script_changed(
+        &self,
+        task_id: Option<Uuid>,
+        target_label: String,
+        summary: String,
+    ) {
+        let _ = self.events.send(ServerEvent::SetupScriptChanged {
+            task_id,
+            target_label,
+            summary,
         });
     }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   RuleGroup,
   RuleSource,
   Settings,
+  SetupScriptChange,
   Stats,
   TailscaleActionResponse,
   TailscaleStatus,
@@ -288,6 +289,14 @@ export function createIssueFromSuggestion(suggestionId: string, target: CreateIs
 // Clears a heart attack from the board banner once the operator has read it.
 export function acknowledgeHeartAttack(id: string) {
   return apiClient.post(`heart-attacks/${id}/ack`).json<HeartAttack>()
+}
+
+// --- Setup-script self-edits (agent MCP, issue #340) -------------------------
+
+// Clears a recorded setup-script change from the board banner once the operator
+// has seen it.
+export function acknowledgeSetupChange(id: string) {
+  return apiClient.post(`setup-changes/${id}/ack`).json<SetupScriptChange>()
 }
 
 // --- Questions ---------------------------------------------------------------

--- a/frontend/src/lib/components/Notifications.svelte
+++ b/frontend/src/lib/components/Notifications.svelte
@@ -27,8 +27,14 @@
     prompt: string
     // 'question' is the agent asking for input; 'heart_attack' is a dead turn;
     // 'repo_sync_error' is a repo whose issue sync started failing (issue #213);
-    // 'anomalous_empty_pr' is an open non-draft PR with no changes (issue #314).
-    kind: 'question' | 'heart_attack' | 'repo_sync_error' | 'anomalous_empty_pr'
+    // 'anomalous_empty_pr' is an open non-draft PR with no changes (issue #314);
+    // 'setup_script_changed' is the agent editing its own setup script (issue #340).
+    kind:
+      | 'question'
+      | 'heart_attack'
+      | 'repo_sync_error'
+      | 'anomalous_empty_pr'
+      | 'setup_script_changed'
   }
 
   function loadIds(key: string): Set<string> {
@@ -236,6 +242,19 @@
     playSound('completion')
   }
 
+  // The agent edited one of its own setup scripts (issue #340). Fires once when the
+  // change is made; the board's banner carries the detail and clears on ack. Not an
+  // error, so no alert sound, just a toast + native notification so the operator knows.
+  function handleSetupScriptChanged(event: MessageEvent) {
+    const data = JSON.parse(event.data) as {
+      task_id: string | null
+      target_label: string
+      summary: string
+    }
+    pushToast(data.task_id, data.target_label, data.summary, 'setup_script_changed')
+    notifyNatively(`Agent updated a setup script: ${data.target_label}`, data.summary)
+  }
+
   onMount(() => {
     refresh()
     loadSoundPrefs()
@@ -253,6 +272,7 @@
     eventSource.addEventListener('repo_sync_error', handleRepoSyncError)
     eventSource.addEventListener('anomalous_empty_pr', handleAnomalousEmptyPr)
     eventSource.addEventListener('task_finished', handleTaskFinished)
+    eventSource.addEventListener('setup_script_changed', handleSetupScriptChanged)
     eventSource.addEventListener('refresh', () => {
       refresh()
       // Pick up sound-preference changes the operator just saved.
@@ -351,7 +371,9 @@
       class="pointer-events-auto flex items-start overflow-hidden rounded-lg border bg-card shadow-2xl {toast.kind ===
         'heart_attack' || toast.kind === 'repo_sync_error' || toast.kind === 'anomalous_empty_pr'
         ? 'border-destructive/60'
-        : 'border-warning/50'}"
+        : toast.kind === 'setup_script_changed'
+          ? 'border-primary/50'
+          : 'border-warning/50'}"
     >
       <button
         type="button"
@@ -369,6 +391,10 @@
         {:else if toast.kind === 'anomalous_empty_pr'}
           <span class="text-[10px] font-bold uppercase tracking-wide text-destructive"
             >Empty pull request</span
+          >
+        {:else if toast.kind === 'setup_script_changed'}
+          <span class="text-[10px] font-bold uppercase tracking-wide text-primary"
+            >Setup script updated</span
           >
         {:else}
           <span class="text-[10px] font-bold uppercase tracking-wide text-warning"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -320,6 +320,25 @@ export type AnomalousEmptyPr = {
   pr_url: string
 }
 
+// A setup-script edit the agent made to itself via the Seraphim MCP (issue #340),
+// recorded so the board can surface it in a banner until the operator acknowledges it.
+export type SetupScriptChange = {
+  id: string
+  // The task being worked when the change was made; null once that task is gone.
+  task_id: string | null
+  // 'repo' (a repository's setup_script) or 'base' (the global environment setup).
+  target: 'repo' | 'base'
+  repo_id: string | null
+  // The repo's owner/name at the time (snapshotted); null for a 'base' change.
+  repo_full_name: string | null
+  old_script: string
+  new_script: string
+  // The agent's one-line reason for the change.
+  summary: string
+  acknowledged: boolean
+  created_at: string
+}
+
 // What deleting a repository will purge, shown in the delete confirmation.
 export type RepoDeletionImpact = {
   tasks: number
@@ -547,6 +566,9 @@ export type BoardResponse = {
   repo_sync_errors: RepoSyncError[]
   // Open, non-draft empty PRs (issue #314), for the self-clearing anomaly banner.
   anomalous_empty_prs: AnomalousEmptyPr[]
+  // Setup-script edits the agent made to itself (issue #340), unacknowledged, for
+  // the board banner that keeps the operator aware of the change.
+  setup_script_changes: SetupScriptChange[]
 }
 
 // A pull request the task has opened. A task may span several repos, so it can

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { DndEvent } from 'svelte-dnd-action'
-  import type { AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, Settings, SourceKind, Task, TaskColumn } from '$lib/types'
+  import type { AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, SetupScriptChange, Settings, SourceKind, Task, TaskColumn } from '$lib/types'
 
   import { onMount, onDestroy } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
@@ -18,13 +18,15 @@
     X,
     ListChecks,
     Filter,
-    Check
+    Check,
+    Wrench
   } from '@lucide/svelte'
   import { PaneGroup } from 'paneforge'
 
   import { COLUMNS } from '$lib/types'
   import {
     acknowledgeHeartAttack,
+    acknowledgeSetupChange,
     assignRepoToRailway,
     bulkDeleteTasks,
     bulkSetTaskFields,
@@ -88,6 +90,10 @@
   const visibleEmptyPrs = $derived(
     anomalousEmptyPrs.filter((pr) => !dismissedEmptyPrs.has(pr.pr_url))
   )
+  // Setup-script edits the agent made to itself (issue #340). Recorded server-side
+  // and acknowledged via the API (like heart attacks), so the banner clears on the
+  // next board load; the one-time toast is driven via SSE.
+  let setupScriptChanges = $state<SetupScriptChange[]>([])
   // Every railway (swimlane), already ordered `main` first then by rank.
   let railways = $state<Railway[]>([])
   // The board cards, grouped first by railway id, then by column. One array per
@@ -439,6 +445,7 @@
         dismissedEmptyPrs.delete(url)
       }
     }
+    setupScriptChanges = board.setup_script_changes
     repoNames = Object.fromEntries(repos.map((repo) => [repo.id, repo.full_name]))
 
     // Group every card by railway, then by column. A lane with no cards still gets
@@ -483,6 +490,17 @@
       await acknowledgeHeartAttack(id)
     } catch (error) {
       console.debug('failed to acknowledge heart attack', error)
+    }
+  }
+
+  // Acknowledge a setup-script change (issue #340): drop it locally so the banner
+  // clears instantly, then persist so it stays cleared on the next board load.
+  async function dismissSetupChange(id: string) {
+    setupScriptChanges = setupScriptChanges.filter((change) => change.id !== id)
+    try {
+      await acknowledgeSetupChange(id)
+    } catch (error) {
+      console.debug('failed to acknowledge setup-script change', error)
     }
   }
 
@@ -1014,6 +1032,51 @@
         title="Dismiss"
         aria-label="Dismiss empty pull request anomaly"
         onclick={() => dismissedEmptyPrs.add(pr.pr_url)}
+      >
+        <X class="size-4" />
+      </Button>
+    </Alert.Root>
+  {/each}
+
+  {#each setupScriptChanges as change (change.id)}
+    <!-- The agent edited one of its own setup scripts (issue #340). Not an error,
+         so this is an informational banner (primary accent, not destructive): it
+         names what changed and why, shows the new script, and links to the task,
+         with a dismiss that acknowledges it server-side so it clears for good. -->
+    <Alert.Root class="mx-6 mt-4 flex items-start justify-between gap-4 border-primary/40">
+      <div class="min-w-0">
+        <Alert.Title class="flex items-center gap-1.5">
+          <Wrench class="size-4 flex-none" />
+          Agent updated the setup script: {change.target === 'base'
+            ? 'environment setup'
+            : (change.repo_full_name ?? 'a repository')}
+        </Alert.Title>
+        <Alert.Description class="break-words">
+          {#if change.summary}
+            <span class="block">{change.summary}</span>
+          {/if}
+          <pre
+            class="mt-1 max-h-40 overflow-auto rounded-md border border-border bg-muted/40 p-2 font-mono text-xs whitespace-pre-wrap">{change.new_script ||
+              '(empty script)'}</pre>
+          {#if change.target === 'base'}
+            <span class="mt-1 block text-xs opacity-80">
+              Takes effect on the next workspace provision/recreate.
+            </span>
+          {/if}
+          {#if change.task_id}
+            <a href={`/task/${change.task_id}`} class="mt-1 inline-block text-xs underline">
+              Open the task that made this change
+            </a>
+          {/if}
+        </Alert.Description>
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        class="flex-none"
+        title="Dismiss"
+        aria-label="Dismiss setup-script change"
+        onclick={() => dismissSetupChange(change.id)}
       >
         <X class="size-4" />
       </Button>

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -219,10 +219,13 @@ COPY seraphim-state /usr/local/bin/seraphim-state
 COPY seraphim-draft /usr/local/bin/seraphim-draft
 COPY seraphim-screenshot /usr/local/bin/seraphim-screenshot
 COPY seraphim-followup /usr/local/bin/seraphim-followup
+# The Seraphim MCP server (issue #340): a stdio MCP the agent uses to edit its own
+# setup scripts. Registered at user scope by the entrypoint, like the Playwright MCP.
+COPY seraphim-mcp /usr/local/bin/seraphim-mcp
 RUN chmod +x /usr/local/bin/seraphim-suggest /usr/local/bin/seraphim-ask \
     /usr/local/bin/seraphim-comment /usr/local/bin/seraphim-state \
     /usr/local/bin/seraphim-draft /usr/local/bin/seraphim-screenshot \
-    /usr/local/bin/seraphim-followup
+    /usr/local/bin/seraphim-followup /usr/local/bin/seraphim-mcp
 
 # --- Computed-style check library for visual self-review (issue #245) ---------
 # The deterministic CSS checks (centering/spacing/overflow/stacking) the agent

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -111,5 +111,21 @@ if command -v playwright-mcp >/dev/null 2>&1; then
   ' || echo "warning: could not register the Playwright MCP; visual self-review will be unavailable" >&2
 fi
 
+# --- Seraphim MCP: let the agent edit its own setup scripts (issue #340) -------
+# A stdio MCP server the agent uses to read and update the setup scripts Seraphim
+# runs (a repo's setup_script or the global environment setup), so it can apply an
+# environment optimization itself, not only recommend it. Registered at USER scope
+# in the same CLAUDE_CONFIG_DIR/.claude.json so a `claude -p ... --permission-mode
+# bypassPermissions` turn loads it with no approval gate. Idempotent (remove-then-
+# add) and survives the config-repo checkout, exactly like the Playwright MCP.
+# It reads SERAPHIM_API_URL / SERAPHIM_TASK_ID, injected per turn into the claude
+# exec whose child the server inherits. Best-effort: a failure never blocks idling.
+if command -v seraphim-mcp >/dev/null 2>&1; then
+  runuser -u "${AGENT_USER}" -- env CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR}" bash -c '
+    claude mcp remove -s user seraphim >/dev/null 2>&1 || true
+    claude mcp add -s user seraphim -- seraphim-mcp >/dev/null 2>&1
+  ' || echo "warning: could not register the Seraphim MCP; setup-script self-edits will be unavailable" >&2
+fi
+
 # Hand off to the idle command (tail -f /dev/null).
 exec "$@"

--- a/workspace/seraphim-mcp
+++ b/workspace/seraphim-mcp
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// seraphim-mcp: an MCP server that lets the agent edit its own setup scripts (issue #340).
+//
+// Registered at user scope by the workspace entrypoint (`claude mcp add -s user
+// seraphim -- seraphim-mcp`), so a `claude -p --permission-mode bypassPermissions`
+// turn loads it with no approval gate, exactly like the Playwright MCP. It exposes
+// three tools backed by the Seraphim API:
+//   - list_setup_scripts      read the current base + per-repo setup scripts
+//   - update_repo_setup_script  replace one repo's setup_script
+//   - update_base_setup_script  replace the global environment-setup script
+//
+// So the agent can APPLY an environment optimization it spots (e.g. "add
+// `cd frontend && yarn install` so UI tasks build immediately"), not just
+// recommend it. Every update is recorded by the API and surfaced to the operator
+// (a board banner + a notification), so the autonomy is never silent.
+//
+// This is a hand-rolled stdio MCP server (newline-delimited JSON-RPC 2.0), zero
+// dependencies like the other `seraphim-*` helpers. It reads SERAPHIM_API_URL and
+// (when inside a task turn) SERAPHIM_TASK_ID from its environment, inherited from
+// the `claude` process the orchestrator execs.
+
+const SERVER_NAME = 'seraphim'
+const SERVER_VERSION = '1.0.0'
+// Echoed back to a client that requests it; else this recent protocol revision.
+const DEFAULT_PROTOCOL_VERSION = '2025-06-18'
+
+const API_URL = process.env.SERAPHIM_API_URL
+const TASK_ID = process.env.SERAPHIM_TASK_ID
+
+// Only stderr is safe to log to: stdout carries the JSON-RPC stream.
+function log(message) {
+  process.stderr.write(`seraphim-mcp: ${message}\n`)
+}
+
+// --- Tool definitions --------------------------------------------------------
+
+const TOOLS = [
+  {
+    name: 'list_setup_scripts',
+    description:
+      'List the current setup scripts Seraphim runs: the global base (environment) ' +
+      'setup script and each repository\'s per-repo setup_script. Call this first to ' +
+      'read what exists before proposing an edit.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
+    name: 'update_repo_setup_script',
+    description:
+      "Replace a repository's setup_script (runs after each clone; before every task " +
+      'when setup_script_always_run is on). Use this to bake in a repo-specific setup ' +
+      'step you had to run by hand, e.g. installing dependencies. Read the current ' +
+      'script with list_setup_scripts first and send the full new script. The change ' +
+      'is recorded and shown to the operator.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: "The repository: its owner/name, its short name, or its id."
+        },
+        setup_script: {
+          type: 'string',
+          description: 'The full new setup script (replaces the existing one).'
+        },
+        summary: {
+          type: 'string',
+          description: 'A one-line reason for the change, shown to the operator.'
+        }
+      },
+      required: ['repo', 'setup_script', 'summary'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'update_base_setup_script',
+    description:
+      'Replace the global base (environment) setup script, which runs once per ' +
+      'workspace provision/recreate. Use this only for a truly global tool or step; ' +
+      'prefer update_repo_setup_script for anything repo-specific. The change takes ' +
+      'effect on the next workspace provision/recreate. It is recorded and shown to ' +
+      'the operator.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        setup_script: {
+          type: 'string',
+          description: 'The full new base setup script (replaces the existing one).'
+        },
+        summary: {
+          type: 'string',
+          description: 'A one-line reason for the change, shown to the operator.'
+        }
+      },
+      required: ['setup_script', 'summary'],
+      additionalProperties: false
+    }
+  }
+]
+
+// --- API helpers -------------------------------------------------------------
+
+async function apiGet(path) {
+  const response = await fetch(`${API_URL}${path}`)
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`the API returned HTTP ${response.status}: ${text}`)
+  }
+  return text ? JSON.parse(text) : {}
+}
+
+async function apiPost(path, body) {
+  const response = await fetch(`${API_URL}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    // The API returns { "error": "..." } for a bad request; surface that verbatim.
+    let detail = text
+    try {
+      detail = JSON.parse(text)?.error ?? text
+    } catch {
+      // Non-JSON body; use it as is.
+    }
+    throw new Error(detail || `the API returned HTTP ${response.status}`)
+  }
+  return text ? JSON.parse(text) : {}
+}
+
+// --- Tool handlers -----------------------------------------------------------
+
+async function callTool(name, args) {
+  if (!API_URL) {
+    throw new Error('SERAPHIM_API_URL is not set (it is injected by the orchestrator per turn)')
+  }
+
+  if (name === 'list_setup_scripts') {
+    const data = await apiGet('/api/v1/agent/setup-scripts')
+    return JSON.stringify(data, null, 2)
+  }
+
+  if (name === 'update_repo_setup_script') {
+    const change = await apiPost('/api/v1/agent/setup-scripts/repo', {
+      task_id: TASK_ID,
+      repo: String(args?.repo ?? ''),
+      setup_script: String(args?.setup_script ?? ''),
+      summary: String(args?.summary ?? '')
+    })
+    return `Updated the setup script for ${change?.change?.repo_full_name ?? args?.repo}. The operator has been notified.`
+  }
+
+  if (name === 'update_base_setup_script') {
+    await apiPost('/api/v1/agent/setup-scripts/base', {
+      task_id: TASK_ID,
+      setup_script: String(args?.setup_script ?? ''),
+      summary: String(args?.summary ?? '')
+    })
+    return 'Updated the base (environment) setup script. It takes effect on the next workspace provision/recreate. The operator has been notified.'
+  }
+
+  throw new Error(`unknown tool '${name}'`)
+}
+
+// --- JSON-RPC over newline-delimited stdio -----------------------------------
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`)
+}
+
+function sendResult(id, result) {
+  send({ jsonrpc: '2.0', id, result })
+}
+
+function sendError(id, code, message) {
+  send({ jsonrpc: '2.0', id, error: { code, message } })
+}
+
+async function handleMessage(message) {
+  const { id, method, params } = message
+  // A response has no method; a notification has no id. We only act on requests
+  // (and the initialized notification, which needs no reply).
+  const isRequest = method !== undefined && id !== undefined && id !== null
+
+  if (method === 'initialize') {
+    const protocolVersion =
+      typeof params?.protocolVersion === 'string' ? params.protocolVersion : DEFAULT_PROTOCOL_VERSION
+    sendResult(id, {
+      protocolVersion,
+      capabilities: { tools: {} },
+      serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+      instructions:
+        'Edit the setup scripts Seraphim runs for its repos. List them first, then ' +
+        'update a repo\'s setup_script or the base environment script. Changes are ' +
+        'recorded and shown to the operator.'
+    })
+    return
+  }
+
+  if (method === 'notifications/initialized') {
+    return
+  }
+
+  if (method === 'ping') {
+    sendResult(id, {})
+    return
+  }
+
+  if (method === 'tools/list') {
+    sendResult(id, { tools: TOOLS })
+    return
+  }
+
+  if (method === 'tools/call') {
+    const toolName = params?.name
+    try {
+      const text = await callTool(toolName, params?.arguments ?? {})
+      sendResult(id, { content: [{ type: 'text', text }] })
+    } catch (error) {
+      // A tool failure is reported inside the result (isError), not as a protocol
+      // error, so the model sees the message and can correct itself.
+      sendResult(id, { content: [{ type: 'text', text: `Error: ${error.message}` }], isError: true })
+    }
+    return
+  }
+
+  // Any other request method is unsupported; notifications are ignored silently.
+  if (isRequest) {
+    sendError(id, -32601, `method not found: ${method}`)
+  }
+}
+
+function main() {
+  let buffer = ''
+  process.stdin.setEncoding('utf8')
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk
+    let newline
+    while ((newline = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      if (!line) {
+        continue
+      }
+      let message
+      try {
+        message = JSON.parse(line)
+      } catch (error) {
+        log(`ignoring unparseable line: ${error.message}`)
+        continue
+      }
+      // Handle sequentially; each handler awaits its own API call. Errors are
+      // contained per message so one bad call never tears down the server.
+      handleMessage(message).catch((error) => log(`handler error: ${error.message}`))
+    }
+  })
+  process.stdin.on('end', () => process.exit(0))
+}
+
+main()


### PR DESCRIPTION
Closes #340.

## Why

When the agent spots an environment optimization (the motivating example: "add `cd frontend && yarn install` so UI tasks build immediately"), it could only recommend it via `seraphim-suggest` and wait for a human. This gives the agent the autonomy to apply setup-script changes itself, with full accountability so the operator always knows.

## What changed

**Seraphim MCP** (`workspace/seraphim-mcp`)
- A hand-rolled, zero-dependency stdio MCP server (newline-delimited JSON-RPC 2.0), consistent with the existing `seraphim-*` helpers. Registered at user scope by the entrypoint alongside the Playwright MCP, so a `claude -p --permission-mode bypassPermissions` turn loads it with no approval gate.
- Tools: `list_setup_scripts`, `update_repo_setup_script`, `update_base_setup_script`. It reads `SERAPHIM_API_URL` / `SERAPHIM_TASK_ID` (injected per turn into the `claude` exec it is a child of).

**API** (`http/setup_scripts.rs`, migration `0048`)
- `GET /agent/setup-scripts` returns the base + per-repo scripts to read first.
- `POST /agent/setup-scripts/repo` and `/base` replace a repo's `setup_script` or the global `base_setup_script`, resolving a repo by id / `owner/name` / unambiguous short name.
- Every edit records a `setup_script_changes` row (before/after, `target`, `summary`, `task_id`). No-op edits are rejected so the audit holds only real changes.

**Never silent** (record + make the operator aware)
- The board payload carries unacknowledged changes; the board shows a banner (script + reason + link to the task), dismissed via `POST /setup-changes/:id/ack`.
- A one-time toast + native notification fires (`ServerEvent::SetupScriptChanged` -> the notifications sidebar).

**Prompt**: a standing `SETUP_SCRIPT_AUTONOMY` instruction tells the agent it can apply the change itself, with accountability, or fall back to `seraphim-suggest` when unsure.

## Testing

- `cargo +1.88 fmt --check`, `clippy --all-targets`, `test` (182 pass, incl. new repo-reference resolver tests). Migration applies on a throwaway Postgres.
- `npm run check` (0 errors/warnings) and `npm run build`.
- The MCP was exercised end-to-end against a live API (ephemeral Postgres): validated the protocol handshake (`initialize` / `tools/list` / `ping`), then `list_setup_scripts`, `update_repo_setup_script` (multiline), and `update_base_setup_script`. Confirmed the DB was updated, the change was recorded, the board payload carried it, no-op edits 400, and `ack` cleared it.
- Visual self-review via the Playwright MCP: the board banner (script + summary + task link, distinct from error banners) and the live SSE toast both render, verified at 375px and 1280px with no page overflow.