### PR TITLE
Add a lightweight LiteLLM proxy sidecar service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,22 @@ SSH_HOME=/home/youruser/.ssh
 # single-threaded sessions.
 CLAUDE_MODEL=claude-opus-4-8[1m]
 
+# --- LiteLLM proxy (optional; opt-in via the `llm` compose profile) -----------
+# A lightweight LiteLLM sidecar (issue #342) that will let Seraphim drive any
+# LiteLLM-supported LLM (OpenAI, xAI Grok, Moonshot Kimi, ...) through one
+# Anthropic-compatible endpoint. It is NOT wired into the agent yet and does not
+# start by default; bring it up with `docker compose --profile llm up -d`.
+# Edit routes in `litellm/config.yaml`.
+#
+# Master key clients use to authenticate to the proxy. Generate your own strong
+# value; the placeholder below MUST be changed before exposing anything.
+LITELLM_MASTER_KEY=sk-seraphim-litellm-change-me-8Ftq2Zx9
+# Provider API keys the proxy routes use. Leave blank for providers you don't use;
+# an unset key just makes that route fail at call time (the proxy still starts).
+OPENAI_API_KEY=
+XAI_API_KEY=
+MOONSHOT_API_KEY=
+
 # --- Tailscale ----------------------------------------------------------------
 # Auth key from https://login.tailscale.com/admin/settings/keys (reusable +
 # ephemeral recommended for a container). Leave blank to skip Tailscale and use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Five Compose services (`docker-compose.yml`):
 | `frontend` | SvelteKit | Kanban UI, live task stream, settings |
 | `workspace` | Custom image | Long-lived agent sandbox (Claude Code + toolchain) |
 | `tailscale` | Tailscale | Exposes the UI over the tailnet with HTTPS |
+| `litellm` | LiteLLM proxy | **Opt-in** sidecar (`llm` profile): translates other LLMs to the Anthropic API (issue #342) |
 
 **Control flow:** the `api` is the brain. The `workspace` is a powerful-but-dumb
 sandbox; the API reaches in via `docker exec` (bollard) over the mounted host
@@ -81,6 +82,7 @@ api/        Rust backend (see below)
 frontend/   SvelteKit UI
 workspace/  Dockerfile + entrypoint.sh (the agent sandbox image)
 tailscale/  serve.json
+litellm/    config.yaml + README (opt-in LiteLLM proxy sidecar, issue #342)
 scripts/    start.sh stop.sh restart.sh
 ```
 
@@ -617,6 +619,9 @@ docker compose build --no-cache <svc>     # clean rebuild if needed
 docker compose ps
 docker compose logs api --tail 50
 docker compose down           # stop, keep volumes (scripts/stop.sh)
+
+# Opt-in LiteLLM proxy sidecar (issue #342): off by default, `llm` profile
+docker compose --profile llm up -d litellm
 ```
 
 `.env` (gitignored) holds the Postgres creds (bootstrap), ports, `SSH_HOME`,
@@ -640,6 +645,30 @@ turn is in progress, pauses the agent, then launches a detached `docker:cli`
 -d --build`; being outside the compose project, it survives the API being rebuilt.
 The UI then polls `/version` and reloads when the commit changes. `HOST_REPO_DIR`
 is the only new required env for the in-app update (the check works without it).
+
+## LiteLLM proxy sidecar (issue #342)
+
+Groundwork toward running the agent on any LiteLLM-supported LLM (OpenAI, xAI
+Grok, Moonshot Kimi, ...). The `litellm` compose service is a **lightweight**
+LiteLLM proxy: it translates other providers' message shapes to and from the
+Anthropic Messages API (`/v1/messages`) that the Claude Code CLI speaks. Lives in
+`litellm/` (`config.yaml` = the model routes, `README.md` = the how-to).
+
+- **Lightweight** = proxy only, no database (no `DATABASE_URL` / `STORE_MODEL_IN_DB`,
+  so it skips Prisma and boots from `config.yaml`), no admin UI (`DISABLE_ADMIN_UI`),
+  no telemetry. The `ghcr.io/berriai/litellm` image (pinned) is the DB-free proxy;
+  the `litellm-database` variant is the heavier one, deliberately not used.
+- **Opt-in.** It only starts under the `llm` profile
+  (`docker compose --profile llm up -d litellm`), so a default deployment carries
+  no extra container. Internal-only, reachable at `http://litellm:4000`; not exposed
+  on a host port.
+- **Config.** Routes in `litellm/config.yaml` map a requested `model_name` to a
+  `<provider>/<model>`. Keys come from `.env` (`LITELLM_MASTER_KEY` for client auth;
+  `OPENAI_API_KEY` / `XAI_API_KEY` / `MOONSHOT_API_KEY` for the routes); an unset
+  provider key just fails that route at call time, so the proxy still starts.
+- **Not wired in yet.** Selecting a model per credential and pointing the agent's
+  `claude` exec at the proxy (`ANTHROPIC_BASE_URL=http://litellm:4000`) is future
+  work (issue #341). This sidecar is the translation layer that will build on.
 
 ## Local dev / checks (must pass before committing)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,45 @@ services:
     networks:
       - seraphim
 
+  # Lightweight LiteLLM proxy sidecar (issue #342). Groundwork to eventually drive
+  # any LiteLLM-supported LLM (OpenAI, xAI Grok, Moonshot Kimi, ...) through one
+  # Anthropic-compatible endpoint the Claude Code CLI can be pointed at. It runs in
+  # LiteLLM's lightweight mode: no database, no admin UI, no telemetry. Opt-in and
+  # NOT wired into the agent yet, so it only starts under the `llm` profile
+  # (`docker compose --profile llm up -d`); a default deployment carries no extra
+  # container until model routing lands. Reachable in-cluster at http://litellm:4000.
+  litellm:
+    container_name: seraphim-litellm
+    # Pinned; the plain `litellm` image is the DB-free proxy (the `-database`
+    # variant is the heavier one). Bump deliberately, per the version-pinning rule.
+    image: ghcr.io/berriai/litellm:v1.93.0
+    profiles: ["llm"]
+    restart: unless-stopped
+    command: ["--config", "/etc/litellm/config.yaml", "--port", "4000", "--num_workers", "1"]
+    environment:
+      # No DATABASE_URL / STORE_MODEL_IN_DB is set, so the proxy skips the database
+      # entirely; the admin UI is disabled too. This is the lightweight deployment.
+      DISABLE_ADMIN_UI: "True"
+      # Auth for clients hitting the proxy, plus the provider keys the routes use.
+      # All from `.env`; an unset provider key just makes that route fail at call
+      # time, so the proxy still starts with none configured.
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
+      MOONSHOT_API_KEY: ${MOONSHOT_API_KEY:-}
+    volumes:
+      - ./litellm/config.yaml:/etc/litellm/config.yaml:ro
+    networks:
+      - seraphim
+    healthcheck:
+      # The image is Python-based (no curl/wget guaranteed); urllib is always here.
+      # /health/liveliness needs no auth and returns 200 once the proxy is serving.
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   tailscale:
     container_name: seraphim-tailscale
     image: tailscale/tailscale:latest

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -1,0 +1,52 @@
+# LiteLLM proxy sidecar
+
+A lightweight [LiteLLM](https://docs.litellm.ai/) proxy that translates other
+providers' message shapes into the Anthropic Messages API the Claude Code CLI
+speaks. It is the groundwork (issue #342) for eventually running Seraphim's agent
+on any LiteLLM-supported LLM (OpenAI, xAI Grok, Moonshot Kimi, and more).
+
+## Lightweight by design
+
+The full LiteLLM platform ships a database, an admin UI, and spend logging. This
+sidecar runs the proxy **only**:
+
+- **No database.** `DATABASE_URL` / `STORE_MODEL_IN_DB` are never set, so the
+  proxy skips Prisma entirely and boots from `config.yaml` alone.
+- **No admin UI.** `DISABLE_ADMIN_UI=True`.
+- **No telemetry.** `litellm_settings.telemetry: false`.
+
+## Opt-in
+
+It is not wired into the agent yet and does not start by default. It only runs
+under the `llm` compose profile:
+
+```bash
+docker compose --profile llm up -d litellm
+```
+
+In-cluster it is reachable at `http://litellm:4000`; it is not exposed on a host
+port.
+
+## Configure
+
+- Routes live in [`config.yaml`](./config.yaml). Each entry maps a `model_name`
+  (what a client requests) to a `<provider>/<model>` route. The listed models are
+  examples; edit them for your accounts.
+- API keys come from the environment (`.env`): `LITELLM_MASTER_KEY` (clients
+  authenticate to the proxy with this), plus `OPENAI_API_KEY`, `XAI_API_KEY`,
+  `MOONSHOT_API_KEY`. A route whose key is unset just fails at call time, so the
+  proxy still starts with none configured.
+
+## Eventual usage
+
+LiteLLM exposes an Anthropic-compatible endpoint at `/v1/messages`. To drive the
+agent through it later, point the Claude Code CLI at the proxy
+(`ANTHROPIC_BASE_URL=http://litellm:4000`, auth = the master key) and request one
+of the configured `model_name`s. Selecting a model per credential is future work
+(issue #341); this sidecar is the translation layer it will build on.
+
+## Bump the version
+
+The image is pinned in `docker-compose.yml` (`ghcr.io/berriai/litellm:<version>`).
+Bump it deliberately; the plain `litellm` image is the DB-free proxy (the
+`litellm-database` variant is the heavier one).

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,0 +1,57 @@
+# Lightweight LiteLLM proxy config for Seraphim (issue #342).
+#
+# Groundwork so Seraphim can eventually drive any LiteLLM-supported LLM through a
+# single Anthropic-compatible endpoint the Claude Code CLI understands: point the
+# CLI at the proxy (ANTHROPIC_BASE_URL=http://litellm:4000, auth = the master key)
+# and LiteLLM translates the provider's own message shapes to and from the
+# Anthropic Messages API. This file is not wired into the agent yet; it is the
+# config the sidecar boots from.
+#
+# The sidecar runs in LiteLLM's LIGHTWEIGHT mode: no database, no admin UI, no
+# telemetry. It reads provider API keys from the environment (see `.env`); a route
+# whose key is unset simply fails at call time, so the proxy still starts with
+# none configured.
+#
+# The models below are EXAMPLES to edit for your accounts. `model_name` is the id
+# a client requests; `litellm_params.model` is LiteLLM's `<provider>/<model>`
+# route. Provider references:
+#   OpenAI:   https://docs.litellm.ai/docs/providers/openai
+#   xAI Grok: https://docs.litellm.ai/docs/providers/xai
+#   Moonshot: https://docs.litellm.ai/docs/providers/moonshot
+
+model_list:
+  # OpenAI (ChatGPT).
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-4.1
+    litellm_params:
+      model: openai/gpt-4.1
+      api_key: os.environ/OPENAI_API_KEY
+
+  # xAI Grok.
+  - model_name: grok-4
+    litellm_params:
+      model: xai/grok-4
+      api_key: os.environ/XAI_API_KEY
+
+  # Moonshot Kimi.
+  - model_name: kimi-k2
+    litellm_params:
+      model: moonshot/kimi-k2-0711-preview
+      api_key: os.environ/MOONSHOT_API_KEY
+
+litellm_settings:
+  # This is a self-hosted sidecar; never phone home.
+  telemetry: false
+  # Silently drop a provider-unsupported parameter instead of erroring, so a
+  # request shaped for one model still routes cleanly to a provider that lacks a
+  # given field. This is what makes the Anthropic <-> other-provider translation
+  # forgiving across differing schemas.
+  drop_params: true
+
+general_settings:
+  # Clients (eventually the Claude Code CLI via ANTHROPIC_BASE_URL) authenticate
+  # to the proxy with this key. Set it in `.env`; never commit a real one.
+  master_key: os.environ/LITELLM_MASTER_KEY


### PR DESCRIPTION
Closes #342.

## Why

Groundwork toward running Seraphim's agent on any LiteLLM-supported LLM (OpenAI, xAI Grok, Moonshot Kimi, and more). LiteLLM's full platform is heavy (its own database, admin UI, spend logging); this adds only the proxy, which translates other providers' message shapes to and from the Anthropic Messages API (`/v1/messages`) that the Claude Code CLI speaks.

## What changed

- **`litellm` compose service** (`docker-compose.yml`): the LiteLLM proxy in **lightweight mode**: no database (no `DATABASE_URL` / `STORE_MODEL_IN_DB`, so it skips Prisma and boots from `config.yaml`), no admin UI (`DISABLE_ADMIN_UI`), no telemetry. Pinned to `ghcr.io/berriai/litellm:v1.93.0` (the plain image is the DB-free proxy; the `-database` variant is the heavier one). Health-checked via `/health/liveliness`.
- **Opt-in**: it only starts under the `llm` compose profile (`docker compose --profile llm up -d litellm`), so a default deployment carries no extra container until model routing is wired up (issue #341). Internal-only, reachable at `http://litellm:4000`; no host port.
- **`litellm/config.yaml`**: example model routes for OpenAI / xAI / Moonshot (edit for your accounts), keyed to env-var API keys, `telemetry: false`, `drop_params: true`, master-key auth.
- **`litellm/README.md`**: what it is, how to enable, and the eventual wiring (`ANTHROPIC_BASE_URL` -> the proxy).
- **`.env.example`**: optional `LITELLM_MASTER_KEY` + `OPENAI_API_KEY` / `XAI_API_KEY` / `MOONSHOT_API_KEY`, with blank defaults so the proxy still starts with none configured.
- **`CLAUDE.md`**: documented the sidecar (architecture table, repo layout, a dedicated section, launch note).

## Testing

- `docker compose config` validates the file parses; profile gating confirmed (litellm is absent by default, present under `--profile llm`).
- Booted the pinned image in isolation (standalone container, not the compose project) with this exact `config.yaml`. Confirmed it: starts **DB-free** (no Prisma/database in logs), loads the routes (`/v1/models` returns `gpt-4o, gpt-4.1, grok-4, kimi-k2`), serves `/health/liveliness`, and **accepts an Anthropic-shaped `POST /v1/messages` and translates/routes it to the provider** (xAI returned a no-credentials 401, i.e. the request reached the provider through the Anthropic endpoint).
- No app code changed (infra + config + docs only), so the Rust/frontend builds are unaffected. Source-hygiene check passes.
- Visual self-review: skipped, this is a backend/infra change with no UI.