### PR TITLE
Support multiple Claude credentials with priority rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,10 @@ the mounted SSH keys, never by code.
 - **Orchestration:** Docker Compose is the primary deployment method.
 - **Exposure:** Tailscale sidecar (`tailscale serve`); `scripts/{start,stop,restart}.sh` wrappers.
 - **Hosts:** Windows 11 + Linux only (all services are Linux containers). No macOS.
-- **Claude auth:** subscription only, **no API key**. Token from `claude setup-token`.
+- **Claude auth:** multiple credentials with priority rotation (issue #341), managed
+  on Settings -> LLMs. Any mix of subscription OAuth logins, long-lived setup-tokens
+  (`claude setup-token`), and Anthropic API keys; the agent runs on the highest
+  priority one and rotates to the next when it hits its usage limit.
 - **Secrets (Claude OAuth + GitHub tokens):** stored in the **database** (Settings UI), never in `.env`; injected into the agent's execs at runtime.
 - **Agent trigger:** auto-pulls the top of **To Do** when idle (global pause switch exists).
 - **Workspace model:** all enabled repos cloned flat under `/workspace`; Claude spawned at `/workspace` for cross-repo work.
@@ -117,14 +120,13 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 - **`settings`** — single row (`id=1`): org profile, `global_instructions`,
   `default_review_policy`, `agent_paused`, `claude_model`, `base_setup_script`
   (= environment setup), `config_repo_url`, `default_branch_template`,
-  `current_session_id` (the one shared Claude session), the secret columns
-  `claude_oauth_token` / `github_token` (the API only ever exposes
-  `*_token_set` booleans plus a masked `*_token_preview`, never the raw values;
-  write via `POST /settings/tokens`), the connected Claude account's
-  `claude_account_email` (captured from the subscription OAuth token-exchange /
-  refresh response and shown next to the environment name on the board, issue
-  #269; blank for a pasted setup-token or API key), and the optional
-  **availability schedule**
+  `current_session_id` (the one shared Claude session), the secret column
+  `github_token` (the API only ever exposes `*_token_set` booleans plus a masked
+  `*_token_preview`, never the raw values; write via `POST /settings/tokens`).
+  The Claude credentials moved off this row into `llm_credentials` (issue #341, see
+  below); the usage-pause columns (`usage_limit_pause_enabled`,
+  `usage_limit_threshold`, `usage_paused_until`) stay here since they gate the whole
+  agent. It also holds the optional **availability schedule**
   (`availability_enabled`, `availability_timezone` (IANA), `availability_windows`
   JSONB, `availability_skip_dates` JSONB). When enabled, the agent only pulls new
   work during the configured weekly windows in the operator's time zone, skipping
@@ -141,6 +143,30 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   Attention sounds fire on the `notification`/`heart_attack` SSE events; the
   completion sound fires on a new `task_finished` SSE event emitted from the
   review loop's auto-merge-to-Done path (`ServerEvent::TaskFinished`).
+- **`llm_credentials`** (issue #341) — the priority-ordered Claude credentials the
+  agent rotates through, managed on the **Settings -> LLMs** subpage. Each row is a
+  `kind` (`subscription_oauth` | `setup_token` | `api_key`), a `label`, a fractional
+  `position` (lower runs first), `enabled`, the inference `secret`, the refreshing
+  OAuth material (subscription OAuth only), `account_email`, an `exhausted_until`
+  rotation timer, a `last_error`, and a provider-agnostic `provider` + `base_url`
+  (empty = Anthropic direct; a non-Anthropic provider is reached through the LiteLLM
+  sidecar's Anthropic endpoint, issue #342). The API never returns raw secrets, only
+  a masked `LlmCredentialView` (`GET /credentials`); mutations are
+  `POST /credentials/{oauth/start,oauth/finish,token,api-key,reorder}`,
+  `PATCH/DELETE /credentials/:id`. The rotation core is `orchestrator::credentials`:
+  `active_credential` resolves the highest-priority available credential (enabled,
+  has a secret, not exhausted) and refreshes its OAuth token ahead of expiry; a turn
+  runs on it (`TurnArgs.credential_kind`/`oauth_token`/`base_url`, exec injects
+  `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`, plus `ANTHROPIC_BASE_URL` when a
+  base URL is set). On a `rate_limit_event` the active credential is marked
+  `exhausted_until` the reset and `reconcile_pause` either rotates to the next
+  credential (clears the global pause) or, when EVERY credential is exhausted, sets
+  `settings.usage_paused_until` to the soonest reset. The board header shows the
+  active credential's email/label (`board.active_credential`); the usage gauge polls
+  the active subscription-OAuth credential when its consent granted `user:profile`.
+  `next_actionable_task` stays idle when `has_usable_credential` is false (none
+  configured or all exhausted). On first run, migration `0049` moves any existing
+  single credential off the `settings` row into this table as entry #1.
 - **`environment_variables`** — user-defined `key` / `value` / `is_secret` rows,
   injected into the agent's turn and setup execs at runtime. A secret value is
   scrubbed out of Claude's output before anything is persisted or streamed
@@ -769,11 +795,14 @@ Playwright MCP, check layout via computed styles at 375px and 1280px).
   write-back.
 - **MooreslabAI human-review commenting** — `GitHubSource::comment` exists but is
   unused (`#[expect(dead_code)]`).
-- **Subscription usage auto-pause** — when `usage_limit_pause_enabled`, a Claude
+- **Usage-limit rotation + auto-pause** — when `usage_limit_pause_enabled`, a Claude
   `rate_limit_event` that crosses `usage_limit_threshold` (or a rejected/exhausted
-  window) sets `settings.usage_paused_until` to the window's reset time (pure
-  decision in `orchestrator::usage::pause_until`); `next_actionable_task` holds all
-  new work until that time, then auto-clears it. Escape hatches (issue #292):
+  window; pure decision in `orchestrator::usage::pause_until`) marks the **active
+  credential** `exhausted_until` the window reset and rotates to the next credential
+  by priority (issue #341, `orchestrator::credentials::mark_exhausted_and_reconcile`).
+  Only when EVERY credential is exhausted does `reconcile_pause` set
+  `settings.usage_paused_until` to the soonest reset, and `next_actionable_task`
+  holds all new work until then, then auto-clears it. Escape hatches (issue #292):
   `POST /settings/usage/resume` clears the pause now (the board banner and the
   Settings usage section each have a "Resume now" button), and every settings
   update runs `orchestrator::reevaluate_usage_pause`, which lifts an active pause

--- a/api/migrations/0049_llm_credentials.sql
+++ b/api/migrations/0049_llm_credentials.sql
@@ -1,0 +1,91 @@
+-- Multiple Claude credentials with priority rotation (issue #341).
+--
+-- Replaces the single credential that lived on the `settings` row with a
+-- first-class, priority-ordered table. The agent runs on the highest-priority
+-- usable credential; when one hits its usage limit it is marked exhausted and the
+-- agent rotates to the next, pausing only when every credential is exhausted.
+--
+-- The schema is provider-agnostic so other LLMs can be added later (issue #342's
+-- LiteLLM sidecar): `provider` names the logical provider and `base_url` is the
+-- Anthropic-compatible endpoint a non-Anthropic credential is reached through
+-- (empty = Anthropic direct). Today only `anthropic` with the three Claude kinds.
+
+CREATE TABLE llm_credentials (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Logical provider. 'anthropic' today; future: 'openai', 'xai', 'moonshot', ...
+    provider TEXT NOT NULL DEFAULT 'anthropic',
+    -- How the credential authenticates the Claude Code CLI:
+    --   'subscription_oauth' -> CLAUDE_CODE_OAUTH_TOKEN, refreshing OAuth pair + usage gauge
+    --   'setup_token'        -> CLAUDE_CODE_OAUTH_TOKEN, long-lived pasted token, no refresh
+    --   'api_key'            -> ANTHROPIC_API_KEY
+    kind TEXT NOT NULL CHECK (kind IN ('subscription_oauth', 'setup_token', 'api_key')),
+    -- Operator-facing name (seeded from the account email for OAuth logins).
+    label TEXT NOT NULL DEFAULT '',
+    -- Priority: lower runs first. Fractional so a drag-drop reorder rewrites rows cheaply.
+    position DOUBLE PRECISION NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    -- The inference credential the agent runs on: the sk-ant-oat token, or the API key.
+    secret TEXT NOT NULL DEFAULT '',
+    -- Refreshing OAuth material (subscription_oauth only; empty for the other kinds).
+    oauth_access_token TEXT NOT NULL DEFAULT '',
+    oauth_refresh_token TEXT NOT NULL DEFAULT '',
+    oauth_expires_at TIMESTAMPTZ,
+    oauth_scopes TEXT NOT NULL DEFAULT '',
+    account_email TEXT NOT NULL DEFAULT '',
+    -- Future non-Anthropic routing via the LiteLLM sidecar (ANTHROPIC_BASE_URL).
+    -- Empty = talk to Anthropic directly.
+    base_url TEXT NOT NULL DEFAULT '',
+    -- Rotation state: until when this credential is unavailable after hitting its
+    -- usage window. NULL = available; cleared lazily once the reset time passes.
+    exhausted_until TIMESTAMPTZ,
+    -- Last failure reason (an exhausted window, a dead refresh token), shown on the
+    -- LLMs page so the operator can act. NULL when the credential is healthy.
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The rotation query orders enabled credentials by priority.
+CREATE INDEX llm_credentials_priority_idx ON llm_credentials (enabled, position);
+
+-- Migrate the existing single credential (if any) into the table as entry #1.
+-- The kind is inferred from the old auth mode: an API key stays an API key; a
+-- subscription with a stored refresh token is an OAuth login; a subscription
+-- without one is a manually pasted setup-token.
+INSERT INTO llm_credentials (
+    provider, kind, label, position, enabled, secret,
+    oauth_access_token, oauth_refresh_token, oauth_expires_at, oauth_scopes, account_email
+)
+SELECT
+    'anthropic',
+    CASE
+        WHEN claude_auth_mode = 'api_key' THEN 'api_key'
+        WHEN claude_usage_refresh_token <> '' THEN 'subscription_oauth'
+        ELSE 'setup_token'
+    END,
+    claude_account_email,
+    1000,
+    TRUE,
+    claude_oauth_token,
+    claude_usage_access_token,
+    claude_usage_refresh_token,
+    claude_usage_expires_at,
+    claude_usage_scopes,
+    claude_account_email
+FROM settings
+WHERE id = 1 AND claude_oauth_token <> '';
+
+-- The per-credential columns now live in llm_credentials; drop them from settings.
+-- The global usage-pause controls (usage_limit_pause_enabled, usage_limit_threshold,
+-- usage_paused_until) stay: they gate the whole agent when ALL credentials exhaust.
+ALTER TABLE settings
+    DROP COLUMN claude_oauth_token,
+    DROP COLUMN claude_auth_mode,
+    DROP COLUMN claude_usage_access_token,
+    DROP COLUMN claude_usage_refresh_token,
+    DROP COLUMN claude_usage_expires_at,
+    DROP COLUMN claude_usage_scopes,
+    DROP COLUMN claude_account_email;
+
+-- The enum backed only the dropped column; remove it so it does not dangle.
+DROP TYPE IF EXISTS claude_auth_mode;

--- a/api/src/claude/exec.rs
+++ b/api/src/claude/exec.rs
@@ -12,7 +12,7 @@ use eyre::{eyre, Result};
 use futures::{Stream, StreamExt};
 
 use super::events::{parse_line, AgentEvent};
-use crate::db::models::ClaudeAuthMode;
+use crate::db::models::CredentialKind;
 
 /// Everything needed to run one turn of the long-lived conversation.
 #[derive(Debug, Clone)]
@@ -27,12 +27,17 @@ pub struct TurnArgs {
     pub resume_session_id: Option<String>,
     /// Model id, e.g. `claude-opus-4-8[1m]`.
     pub model: String,
-    /// How [`Self::oauth_token`] is injected: a subscription token becomes
-    /// `CLAUDE_CODE_OAUTH_TOKEN`; an API key becomes `ANTHROPIC_API_KEY`.
-    pub auth_mode: ClaudeAuthMode,
-    /// The Claude credential (subscription token or API key), injected into the
-    /// exec env per [`Self::auth_mode`] (never baked into the container).
+    /// The kind of the active credential (issue #341): the two subscription kinds
+    /// inject [`Self::oauth_token`] as `CLAUDE_CODE_OAUTH_TOKEN`; an API key injects
+    /// it as `ANTHROPIC_API_KEY`.
+    pub credential_kind: CredentialKind,
+    /// The resolved Claude credential (subscription token or API key), injected into
+    /// the exec env per [`Self::credential_kind`] (never baked into the container).
     pub oauth_token: String,
+    /// Anthropic-compatible base URL for a non-Anthropic credential routed through
+    /// the `LiteLLM` sidecar (exported as `ANTHROPIC_BASE_URL`); empty = Anthropic
+    /// direct, so nothing is exported.
+    pub base_url: String,
     /// GitHub token, so the agent's `gh`/`git` are authed for this turn.
     pub github_token: String,
     /// The task being worked, so the agent's helpers (`seraphim-ask`,
@@ -53,9 +58,10 @@ pub struct TurnArgs {
 /// any user-defined variables. User variables come last so they cannot shadow
 /// the tokens and wiring we control.
 fn build_env(args: &TurnArgs) -> Vec<String> {
-    let credential = match args.auth_mode {
-        ClaudeAuthMode::Subscription => format!("CLAUDE_CODE_OAUTH_TOKEN={}", args.oauth_token),
-        ClaudeAuthMode::ApiKey => format!("ANTHROPIC_API_KEY={}", args.oauth_token),
+    let credential = if args.credential_kind.uses_oauth_token_env() {
+        format!("CLAUDE_CODE_OAUTH_TOKEN={}", args.oauth_token)
+    } else {
+        format!("ANTHROPIC_API_KEY={}", args.oauth_token)
     };
     let mut env = vec![
         credential,
@@ -63,6 +69,11 @@ fn build_env(args: &TurnArgs) -> Vec<String> {
         format!("SERAPHIM_TASK_ID={}", args.task_id),
         format!("SERAPHIM_API_URL={}", args.internal_api_url),
     ];
+    // A non-Anthropic credential is reached through the LiteLLM sidecar; point the
+    // CLI at it. Empty means talk to Anthropic directly, so nothing is exported.
+    if !args.base_url.is_empty() {
+        env.push(format!("ANTHROPIC_BASE_URL={}", args.base_url));
+    }
     for (key, value) in &args.env {
         env.push(format!("{key}={value}"));
     }
@@ -200,8 +211,9 @@ mod tests {
             prompt: "do the thing".to_string(),
             resume_session_id: Some("sess-1".to_string()),
             model: "claude-opus-4-8[1m]".to_string(),
-            auth_mode: ClaudeAuthMode::Subscription,
+            credential_kind: CredentialKind::SubscriptionOauth,
             oauth_token: "tok".to_string(),
+            base_url: String::new(),
             github_token: "gh".to_string(),
             task_id: "task-1".to_string(),
             internal_api_url: "http://api:27182".to_string(),
@@ -224,8 +236,9 @@ mod tests {
             prompt: "start".to_string(),
             resume_session_id: None,
             model: "claude-opus-4-8[1m]".to_string(),
-            auth_mode: ClaudeAuthMode::Subscription,
+            credential_kind: CredentialKind::SubscriptionOauth,
             oauth_token: "tok".to_string(),
+            base_url: String::new(),
             github_token: "gh".to_string(),
             task_id: "task-1".to_string(),
             internal_api_url: "http://api:27182".to_string(),

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -53,18 +53,52 @@ pub enum NetworkAccessLevel {
     Custom,
 }
 
-/// How the agent authenticates to Claude.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
-#[sqlx(type_name = "claude_auth_mode", rename_all = "snake_case")]
+/// The kind of a stored LLM credential, deciding how it authenticates the Claude
+/// Code CLI (issue #341). Stored as the `llm_credentials.kind` TEXT column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ClaudeAuthMode {
-    /// A Claude subscription token (the long-lived inference token, from the
-    /// OAuth login or a manual `setup-token`), injected as
-    /// `CLAUDE_CODE_OAUTH_TOKEN`. The default and the historical behavior.
-    Subscription,
-    /// An Anthropic API key, injected as `ANTHROPIC_API_KEY`. No subscription
-    /// usage gauge applies in this mode.
+pub enum CredentialKind {
+    /// A Claude subscription OAuth login: a refreshing access/refresh pair whose
+    /// access token runs the agent (injected as `CLAUDE_CODE_OAUTH_TOKEN`). The
+    /// only kind whose usage the gauge can read.
+    SubscriptionOauth,
+    /// A long-lived pasted subscription token (`claude setup-token`), injected as
+    /// `CLAUDE_CODE_OAUTH_TOKEN`. No refresh and no usage reporting.
+    SetupToken,
+    /// An Anthropic API key, injected as `ANTHROPIC_API_KEY`.
     ApiKey,
+}
+
+impl CredentialKind {
+    /// The `llm_credentials.kind` string this maps to.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SubscriptionOauth => "subscription_oauth",
+            Self::SetupToken => "setup_token",
+            Self::ApiKey => "api_key",
+        }
+    }
+
+    /// Parses a stored `kind` string, returning `None` for an unknown value.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "subscription_oauth" => Some(Self::SubscriptionOauth),
+            "setup_token" => Some(Self::SetupToken),
+            "api_key" => Some(Self::ApiKey),
+            _ => None,
+        }
+    }
+
+    /// Whether the secret is injected as `CLAUDE_CODE_OAUTH_TOKEN` (both Claude
+    /// subscription kinds) rather than `ANTHROPIC_API_KEY` (an API key).
+    pub fn uses_oauth_token_env(self) -> bool {
+        !matches!(self, Self::ApiKey)
+    }
+
+    /// Whether this kind refreshes an OAuth token pair (subscription OAuth only).
+    pub fn refreshes_oauth(self) -> bool {
+        matches!(self, Self::SubscriptionOauth)
+    }
 }
 
 /// Which Jira deployment we are talking to, which decides both the auth scheme
@@ -203,18 +237,6 @@ pub struct Settings {
     /// no longer read or written as the live session. A later migration drops it.
     pub current_session_id: Option<String>,
     pub updated_at: DateTime<Utc>,
-    /// Whether a Claude OAuth token is stored (the token itself is never sent).
-    pub claude_token_set: bool,
-    /// How the agent authenticates to Claude (subscription token vs API key).
-    pub claude_auth_mode: ClaudeAuthMode,
-    /// The connected Claude account's email, shown next to the environment name on
-    /// the board (issue #269). Captured from the OAuth token response; empty for a
-    /// manually pasted setup-token or API key, where no account identity is known.
-    pub claude_account_email: String,
-    /// Whether subscription usage credentials are stored (the refreshing
-    /// access/refresh pair used only to poll the usage gauge). Only meaningful in
-    /// `subscription` mode; the tokens themselves are never sent.
-    pub claude_usage_token_set: bool,
     /// Whether a GitHub token is stored (the token itself is never sent).
     pub github_token_set: bool,
     /// When true, the agent only works during [`Self::availability_windows`].
@@ -284,16 +306,12 @@ pub struct Settings {
     /// [`Self::attention_sound_custom`]).
     pub completion_sound_custom: bool,
     /// Masked preview of the stored Jira API token. Filled like
-    /// [`Self::claude_token_preview`].
+    /// [`Self::github_token_preview`].
     #[sqlx(default)]
     pub jira_token_preview: Option<String>,
-    /// Masked preview of the stored Claude token, e.g. `sk-ant-****abcd`. Not a
-    /// DB column; the settings handler fills it from the raw token so an operator
-    /// can recognize what is stored without it being revealed.
-    #[sqlx(default)]
-    pub claude_token_preview: Option<String>,
-    /// Masked preview of the stored GitHub token. Filled like
-    /// [`Self::claude_token_preview`].
+    /// Masked preview of the stored GitHub token. Not a DB column; the settings
+    /// handler fills it from the raw token so an operator can recognize what is
+    /// stored without it being revealed.
     #[sqlx(default)]
     pub github_token_preview: Option<String>,
     /// Runtime UI signal: while set and in the future, the agent is in a brief
@@ -304,17 +322,75 @@ pub struct Settings {
     pub cooldown_until: Option<DateTime<Utc>>,
 }
 
-/// The refreshing OAuth credentials from a subscription login: the short-lived
-/// access token the agent runs on, its long-lived refresh token, and the expiry.
-/// All-empty when no subscription login is configured. Never serialized to clients.
+/// A stored LLM credential (issue #341): one entry in the priority-ordered
+/// `llm_credentials` table the agent rotates through. Holds the raw secret and
+/// OAuth material, so it is NEVER serialized to clients ([`LlmCredentialView`] is).
 #[derive(Debug, Clone, sqlx::FromRow)]
-pub struct ClaudeUsageCredentials {
-    pub access_token: String,
-    pub refresh_token: String,
-    pub expires_at: Option<DateTime<Utc>>,
-    /// The scopes the consent granted, space-separated. Used to decide whether the
-    /// usage gauge (`/api/oauth/usage`, needs `user:profile`) can be polled.
-    pub scopes: String,
+pub struct LlmCredential {
+    pub id: Uuid,
+    /// Logical provider (`anthropic` today; other LLMs later via the `LiteLLM` sidecar).
+    pub provider: String,
+    /// The [`CredentialKind`] string: `subscription_oauth` / `setup_token` / `api_key`.
+    pub kind: String,
+    pub label: String,
+    /// Priority rank; lower runs first.
+    pub position: f64,
+    pub enabled: bool,
+    /// The inference credential the agent runs on (the sk-ant-oat token or API key).
+    pub secret: String,
+    /// Refreshing OAuth material (subscription OAuth only; empty otherwise).
+    pub oauth_access_token: String,
+    pub oauth_refresh_token: String,
+    pub oauth_expires_at: Option<DateTime<Utc>>,
+    /// Scopes the consent granted, space-separated. `user:profile` authorizes the
+    /// usage gauge.
+    pub oauth_scopes: String,
+    pub account_email: String,
+    /// Anthropic-compatible endpoint for a non-Anthropic credential (`ANTHROPIC_BASE_URL`);
+    /// empty = Anthropic direct.
+    pub base_url: String,
+    /// When set and in the future, this credential is out of quota until then.
+    pub exhausted_until: Option<DateTime<Utc>>,
+    /// Last failure reason (exhausted window, dead refresh token); `None` = healthy.
+    pub last_error: Option<String>,
+}
+
+impl LlmCredential {
+    /// The parsed [`CredentialKind`], or `None` if the stored string is unknown.
+    pub fn parsed_kind(&self) -> Option<CredentialKind> {
+        CredentialKind::parse(&self.kind)
+    }
+
+    /// Whether the credential can be used right now: enabled, has a secret, and is
+    /// not currently exhausted (its window has reset, or it never hit one).
+    pub fn is_available(&self, now: DateTime<Utc>) -> bool {
+        self.enabled
+            && !self.secret.is_empty()
+            && self.exhausted_until.is_none_or(|until| until <= now)
+    }
+}
+
+/// The masked, client-facing view of an [`LlmCredential`] (issue #341). Carries no
+/// raw secret or OAuth material, mirroring how [`Settings`] exposes only previews.
+/// `token_preview` / `available` / `active` are filled by the handler.
+#[derive(Debug, Clone, Serialize)]
+pub struct LlmCredentialView {
+    pub id: Uuid,
+    pub provider: String,
+    pub kind: String,
+    pub label: String,
+    pub position: f64,
+    pub enabled: bool,
+    /// Masked preview of the stored secret, e.g. `sk-ant-****abcd`.
+    pub token_preview: Option<String>,
+    pub account_email: String,
+    pub base_url: String,
+    pub exhausted_until: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+    /// Usable right now (enabled, has a secret, not exhausted).
+    pub available: bool,
+    /// The credential the agent is currently running on (highest-priority available).
+    pub active: bool,
 }
 
 /// A user-defined environment variable injected into the agent's execs.

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -13,8 +13,8 @@ use uuid::Uuid;
 
 use super::models::{
     AggregatedSuggestion, AnomalousEmptyPr, AnswerKind, AutomationRule, AvailabilityWindow,
-    ClaudeUsageCredentials, DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack,
-    InternalComment, JiraBoard, JiraDeployment, NetworkAccessLevel, PendingPlacement,
+    DependencyCandidate, EnvSuggestion, EnvVar, EnvVarWrite, HeartAttack, InternalComment,
+    JiraBoard, JiraDeployment, LlmCredential, NetworkAccessLevel, PendingPlacement,
     PendingQuestion, Question, QuestionOption, QuestionStatus, Railway, RepoDeletionImpact,
     RepoSyncError, ReposDeletionImpact, Repository, ReviewPolicy, Settings, SetupScriptChange,
     SourceKind, StatsAggregate, Task, TaskAttachment, TaskColumn, TaskPullRequest, TaskScreenshot,
@@ -31,9 +31,6 @@ const SETTINGS_COLUMNS: &str =
     "org_name, global_instructions, default_review_policy, agent_paused, \
      claude_model, workspace_image_tag, base_setup_script, config_repo_url, \
      default_branch_template, config_repo_error, current_session_id, updated_at, \
-     (claude_oauth_token <> '') AS claude_token_set, \
-     claude_auth_mode, claude_account_email, \
-     (claude_usage_refresh_token <> '') AS claude_usage_token_set, \
      (github_token <> '') AS github_token_set, \
      availability_enabled, availability_timezone, availability_windows, \
      availability_skip_dates, network_access_level, network_access_domains, \
@@ -222,13 +219,6 @@ pub async fn set_config_repo_error(pool: &PgPool, error: Option<&str>) -> sqlx::
     Ok(())
 }
 
-/// The stored Claude OAuth token (empty string if unset). Internal use only.
-pub async fn get_claude_token(pool: &PgPool) -> sqlx::Result<String> {
-    sqlx::query_scalar("SELECT claude_oauth_token FROM settings WHERE id = 1")
-        .fetch_one(pool)
-        .await
-}
-
 /// The stored GitHub token (empty string if unset). Internal use only.
 pub async fn get_github_token(pool: &PgPool) -> sqlx::Result<String> {
     sqlx::query_scalar("SELECT github_token FROM settings WHERE id = 1")
@@ -258,10 +248,10 @@ pub async fn get_jira_webhook_secret(pool: &PgPool) -> sqlx::Result<String> {
 }
 
 /// Writes the app tokens and webhook secrets; `None` leaves the existing value
-/// untouched (so the UI can update one without resending the others).
+/// untouched (so the UI can update one without resending the others). The Claude
+/// credential is no longer here: it lives in `llm_credentials` (issue #341).
 pub async fn set_tokens(
     pool: &PgPool,
-    claude_oauth_token: Option<String>,
     github_token: Option<String>,
     jira_api_token: Option<String>,
     github_webhook_secret: Option<String>,
@@ -269,14 +259,12 @@ pub async fn set_tokens(
 ) -> sqlx::Result<()> {
     sqlx::query(
         "UPDATE settings SET \
-         claude_oauth_token = COALESCE($1, claude_oauth_token), \
-         github_token = COALESCE($2, github_token), \
-         jira_api_token = COALESCE($3, jira_api_token), \
-         github_webhook_secret = COALESCE($4, github_webhook_secret), \
-         jira_webhook_secret = COALESCE($5, jira_webhook_secret), \
+         github_token = COALESCE($1, github_token), \
+         jira_api_token = COALESCE($2, jira_api_token), \
+         github_webhook_secret = COALESCE($3, github_webhook_secret), \
+         jira_webhook_secret = COALESCE($4, jira_webhook_secret), \
          updated_at = now() WHERE id = 1",
     )
-    .bind(claude_oauth_token)
     .bind(github_token)
     .bind(jira_api_token)
     .bind(github_webhook_secret)
@@ -286,97 +274,184 @@ pub async fn set_tokens(
     Ok(())
 }
 
-/// The refreshing OAuth credentials from a subscription login (all-empty when none
-/// is configured). Drives both the on-demand inference-token refresh and the usage
-/// gauge. Internal use only.
-pub async fn get_usage_credentials(pool: &PgPool) -> sqlx::Result<ClaudeUsageCredentials> {
-    sqlx::query_as::<_, ClaudeUsageCredentials>(
-        "SELECT claude_usage_access_token AS access_token, \
-         claude_usage_refresh_token AS refresh_token, \
-         claude_usage_expires_at AS expires_at, \
-         claude_usage_scopes AS scopes FROM settings WHERE id = 1",
+// --- LLM credentials (issue #341) --------------------------------------------
+//
+// The priority-ordered credentials the agent rotates through. Rows carry the raw
+// secret + OAuth material, so these are internal; the HTTP layer masks them into
+// `LlmCredentialView`. Ordered by `position` ascending (lower runs first).
+
+/// Every stored credential, highest priority first. Internal use only.
+pub async fn list_llm_credentials(pool: &PgPool) -> sqlx::Result<Vec<LlmCredential>> {
+    sqlx::query_as::<_, LlmCredential>("SELECT * FROM llm_credentials ORDER BY position ASC")
+        .fetch_all(pool)
+        .await
+}
+
+/// One credential by id, or `None` if it was deleted. Internal use only.
+pub async fn get_llm_credential(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<LlmCredential>> {
+    sqlx::query_as::<_, LlmCredential>("SELECT * FROM llm_credentials WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+}
+
+/// Appends a new credential at the bottom of the priority list (lowest priority).
+/// Returns the created row.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_llm_credential(
+    pool: &PgPool,
+    provider: &str,
+    kind: &str,
+    label: &str,
+    secret: &str,
+    oauth_access_token: &str,
+    oauth_refresh_token: &str,
+    oauth_expires_at: Option<DateTime<Utc>>,
+    oauth_scopes: &str,
+    account_email: &str,
+) -> sqlx::Result<LlmCredential> {
+    // Land after the current last entry, leaving room so a later reorder is cheap.
+    sqlx::query_as::<_, LlmCredential>(
+        "INSERT INTO llm_credentials \
+           (provider, kind, label, position, secret, oauth_access_token, \
+            oauth_refresh_token, oauth_expires_at, oauth_scopes, account_email) \
+         VALUES ($1, $2, $3, \
+           COALESCE((SELECT MAX(position) FROM llm_credentials), 0) + 1000, \
+           $4, $5, $6, $7, $8, $9) \
+         RETURNING *",
+    )
+    .bind(provider)
+    .bind(kind)
+    .bind(label)
+    .bind(secret)
+    .bind(oauth_access_token)
+    .bind(oauth_refresh_token)
+    .bind(oauth_expires_at)
+    .bind(oauth_scopes)
+    .bind(account_email)
+    .fetch_one(pool)
+    .await
+}
+
+/// Updates a credential's editable metadata (label and/or enabled). A `None`
+/// argument leaves that field unchanged. Returns the updated row.
+pub async fn update_llm_credential(
+    pool: &PgPool,
+    id: Uuid,
+    label: Option<&str>,
+    enabled: Option<bool>,
+) -> sqlx::Result<LlmCredential> {
+    sqlx::query_as::<_, LlmCredential>(
+        "UPDATE llm_credentials SET \
+         label = COALESCE($2, label), \
+         enabled = COALESCE($3, enabled), \
+         updated_at = now() WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(label)
+    .bind(enabled)
+    .fetch_one(pool)
+    .await
+}
+
+/// Deletes a credential. Returns whether a row was removed.
+pub async fn delete_llm_credential(pool: &PgPool, id: Uuid) -> sqlx::Result<bool> {
+    let result = sqlx::query("DELETE FROM llm_credentials WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Rewrites the priority order: each id's `position` becomes its index in the list
+/// (times a step, leaving room), so the agent tries them in exactly this order.
+pub async fn reorder_llm_credentials(pool: &PgPool, ids: &[Uuid]) -> sqlx::Result<()> {
+    let mut tx = pool.begin().await?;
+    for (index, id) in ids.iter().enumerate() {
+        // f64 from a small index is exact; the step keeps room for a future insert.
+        let position = (index as f64) * 1000.0;
+        sqlx::query("UPDATE llm_credentials SET position = $2, updated_at = now() WHERE id = $1")
+            .bind(id)
+            .bind(position)
+            .execute(&mut *tx)
+            .await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Persists a refreshed subscription OAuth token on one credential: the new access
+/// token becomes both the inference `secret` and the usage copy, the rotated
+/// refresh token is kept when returned (empty keeps the existing one), and a
+/// successful refresh clears any recorded error. Mirrors the old `set_oauth_tokens`.
+pub async fn set_credential_oauth_tokens(
+    pool: &PgPool,
+    id: Uuid,
+    access_token: &str,
+    refresh_token: &str,
+    expires_at: DateTime<Utc>,
+    account_email: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE llm_credentials SET secret = $2, oauth_access_token = $2, \
+         oauth_refresh_token = COALESCE(NULLIF($3, ''), oauth_refresh_token), \
+         oauth_expires_at = $4, \
+         account_email = COALESCE(NULLIF($5, ''), account_email), \
+         last_error = NULL, updated_at = now() WHERE id = $1",
+    )
+    .bind(id)
+    .bind(access_token)
+    .bind(refresh_token)
+    .bind(expires_at)
+    .bind(account_email)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Marks a credential unavailable until `until`, recording why. Used both for a
+/// usage-limit window (the reset time) and a failed refresh (a short cooldown).
+pub async fn set_credential_exhausted(
+    pool: &PgPool,
+    id: Uuid,
+    until: DateTime<Utc>,
+    reason: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE llm_credentials SET exhausted_until = $2, last_error = $3, \
+         updated_at = now() WHERE id = $1",
+    )
+    .bind(id)
+    .bind(until)
+    .bind(reason)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Whether any credential is usable right now: enabled, has a secret, and not
+/// currently exhausted. A cheap gate the agent loop checks before pulling work, so
+/// it stays idle when nothing is configured or everything is exhausted.
+pub async fn has_usable_credential(pool: &PgPool) -> sqlx::Result<bool> {
+    sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM llm_credentials \
+         WHERE enabled = TRUE AND secret <> '' \
+         AND (exhausted_until IS NULL OR exhausted_until <= now()))",
     )
     .fetch_one(pool)
     .await
 }
 
-/// Persists a completed subscription OAuth login: the long-lived inference token
-/// the agent runs on, plus the refreshing usage credentials, switching auth mode
-/// to `subscription`.
-pub async fn set_subscription_credentials(
-    pool: &PgPool,
-    inference_token: &str,
-    access_token: &str,
-    refresh_token: &str,
-    expires_at: DateTime<Utc>,
-    scopes: &str,
-    account_email: &str,
-) -> sqlx::Result<()> {
-    // An empty `account_email` keeps the stored one rather than wiping it, so a
-    // response that happens to omit the account never blanks a known email.
-    sqlx::query(
-        "UPDATE settings SET claude_oauth_token = $1, claude_auth_mode = 'subscription', \
-         claude_usage_access_token = $2, claude_usage_refresh_token = $3, \
-         claude_usage_expires_at = $4, claude_usage_scopes = $5, \
-         claude_account_email = COALESCE(NULLIF($6, ''), claude_account_email), \
-         updated_at = now() WHERE id = 1",
+/// The soonest `exhausted_until` across enabled, exhausted credentials, i.e. when
+/// the first one frees up. `None` when no enabled credential is exhausted. Drives
+/// the global usage pause once every credential is exhausted.
+pub async fn earliest_credential_reset(pool: &PgPool) -> sqlx::Result<Option<DateTime<Utc>>> {
+    sqlx::query_scalar(
+        "SELECT MIN(exhausted_until) FROM llm_credentials \
+         WHERE enabled = TRUE AND exhausted_until IS NOT NULL",
     )
-    .bind(inference_token)
-    .bind(access_token)
-    .bind(refresh_token)
-    .bind(expires_at)
-    .bind(scopes)
-    .bind(account_email)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-/// Persists a refreshed subscription token. The new access token becomes both the
-/// inference credential the agent runs on (`claude_oauth_token`) and the usage
-/// copy, keeping them in lockstep; the rotated refresh token is stored when the
-/// endpoint returned one (an empty `refresh_token` keeps the existing one).
-pub async fn set_oauth_tokens(
-    pool: &PgPool,
-    access_token: &str,
-    refresh_token: &str,
-    expires_at: DateTime<Utc>,
-    account_email: &str,
-) -> sqlx::Result<()> {
-    // Like the refresh token, an empty `account_email` keeps the existing value, so
-    // a refresh response that omits the account never blanks a known email. This is
-    // also how an install that connected before #269 backfills its email: the first
-    // refresh that returns an account populates it without a reconnect.
-    sqlx::query(
-        "UPDATE settings SET claude_oauth_token = $1, claude_usage_access_token = $1, \
-         claude_usage_refresh_token = COALESCE(NULLIF($2, ''), claude_usage_refresh_token), \
-         claude_usage_expires_at = $3, \
-         claude_account_email = COALESCE(NULLIF($4, ''), claude_account_email), \
-         updated_at = now() WHERE id = 1",
-    )
-    .bind(access_token)
-    .bind(refresh_token)
-    .bind(expires_at)
-    .bind(account_email)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-/// Switches to API-key auth: stores the key as the inference credential and clears
-/// the subscription usage credentials (the gauge does not apply).
-pub async fn set_api_key(pool: &PgPool, api_key: &str) -> sqlx::Result<()> {
-    sqlx::query(
-        "UPDATE settings SET claude_oauth_token = $1, claude_auth_mode = 'api_key', \
-         claude_usage_access_token = '', claude_usage_refresh_token = '', \
-         claude_usage_expires_at = NULL, claude_usage_scopes = '', \
-         claude_account_email = '', updated_at = now() \
-         WHERE id = 1",
-    )
-    .bind(api_key)
-    .execute(pool)
-    .await?;
-    Ok(())
+    .fetch_one(pool)
+    .await
 }
 
 // --- Notification sounds ------------------------------------------------------
@@ -441,21 +516,21 @@ pub async fn list_environment_variables(pool: &PgPool) -> sqlx::Result<Vec<EnvVa
 }
 
 /// Every secret value that should be scrubbed from agent output: the secret
-/// environment variables plus the stored Claude, GitHub, and Jira tokens. Empty
-/// values are omitted.
+/// environment variables, the GitHub and Jira tokens, and every stored LLM
+/// credential's secret + OAuth material (issue #341). Empty values are omitted.
 pub async fn list_secret_values(pool: &PgPool) -> sqlx::Result<Vec<String>> {
     let values: Vec<String> = sqlx::query_scalar(
         "SELECT value FROM environment_variables WHERE is_secret = TRUE AND value <> '' \
-         UNION ALL \
-         SELECT claude_oauth_token FROM settings WHERE id = 1 AND claude_oauth_token <> '' \
          UNION ALL \
          SELECT github_token FROM settings WHERE id = 1 AND github_token <> '' \
          UNION ALL \
          SELECT jira_api_token FROM settings WHERE id = 1 AND jira_api_token <> '' \
          UNION ALL \
-         SELECT claude_usage_access_token FROM settings WHERE id = 1 AND claude_usage_access_token <> '' \
+         SELECT secret FROM llm_credentials WHERE secret <> '' \
          UNION ALL \
-         SELECT claude_usage_refresh_token FROM settings WHERE id = 1 AND claude_usage_refresh_token <> ''",
+         SELECT oauth_access_token FROM llm_credentials WHERE oauth_access_token <> '' \
+         UNION ALL \
+         SELECT oauth_refresh_token FROM llm_credentials WHERE oauth_refresh_token <> ''",
     )
     .fetch_all(pool)
     .await?;

--- a/api/src/http/board.rs
+++ b/api/src/http/board.rs
@@ -47,6 +47,9 @@ pub struct BoardResponse {
     /// newest first, so the board banner shows what changed until the operator
     /// clears it.
     pub setup_script_changes: Vec<SetupScriptChange>,
+    /// The Claude credential the agent is currently running on (issue #341), so the
+    /// board header can show its account/label. `None` when none is usable.
+    pub active_credential: Option<orchestrator::credentials::ActiveCredentialSummary>,
 }
 
 /// `GET /api/v1/board` - every card, the org/pause settings, per-card counts of
@@ -65,6 +68,7 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
     let repo_sync_errors = queries::list_repo_sync_errors(&state.db).await?;
     let anomalous_empty_prs = queries::list_anomalous_empty_prs(&state.db).await?;
     let setup_script_changes = queries::list_unacknowledged_setup_changes(&state.db).await?;
+    let active_credential = orchestrator::credentials::active_summary(&state).await?;
     Ok(Json(BoardResponse {
         tasks,
         settings,
@@ -74,6 +78,7 @@ pub async fn get_board(State(state): State<AppState>) -> ApiResult<Json<BoardRes
         repo_sync_errors,
         anomalous_empty_prs,
         setup_script_changes,
+        active_credential,
     }))
 }
 

--- a/api/src/http/credentials.rs
+++ b/api/src/http/credentials.rs
@@ -1,0 +1,248 @@
+//! Multiple Claude credentials with priority rotation (issue #341).
+//!
+//! Backs the Settings -> LLMs subpage: list the priority-ordered credentials, add a
+//! new one (a subscription OAuth login, a pasted setup-token, or an API key),
+//! reorder them by drag-and-drop, edit a label / enable flag, and delete. The raw
+//! secrets never leave the database; the list returns masked [`LlmCredentialView`]s.
+//!
+//! The agent runs on the highest-priority available credential and rotates to the
+//! next when one is rate-limited; that logic lives in
+//! [`crate::orchestrator::credentials`].
+
+use axum::extract::{Path, State};
+use axum::Json;
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
+
+use super::ApiResult;
+use crate::db::models::{CredentialKind, LlmCredentialView};
+use crate::db::queries;
+use crate::orchestrator;
+use crate::secrets::mask;
+use crate::state::AppState;
+
+/// Builds the masked, priority-ordered view of the stored credentials, marking the
+/// one the agent is currently running on (the highest-priority available one).
+async fn list_views(state: &AppState) -> ApiResult<Vec<LlmCredentialView>> {
+    let now = Utc::now();
+    let credentials = queries::list_llm_credentials(&state.db).await?;
+    // The active credential is simply the first available one in priority order.
+    let active_id = credentials
+        .iter()
+        .find(|credential| credential.is_available(now))
+        .map(|credential| credential.id);
+    let views = credentials
+        .into_iter()
+        .map(|credential| {
+            let available = credential.is_available(now);
+            LlmCredentialView {
+                id: credential.id,
+                provider: credential.provider,
+                kind: credential.kind,
+                label: credential.label,
+                position: credential.position,
+                enabled: credential.enabled,
+                token_preview: (!credential.secret.is_empty()).then(|| mask(&credential.secret)),
+                account_email: credential.account_email,
+                base_url: credential.base_url,
+                // Only surface an exhaustion that is still in the future.
+                exhausted_until: credential.exhausted_until.filter(|until| *until > now),
+                last_error: credential.last_error,
+                available,
+                active: active_id == Some(credential.id),
+            }
+        })
+        .collect();
+    Ok(views)
+}
+
+/// `GET /api/v1/credentials` - the priority-ordered credential list (masked).
+pub async fn list(State(state): State<AppState>) -> ApiResult<Json<Vec<LlmCredentialView>>> {
+    Ok(Json(list_views(&state).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReorderRequest {
+    /// Credential ids in the new priority order (first = highest priority).
+    pub ids: Vec<Uuid>,
+}
+
+/// `POST /api/v1/credentials/reorder` - set the priority order from a drag-drop.
+pub async fn reorder(
+    State(state): State<AppState>,
+    Json(body): Json<ReorderRequest>,
+) -> ApiResult<Json<Vec<LlmCredentialView>>> {
+    queries::reorder_llm_credentials(&state.db, &body.ids).await?;
+    // A reorder can change which credential is active; refresh the board header.
+    orchestrator::credentials::reconcile_pause(&state).await?;
+    Ok(Json(list_views(&state).await?))
+}
+
+#[derive(Debug, Serialize)]
+pub struct OauthStartResponse {
+    /// The consent URL to open in a new tab.
+    pub authorize_url: String,
+}
+
+/// `POST /api/v1/credentials/oauth/start` - begin a Claude subscription OAuth login.
+/// Returns the consent URL; the PKCE secrets are held server-side until the operator
+/// pastes the resulting code back via `.../oauth/finish`.
+pub async fn oauth_start(State(state): State<AppState>) -> ApiResult<Json<OauthStartResponse>> {
+    let (authorize_url, pending) = crate::claude::oauth::start();
+    state.set_pending_oauth(pending);
+    Ok(Json(OauthStartResponse { authorize_url }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OauthFinishRequest {
+    /// The value from the consent callback page (`<code>#<state>` or a bare code).
+    pub code: String,
+    /// Optional operator label; defaults to the connected account's email.
+    #[serde(default)]
+    pub label: String,
+}
+
+/// `POST /api/v1/credentials/oauth/finish` - complete the login and store a new
+/// subscription-OAuth credential (appended at the bottom of the priority list).
+pub async fn oauth_finish(
+    State(state): State<AppState>,
+    Json(body): Json<OauthFinishRequest>,
+) -> ApiResult<Json<Vec<LlmCredentialView>>> {
+    let Some(pending) = state.take_pending_oauth() else {
+        return Err(eyre::eyre!("no Claude login is in progress; start one first").into());
+    };
+    let tokens =
+        crate::claude::oauth::exchange_code(&body.code, &pending.verifier, &pending.state).await?;
+    // The OAuth access token IS the long-lived inference token the agent runs on
+    // (exactly what `claude setup-token` returns); it is both the `secret` and the
+    // usage access token.
+    let expires_at = Utc::now() + Duration::seconds(tokens.expires_in);
+    let label = pick_label(&body.label, &tokens.account_email);
+    queries::create_llm_credential(
+        &state.db,
+        "anthropic",
+        CredentialKind::SubscriptionOauth.as_str(),
+        &label,
+        &tokens.access_token,
+        &tokens.access_token,
+        &tokens.refresh_token,
+        Some(expires_at),
+        &tokens.scopes,
+        &tokens.account_email,
+    )
+    .await?;
+    // A newly added credential may lift an all-exhausted pause.
+    orchestrator::credentials::reconcile_pause(&state).await?;
+    Ok(Json(list_views(&state).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddTokenRequest {
+    /// The long-lived subscription token (`claude setup-token`, `sk-ant-oat01-...`).
+    pub token: String,
+    #[serde(default)]
+    pub label: String,
+}
+
+/// `POST /api/v1/credentials/token` - add a long-lived pasted subscription token.
+pub async fn add_setup_token(
+    State(state): State<AppState>,
+    Json(body): Json<AddTokenRequest>,
+) -> ApiResult<Json<Vec<LlmCredentialView>>> {
+    let token = body.token.trim();
+    if token.is_empty() {
+        return Err(eyre::eyre!("the token is empty").into());
+    }
+    let label = pick_label(&body.label, "");
+    queries::create_llm_credential(
+        &state.db,
+        "anthropic",
+        CredentialKind::SetupToken.as_str(),
+        &label,
+        token,
+        "",
+        "",
+        None,
+        "",
+        "",
+    )
+    .await?;
+    orchestrator::credentials::reconcile_pause(&state).await?;
+    Ok(Json(list_views(&state).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddApiKeyRequest {
+    pub api_key: String,
+    #[serde(default)]
+    pub label: String,
+}
+
+/// `POST /api/v1/credentials/api-key` - add an Anthropic API key.
+pub async fn add_api_key(
+    State(state): State<AppState>,
+    Json(body): Json<AddApiKeyRequest>,
+) -> ApiResult<Json<Vec<LlmCredentialView>>> {
+    let key = body.api_key.trim();
+    if key.is_empty() {
+        return Err(eyre::eyre!("the API key is empty").into());
+    }
+    let label = pick_label(&body.label, "");
+    queries::create_llm_credential(
+        &state.db,
+        "anthropic",
+        CredentialKind::ApiKey.as_str(),
+        &label,
+        key,
+        "",
+        "",
+        None,
+        "",
+        "",
+    )
+    .await?;
+    orchestrator::credentials::reconcile_pause(&state).await?;
+    Ok(Json(list_views(&state).await?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateRequest {
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// `PATCH /api/v1/credentials/:id` - rename or enable/disable a credential.
+pub async fn update(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateRequest>,
+) -> ApiResult<Json<Vec<LlmCredentialView>>> {
+    queries::update_llm_credential(&state.db, id, body.label.as_deref(), body.enabled).await?;
+    // Enabling/disabling can change which credential is active or lift/raise a pause.
+    orchestrator::credentials::reconcile_pause(&state).await?;
+    Ok(Json(list_views(&state).await?))
+}
+
+/// `DELETE /api/v1/credentials/:id` - remove a credential.
+pub async fn delete(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let deleted = queries::delete_llm_credential(&state.db, id).await?;
+    orchestrator::credentials::reconcile_pause(&state).await?;
+    Ok(Json(json!({ "deleted": deleted })))
+}
+
+/// Picks the label to store: the operator's trimmed input, else the account email,
+/// else a plain empty string (the UI falls back to the kind).
+fn pick_label(requested: &str, account_email: &str) -> String {
+    let requested = requested.trim();
+    if !requested.is_empty() {
+        return requested.to_string();
+    }
+    account_email.trim().to_string()
+}

--- a/api/src/http/mod.rs
+++ b/api/src/http/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod attachments;
 mod automation;
 mod board;
 mod compose;
+mod credentials;
 mod data;
 mod heart_attacks;
 mod jira;
@@ -197,15 +198,18 @@ pub fn router(state: AppState) -> Router {
         .route("/settings/usage/resume", post(settings::resume_usage))
         .route("/notepad", get(notepad::get).put(notepad::set))
         .route("/settings/tokens", post(settings::set_tokens))
+        // Multiple Claude credentials with priority rotation (issue #341): the LLMs
+        // settings subpage lists/adds/reorders them and connects new logins.
+        .route("/credentials", get(credentials::list))
+        .route("/credentials/reorder", post(credentials::reorder))
+        .route("/credentials/oauth/start", post(credentials::oauth_start))
+        .route("/credentials/oauth/finish", post(credentials::oauth_finish))
+        .route("/credentials/token", post(credentials::add_setup_token))
+        .route("/credentials/api-key", post(credentials::add_api_key))
         .route(
-            "/settings/claude/oauth/start",
-            post(settings::claude_oauth_start),
+            "/credentials/:id",
+            axum::routing::patch(credentials::update).delete(credentials::delete),
         )
-        .route(
-            "/settings/claude/oauth/finish",
-            post(settings::claude_oauth_finish),
-        )
-        .route("/settings/claude/api-key", post(settings::claude_api_key))
         .route(
             "/settings/sounds/:kind",
             get(settings::get_sound)

--- a/api/src/http/settings.rs
+++ b/api/src/http/settings.rs
@@ -10,8 +10,6 @@ use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use sqlx::types::Json as SqlxJson;
 
-use tracing::{info, warn};
-
 use super::ApiResult;
 use crate::db::models::{
     AvailabilityWindow, EnvVarWrite, JiraDeployment, NetworkAccessLevel, ReviewPolicy, Settings,
@@ -25,10 +23,8 @@ use crate::state::AppState;
 /// a recognizable hint of each stored secret without ever receiving the raw value.
 async fn settings_view(state: &AppState) -> ApiResult<Settings> {
     let mut settings = queries::get_settings(&state.db).await?;
-    let claude = queries::get_claude_token(&state.db).await?;
     let github = queries::get_github_token(&state.db).await?;
     let jira = queries::get_jira_token(&state.db).await?;
-    settings.claude_token_preview = (!claude.is_empty()).then(|| mask(&claude));
     settings.github_token_preview = (!github.is_empty()).then(|| mask(&github));
     settings.jira_token_preview = (!jira.is_empty()).then(|| mask(&jira));
     Ok(settings)
@@ -124,23 +120,23 @@ pub async fn resume_usage(State(state): State<AppState>) -> ApiResult<Json<Setti
 
 #[derive(Debug, Deserialize)]
 pub struct TokensRequest {
-    pub claude_oauth_token: Option<String>,
     pub github_token: Option<String>,
     pub jira_api_token: Option<String>,
     pub github_webhook_secret: Option<String>,
     pub jira_webhook_secret: Option<String>,
 }
 
-/// `POST /api/v1/settings/tokens` - store the app tokens and webhook secrets
-/// (write-only). Empty values are ignored so you can set one without resending
-/// the others, and the raw secrets are never returned by the API.
+/// `POST /api/v1/settings/tokens` - store the GitHub/Jira tokens and webhook
+/// secrets (write-only). Empty values are ignored so you can set one without
+/// resending the others, and the raw secrets are never returned by the API. The
+/// Claude credential lives in `llm_credentials` now (issue #341), managed via the
+/// `/credentials` endpoints.
 pub async fn set_tokens(
     State(state): State<AppState>,
     Json(body): Json<TokensRequest>,
 ) -> ApiResult<Json<Settings>> {
     queries::set_tokens(
         &state.db,
-        body.claude_oauth_token.filter(|token| !token.is_empty()),
         body.github_token.filter(|token| !token.is_empty()),
         body.jira_api_token.filter(|token| !token.is_empty()),
         body.github_webhook_secret
@@ -148,93 +144,6 @@ pub async fn set_tokens(
         body.jira_webhook_secret.filter(|secret| !secret.is_empty()),
     )
     .await?;
-    Ok(Json(settings_view(&state).await?))
-}
-
-// --- Claude authentication ---------------------------------------------------
-
-#[derive(Debug, Serialize)]
-pub struct OauthStartResponse {
-    /// The consent URL to open in a new tab.
-    pub authorize_url: String,
-}
-
-/// `POST /api/v1/settings/claude/oauth/start` - begins a Claude subscription
-/// OAuth login. Returns the consent URL; the PKCE secrets are held server-side
-/// until the operator pastes the resulting code back via `.../oauth/finish`.
-pub async fn claude_oauth_start(
-    State(state): State<AppState>,
-) -> ApiResult<Json<OauthStartResponse>> {
-    info!("Claude OAuth login started; issuing authorize URL");
-    let (authorize_url, pending) = crate::claude::oauth::start();
-    state.set_pending_oauth(pending);
-    Ok(Json(OauthStartResponse { authorize_url }))
-}
-
-#[derive(Debug, Deserialize)]
-pub struct OauthFinishRequest {
-    /// The value from the consent callback page (`<code>#<state>` or a bare code).
-    pub code: String,
-}
-
-/// `POST /api/v1/settings/claude/oauth/finish` - completes the login: exchanges
-/// the pasted code, mints the long-lived inference token the agent runs on, and
-/// stores it alongside the refreshing usage credentials (switching to
-/// subscription mode).
-pub async fn claude_oauth_finish(
-    State(state): State<AppState>,
-    Json(body): Json<OauthFinishRequest>,
-) -> ApiResult<Json<Settings>> {
-    info!("completing Claude OAuth login: exchanging code");
-    let Some(pending) = state.take_pending_oauth() else {
-        warn!("Claude OAuth finish called with no login in progress");
-        return Err(eyre::eyre!("no Claude login is in progress; start one first").into());
-    };
-    let tokens =
-        crate::claude::oauth::exchange_code(&body.code, &pending.verifier, &pending.state).await?;
-    // The OAuth access token IS the long-lived token the agent runs on (exactly
-    // what `claude setup-token` returns). There is no create_api_key mint step:
-    // that endpoint requires the `org:create_api_key` scope, which this user-scope
-    // consent does not grant (it 403s), and setup-token does not use it either.
-    info!(
-        expires_in = tokens.expires_in,
-        "Claude OAuth access token obtained; using it directly as the inference token"
-    );
-    let inference_token = tokens.access_token.clone();
-    let expires_at = chrono::Utc::now() + chrono::Duration::seconds(tokens.expires_in);
-    queries::set_subscription_credentials(
-        &state.db,
-        &inference_token,
-        &tokens.access_token,
-        &tokens.refresh_token,
-        expires_at,
-        &tokens.scopes,
-        &tokens.account_email,
-    )
-    .await?;
-    info!(
-        scopes = %tokens.scopes,
-        "Claude OAuth login completed; subscription credentials stored"
-    );
-    Ok(Json(settings_view(&state).await?))
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ApiKeyRequest {
-    pub api_key: String,
-}
-
-/// `POST /api/v1/settings/claude/api-key` - stores an Anthropic API key and
-/// switches the agent to API-key auth (no subscription usage gauge applies).
-pub async fn claude_api_key(
-    State(state): State<AppState>,
-    Json(body): Json<ApiKeyRequest>,
-) -> ApiResult<Json<Settings>> {
-    let key = body.api_key.trim();
-    if key.is_empty() {
-        return Err(eyre::eyre!("the API key is empty").into());
-    }
-    queries::set_api_key(&state.db, key).await?;
     Ok(Json(settings_view(&state).await?))
 }
 

--- a/api/src/jira/mod.rs
+++ b/api/src/jira/mod.rs
@@ -981,10 +981,6 @@ mod tests {
             config_repo_error: None,
             current_session_id: None,
             updated_at: Utc::now(),
-            claude_token_set: false,
-            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
-            claude_account_email: String::new(),
-            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,
             availability_timezone: "UTC".to_string(),
@@ -1013,7 +1009,6 @@ mod tests {
             attention_sound_custom: false,
             completion_sound_custom: false,
             jira_token_preview: None,
-            claude_token_preview: None,
             github_token_preview: None,
             cooldown_until: None,
         }

--- a/api/src/orchestrator/availability.rs
+++ b/api/src/orchestrator/availability.rs
@@ -97,10 +97,6 @@ mod tests {
             config_repo_error: None,
             current_session_id: None,
             updated_at: Utc::now(),
-            claude_token_set: false,
-            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
-            claude_account_email: String::new(),
-            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: enabled,
             availability_timezone: timezone.to_string(),
@@ -129,7 +125,6 @@ mod tests {
             attention_sound_custom: false,
             completion_sound_custom: false,
             jira_token_preview: None,
-            claude_token_preview: None,
             github_token_preview: None,
             cooldown_until: None,
         }

--- a/api/src/orchestrator/compose.rs
+++ b/api/src/orchestrator/compose.rs
@@ -15,7 +15,6 @@ use futures::StreamExt;
 use tokio::time::timeout;
 use tracing::warn;
 
-use super::subscription;
 use super::COMPOSE_PID_FILE;
 use crate::claude::run_turn as run_claude_turn;
 use crate::claude::{AgentEventKind, TurnArgs};
@@ -91,14 +90,21 @@ async fn run_inner(state: &AppState, message: String) -> Result<()> {
         .map(|variable| (variable.key, variable.value))
         .collect();
 
+    // Run on the active credential (issue #341); skip cleanly if none is usable.
+    let Some(active) = super::credentials::active_credential(state).await? else {
+        warn!("compose turn skipped: no usable Claude credential");
+        return Ok(());
+    };
+
     let args = TurnArgs {
         container: state.workspace.container().to_string(),
         working_dir: "/workspace".to_string(),
         prompt,
         resume_session_id: resume.clone(),
         model: settings.claude_model.clone(),
-        auth_mode: settings.claude_auth_mode,
-        oauth_token: subscription::fresh_inference_token(state).await?,
+        credential_kind: active.kind,
+        oauth_token: active.token,
+        base_url: active.base_url,
         github_token: queries::get_github_token(&state.db).await?,
         // No task backs the compose chat; its helper (`seraphim-draft`) posts to a
         // task-agnostic endpoint, so a label is enough here.

--- a/api/src/orchestrator/credentials.rs
+++ b/api/src/orchestrator/credentials.rs
@@ -1,0 +1,279 @@
+//! Multiple Claude credentials with priority rotation (issue #341).
+//!
+//! The agent runs on the highest-priority *available* credential (enabled, has a
+//! secret, not currently exhausted). When a turn hits its usage limit the active
+//! credential is marked exhausted and the next turn picks the next credential;
+//! only when EVERY credential is exhausted does the whole agent pause, until the
+//! soonest one frees up. This replaces the old single-credential-on-the-settings-row
+//! model and its "hitting a limit pauses everything" behavior.
+//!
+//! The schema is provider-agnostic (a `base_url` per credential routes a
+//! non-Anthropic provider through the `LiteLLM` sidecar, issue #342), so the same
+//! rotation drives any future LLM; today every credential is Anthropic.
+
+use chrono::{DateTime, Utc};
+use eyre::{eyre, Context, Result};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::claude::oauth;
+use crate::db::models::{CredentialKind, LlmCredential};
+use crate::db::queries;
+use crate::state::AppState;
+
+/// Refresh a subscription OAuth access token this many minutes before it expires,
+/// so a turn never blocks on (or briefly runs past) an expiry.
+const REFRESH_SKEW_MINUTES: i64 = 10;
+
+/// How long to sideline a credential whose OAuth refresh just failed, so the loop
+/// tries the next credential now and retries this one later instead of hot-looping
+/// on a dead refresh token. The operator sees the reason on the LLMs page.
+const REFRESH_FAILURE_COOLDOWN_MINUTES: i64 = 30;
+
+/// The resolved credential a turn runs on: the ready-to-use inference token plus the
+/// routing/identity the exec and the usage gauge need.
+#[derive(Debug, Clone)]
+pub struct ActiveCredential {
+    pub id: Uuid,
+    pub kind: CredentialKind,
+    /// The inference credential, refreshed if it was a near-expiry OAuth token.
+    pub token: String,
+    /// Anthropic-compatible base URL (`ANTHROPIC_BASE_URL`); empty = Anthropic direct.
+    pub base_url: String,
+    /// OAuth scopes (space-separated); `user:profile` authorizes the usage gauge.
+    pub scopes: String,
+}
+
+/// The highest-priority usable credential, refreshing its OAuth token if needed, or
+/// `None` when no credential is currently usable (none configured, all disabled, or
+/// all exhausted). Every turn resolves its auth here.
+pub async fn active_credential(state: &AppState) -> Result<Option<ActiveCredential>> {
+    let now = Utc::now();
+    let credentials = queries::list_llm_credentials(&state.db).await?;
+    for credential in credentials {
+        if !credential.is_available(now) {
+            continue;
+        }
+        let Some(kind) = credential.parsed_kind() else {
+            warn!(id = %credential.id, kind = %credential.kind, "skipping credential with an unknown kind");
+            continue;
+        };
+        // Subscription OAuth refreshes its short-lived access token ahead of expiry;
+        // the other kinds run on their stored secret verbatim.
+        let token = if kind.refreshes_oauth() && !credential.oauth_refresh_token.is_empty() {
+            match ensure_fresh_token(state, &credential, now).await {
+                Ok(token) => token,
+                Err(error) => {
+                    // A dead refresh token: sideline this credential briefly (so we
+                    // move to the next one now and retry it later) and continue.
+                    warn!(id = %credential.id, %error, "credential refresh failed; sidelining it");
+                    let until = now + chrono::Duration::minutes(REFRESH_FAILURE_COOLDOWN_MINUTES);
+                    let _ = queries::set_credential_exhausted(
+                        &state.db,
+                        credential.id,
+                        until,
+                        "OAuth refresh failed; reconnect this subscription in Settings -> LLMs",
+                    )
+                    .await;
+                    continue;
+                }
+            }
+        } else {
+            credential.secret.clone()
+        };
+        return Ok(Some(ActiveCredential {
+            id: credential.id,
+            kind,
+            token,
+            base_url: credential.base_url,
+            scopes: credential.oauth_scopes,
+        }));
+    }
+    Ok(None)
+}
+
+/// Whether a subscription OAuth access token has expired or is within the refresh
+/// skew of expiry. A missing expiry is treated as "refresh now".
+fn is_near_expiry(expires_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    expires_at.is_none_or(|expires_at| {
+        expires_at <= now + chrono::Duration::minutes(REFRESH_SKEW_MINUTES)
+    })
+}
+
+/// Refreshes the credential's OAuth access token when it is missing or near expiry,
+/// persisting the rotated pair; returns a usable access token. Serialized on the
+/// global refresh lock so two turns never rotate a token concurrently.
+async fn ensure_fresh_token(
+    state: &AppState,
+    credential: &LlmCredential,
+    now: DateTime<Utc>,
+) -> Result<String> {
+    if !is_near_expiry(credential.oauth_expires_at, now)
+        && !credential.oauth_access_token.is_empty()
+    {
+        return Ok(credential.secret.clone());
+    }
+    let _guard = state.claude_token_refresh().lock().await;
+    // Re-read under the lock: another turn may have already refreshed it.
+    let latest = queries::get_llm_credential(&state.db, credential.id)
+        .await?
+        .ok_or_else(|| eyre!("credential was deleted during refresh"))?;
+    if !is_near_expiry(latest.oauth_expires_at, Utc::now()) && !latest.oauth_access_token.is_empty()
+    {
+        return Ok(latest.secret);
+    }
+    let tokens = oauth::refresh(&latest.oauth_refresh_token).await.wrap_err(
+        "refreshing the Claude subscription token failed; the refresh token may be \
+         expired or revoked",
+    )?;
+    let expires_at = Utc::now() + chrono::Duration::seconds(tokens.expires_in);
+    queries::set_credential_oauth_tokens(
+        &state.db,
+        credential.id,
+        &tokens.access_token,
+        &tokens.refresh_token,
+        expires_at,
+        &tokens.account_email,
+    )
+    .await?;
+    info!(id = %credential.id, expires_in = tokens.expires_in, "refreshed a Claude subscription token");
+    Ok(tokens.access_token)
+}
+
+/// Marks the active credential exhausted until its window `reset`, then reconciles
+/// the global pause. If another credential is available the agent rotates to it (the
+/// pause is cleared); if every credential is now exhausted the agent pauses until the
+/// soonest reset. Returns `true` when it rotated, `false` when it paused.
+pub async fn mark_exhausted_and_reconcile(
+    state: &AppState,
+    credential_id: Uuid,
+    reset: DateTime<Utc>,
+    reason: &str,
+) -> Result<bool> {
+    queries::set_credential_exhausted(&state.db, credential_id, reset, reason).await?;
+    reconcile_pause(state).await
+}
+
+/// Sets or clears `settings.usage_paused_until` from the current credential state:
+/// if any credential is available now, clears the pause (the agent keeps going on
+/// the next credential); otherwise pauses until the soonest credential frees.
+/// Returns whether a credential is available.
+pub async fn reconcile_pause(state: &AppState) -> Result<bool> {
+    let now = Utc::now();
+    let credentials = queries::list_llm_credentials(&state.db).await?;
+    if credentials
+        .iter()
+        .any(|credential| credential.is_available(now))
+    {
+        queries::set_usage_paused_until(&state.db, None).await?;
+        state.notify_board();
+        return Ok(true);
+    }
+    // Every credential is exhausted or disabled: pause until the soonest one resets
+    // (None when none is on an exhaustion timer, e.g. all simply disabled).
+    let reset = queries::earliest_credential_reset(&state.db).await?;
+    queries::set_usage_paused_until(&state.db, reset).await?;
+    state.notify_board();
+    Ok(false)
+}
+
+/// A masked summary of the active credential, for the board header (issue #269's
+/// account-email display, now sourced from whichever credential is in use).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ActiveCredentialSummary {
+    pub id: Uuid,
+    pub kind: String,
+    pub label: String,
+    pub account_email: String,
+}
+
+/// The active credential summary for the settings/board payload, or `None` when no
+/// credential is usable. Does not refresh tokens (a cheap read for the board), so it
+/// picks the top available credential by priority without touching the network.
+pub async fn active_summary(state: &AppState) -> Result<Option<ActiveCredentialSummary>> {
+    let now = Utc::now();
+    let credentials = queries::list_llm_credentials(&state.db).await?;
+    Ok(credentials
+        .into_iter()
+        .find(|credential| credential.is_available(now))
+        .map(|credential| ActiveCredentialSummary {
+            id: credential.id,
+            kind: credential.kind,
+            label: credential.label,
+            account_email: credential.account_email,
+        }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credential(
+        position: f64,
+        enabled: bool,
+        secret: &str,
+        exhausted_until: Option<DateTime<Utc>>,
+    ) -> LlmCredential {
+        LlmCredential {
+            // The id is irrelevant to these tests (they check ordering/availability),
+            // so a fixed nil id keeps the fixture free of a lossy float-to-int cast.
+            id: Uuid::nil(),
+            provider: "anthropic".into(),
+            kind: "subscription_oauth".into(),
+            label: String::new(),
+            position,
+            enabled,
+            secret: secret.into(),
+            oauth_access_token: String::new(),
+            oauth_refresh_token: String::new(),
+            oauth_expires_at: None,
+            oauth_scopes: String::new(),
+            account_email: String::new(),
+            base_url: String::new(),
+            exhausted_until,
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn availability_requires_enabled_secret_and_not_exhausted() {
+        let now = Utc::now();
+        assert!(credential(0.0, true, "tok", None).is_available(now));
+        // Disabled, empty secret, and a future exhaustion each make it unavailable.
+        assert!(!credential(0.0, false, "tok", None).is_available(now));
+        assert!(!credential(0.0, true, "", None).is_available(now));
+        assert!(
+            !credential(0.0, true, "tok", Some(now + chrono::Duration::hours(1))).is_available(now)
+        );
+        // A past exhaustion has reset, so it is available again.
+        assert!(
+            credential(0.0, true, "tok", Some(now - chrono::Duration::minutes(1)))
+                .is_available(now)
+        );
+    }
+
+    #[test]
+    fn priority_picks_the_first_available_in_order() {
+        let now = Utc::now();
+        // #1 exhausted, #2 disabled, #3 available -> pick #3.
+        let creds = [
+            credential(0.0, true, "a", Some(now + chrono::Duration::hours(1))),
+            credential(1000.0, false, "b", None),
+            credential(2000.0, true, "c", None),
+        ];
+        let picked = creds.iter().position(|c| c.is_available(now));
+        assert_eq!(picked, Some(2));
+    }
+
+    #[test]
+    fn near_expiry_covers_missing_past_and_within_skew() {
+        let now = Utc::now();
+        assert!(is_near_expiry(None, now));
+        assert!(is_near_expiry(Some(now - chrono::Duration::days(1)), now));
+        assert!(is_near_expiry(
+            Some(now + chrono::Duration::minutes(REFRESH_SKEW_MINUTES - 1)),
+            now
+        ));
+        assert!(!is_near_expiry(Some(now + chrono::Duration::hours(4)), now));
+    }
+}

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -12,6 +12,9 @@
 mod availability;
 mod ci_watch;
 pub mod compose;
+// Multiple Claude credentials with priority rotation (issue #341). Crate-visible so
+// the HTTP layer's LLMs page can resolve the active credential for the board.
+pub(crate) mod credentials;
 mod dependencies;
 mod network;
 mod placement;
@@ -1396,14 +1399,20 @@ async fn next_actionable_task(
     if settings.agent_paused || railway.paused {
         return Ok(None);
     }
-    // Automatic usage-limit pause: hold all new work until the subscription
-    // window resets, then clear the pause and resume pulling.
+    // Automatic usage-limit pause: hold all new work until a credential frees up (the
+    // soonest exhaustion reset), then clear the pause and resume pulling (issue #341).
     if let Some(until) = settings.usage_paused_until {
         if Utc::now() < until {
             return Ok(None);
         }
         queries::set_usage_paused_until(&state.db, None).await?;
         state.notify_board();
+    }
+    // No usable Claude credential (none configured, all disabled, or all exhausted):
+    // stay idle rather than pull work we cannot run. Cheap check; the exhaustion case
+    // is also covered by the pause above, but this also covers an unconfigured install.
+    if !queries::has_usable_credential(&state.db).await? {
+        return Ok(None);
     }
     // Hard halt: a configured config repo that failed to set up means the agent
     // is missing its instructions/skills. Refuse to pull work until it's fixed.
@@ -2330,16 +2339,30 @@ async fn stream_turn(
         serde_json::json!({ "type": "prompt", "payload": prompt_event, "created_at": Utc::now() }),
     );
 
+    // Resolve the active credential for this turn (issue #341): the highest-priority
+    // usable one, its OAuth token refreshed if near expiry. `None` means no usable
+    // credential (the loop's gate normally prevents pulling work in that case, but a
+    // refresh can fail between the gate and here); skip the turn rather than run
+    // with no auth. The id lets a mid-turn rate-limit mark THIS credential exhausted.
+    let Some(active) = credentials::active_credential(state).await? else {
+        warn!(task = %task.id, "turn skipped: no usable Claude credential");
+        return Ok(TurnOutcome {
+            session_id: resume_session_id.clone(),
+            error: None,
+            heart_attack: false,
+            epoch: reset_epoch,
+        });
+    };
+    let active_credential_id = active.id;
     let args = TurnArgs {
         container: handle.container().to_string(),
         working_dir,
         prompt,
         resume_session_id: resume_session_id.clone(),
         model: settings.claude_model.clone(),
-        auth_mode: settings.claude_auth_mode,
-        // Refresh the subscription token if it is near expiry, so a turn never runs
-        // on an expired token, even the first turn after a long downtime.
-        oauth_token: subscription::fresh_inference_token(state).await?,
+        credential_kind: active.kind,
+        oauth_token: active.token,
+        base_url: active.base_url,
         github_token: queries::get_github_token(&state.db).await?,
         task_id: task.id.to_string(),
         internal_api_url: state.internal_api_url.clone(),
@@ -2475,9 +2498,11 @@ async fn stream_turn(
         }
 
         // Watch the periodic `rate_limit_event` notices: once a usage window is
-        // (nearly) exhausted, park new work until it resets. This never aborts the
-        // current task - the agent loop only consults the pause before the *next*
-        // pull - so the running task always finishes first.
+        // (nearly) exhausted, mark THIS credential exhausted and rotate to the next
+        // by priority; only when every credential is exhausted does the agent pause,
+        // until the soonest reset (issue #341). This never aborts the current task -
+        // the agent loop only consults the pause/rotation before the *next* pull - so
+        // the running task always finishes first.
         if settings.usage_limit_pause_enabled
             && event.raw.get("type").and_then(serde_json::Value::as_str) == Some("rate_limit_event")
         {
@@ -2485,13 +2510,25 @@ async fn stream_turn(
                 if let Some(reset) = usage::pause_until(info, settings.usage_limit_threshold) {
                     if usage_pause_reset != Some(reset) {
                         if let Some(until) = chrono::DateTime::from_timestamp(reset, 0) {
-                            queries::set_usage_paused_until(&state.db, Some(until)).await?;
-                            state.notify_board();
+                            let rotated = credentials::mark_exhausted_and_reconcile(
+                                state,
+                                active_credential_id,
+                                until,
+                                "subscription usage limit reached",
+                            )
+                            .await?;
                             usage_pause_reset = Some(reset);
-                            warn!(
-                                resets_at = %until,
-                                "subscription usage limit reached; pausing new work until reset"
-                            );
+                            if rotated {
+                                warn!(
+                                    resets_at = %until,
+                                    "usage limit reached; rotating to the next credential"
+                                );
+                            } else {
+                                warn!(
+                                    resets_at = %until,
+                                    "usage limit reached on every credential; pausing until reset"
+                                );
+                            }
                         }
                     }
                 }

--- a/api/src/orchestrator/network.rs
+++ b/api/src/orchestrator/network.rs
@@ -240,10 +240,6 @@ mod tests {
             config_repo_error: None,
             current_session_id: None,
             updated_at: Utc::now(),
-            claude_token_set: false,
-            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
-            claude_account_email: String::new(),
-            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,
             availability_timezone: "UTC".to_string(),
@@ -272,7 +268,6 @@ mod tests {
             attention_sound_custom: false,
             completion_sound_custom: false,
             jira_token_preview: None,
-            claude_token_preview: None,
             github_token_preview: None,
             cooldown_until: None,
         }

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -902,10 +902,6 @@ mod tests {
             config_repo_error: None,
             current_session_id: None,
             updated_at: chrono::Utc::now(),
-            claude_token_set: false,
-            claude_auth_mode: crate::db::models::ClaudeAuthMode::Subscription,
-            claude_account_email: String::new(),
-            claude_usage_token_set: false,
             github_token_set: false,
             availability_enabled: false,
             availability_timezone: "UTC".to_string(),
@@ -934,7 +930,6 @@ mod tests {
             attention_sound_custom: false,
             completion_sound_custom: false,
             jira_token_preview: None,
-            claude_token_preview: None,
             github_token_preview: None,
             cooldown_until: None,
         }

--- a/api/src/orchestrator/subscription.rs
+++ b/api/src/orchestrator/subscription.rs
@@ -1,121 +1,40 @@
-//! Lifecycle of the Claude subscription OAuth token.
+//! Subscription usage-gauge keepalive loop.
 //!
-//! A subscription login yields an OAuth access token (`sk-ant-oat01-...`, the same
-//! thing `claude setup-token` returns) that the agent runs on, plus a long-lived
-//! refresh token. The access token is short-lived (~8h), so on its own the agent
-//! would stop working after a few hours, or after Seraphim is offline past the
-//! expiry. [`fresh_inference_token`] keeps it alive: before each turn (and on a
-//! background cadence) it refreshes the access token with the refresh token when
-//! the access token is expired or near expiry, persisting the rotated pair. As
-//! long as the refresh token is still valid, the agent recovers automatically even
-//! after days offline; only an expired or revoked refresh token forces a reconnect.
-//!
-//! The same loop best-effort polls `/api/oauth/usage` for the subscription usage
-//! gauge, but only when the consent granted `user:profile`. The subscription
-//! consent grants `user:inference` only, so in practice the gauge is skipped (the
-//! endpoint would 403); the usage-limit auto-pause does not depend on it (it reads
-//! the agent's own `rate_limit_event` stream).
+//! Token lifecycle (refresh ahead of expiry, rotation) now lives in
+//! [`crate::orchestrator::credentials`]; this loop's job is the subscription usage
+//! gauge. Every tick it resolves the active credential (which refreshes its OAuth
+//! token if needed, keeping it warm for the next turn) and, when that credential is
+//! a subscription OAuth login whose consent granted `user:profile`, polls
+//! `/api/oauth/usage` for the gauge. Other kinds (a pasted setup-token, an API key)
+//! report no usage, so the gauge is cleared.
 
 use std::time::Duration;
 
-use chrono::Utc;
-use eyre::{eyre, Context, Result};
+use eyre::{eyre, Result};
 use tokio::time::sleep;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::claude::oauth;
-use crate::db::models::{ClaudeAuthMode, ClaudeUsageCredentials};
-use crate::db::queries;
+use crate::db::models::CredentialKind;
+use crate::orchestrator::credentials;
 use crate::state::{AppState, SubscriptionUsage};
 
-/// How often the token keepalive runs and the usage gauge is polled. Deliberately
+/// How often the gauge is polled (and the active token kept warm). Deliberately
 /// infrequent: `/api/oauth/usage` returns 429 under even modest polling, and the
 /// token only needs refreshing every several hours, so five minutes is ample.
 const KEEPALIVE_POLL: Duration = Duration::from_secs(300);
 
-/// Refresh the access token this far before its expiry. Set well above
-/// [`KEEPALIVE_POLL`] so an idle token is always refreshed a tick before it lapses,
-/// rather than briefly expiring between ticks.
-const REFRESH_SKEW_MINUTES: i64 = 10;
-
 /// The scope required to read `/api/oauth/usage`. The subscription consent grants
-/// `user:inference` only, so the gauge is skipped unless a broader login is used.
+/// `user:profile user:inference`; a pasted setup-token has no scopes, so its gauge
+/// is skipped.
 const USAGE_SCOPE: &str = "user:profile";
 
-/// Returns a usable Claude inference token, refreshing it first when needed.
-///
-/// In subscription mode, when an OAuth refresh token is stored and the access
-/// token has expired (or is within [`REFRESH_SKEW_MINUTES`] of expiry), this trades
-/// the refresh token for a fresh access token and persists the rotated pair, then
-/// returns it. A valid token, a manually-pasted token (no refresh token), and
-/// API-key mode are all returned unchanged.
-///
-/// # Errors
-/// Returns an error if the refresh fails, which after a long downtime most likely
-/// means the refresh token has expired or been revoked and the operator must
-/// reconnect in Settings.
-pub async fn fresh_inference_token(state: &AppState) -> Result<String> {
-    let settings = queries::get_settings(&state.db).await?;
-    if settings.claude_auth_mode != ClaudeAuthMode::Subscription {
-        // API-key mode: the stored key is the credential, nothing to refresh.
-        return Ok(queries::get_claude_token(&state.db).await?);
-    }
-
-    // Hold the refresh lock across the whole read-decide-refresh-persist sequence so
-    // a turn and the keepalive loop never refresh the rotating token concurrently.
-    let _guard = state.claude_token_refresh().lock().await;
-    let credentials = queries::get_usage_credentials(&state.db).await?;
-
-    // No refresh token means a manually-pasted setup-token (or no OAuth login):
-    // use the stored token as-is and never attempt a refresh.
-    if credentials.refresh_token.is_empty() {
-        return Ok(queries::get_claude_token(&state.db).await?);
-    }
-    if !is_near_expiry(&credentials) && !credentials.access_token.is_empty() {
-        return Ok(queries::get_claude_token(&state.db).await?);
-    }
-
-    refresh_and_store(state, &credentials.refresh_token).await
-}
-
-/// Whether the access token has expired or is within the refresh skew of expiry. A
-/// missing expiry is treated as "refresh now" so a token of unknown age is renewed.
-fn is_near_expiry(credentials: &ClaudeUsageCredentials) -> bool {
-    credentials.expires_at.is_none_or(|expires_at| {
-        expires_at <= Utc::now() + chrono::Duration::minutes(REFRESH_SKEW_MINUTES)
-    })
-}
-
-/// Refreshes the access token and persists the rotated pair, returning the new
-/// access token. Caller must hold the refresh lock.
-async fn refresh_and_store(state: &AppState, refresh_token: &str) -> Result<String> {
-    let tokens = oauth::refresh(refresh_token).await.wrap_err(
-        "refreshing the Claude subscription token failed; the refresh token may be \
-         expired or revoked. Reconnect the subscription in Settings.",
-    )?;
-    let expires_at = Utc::now() + chrono::Duration::seconds(tokens.expires_in);
-    queries::set_oauth_tokens(
-        &state.db,
-        &tokens.access_token,
-        &tokens.refresh_token,
-        expires_at,
-        &tokens.account_email,
-    )
-    .await?;
-    info!(
-        expires_in = tokens.expires_in,
-        "refreshed the Claude subscription token"
-    );
-    Ok(tokens.access_token)
-}
-
-/// Keeps the subscription token fresh and polls the usage gauge, forever.
+/// Keeps the active subscription token warm and polls the usage gauge, forever.
 pub async fn token_loop(state: AppState) {
     loop {
         if let Err(error) = keepalive_once(&state).await {
-            // A failed refresh here is surfaced loudly so a dead refresh token is
-            // noticed before the next turn needs it; transient poll failures are
-            // benign and just leave the last snapshot in place.
+            // A failed refresh surfaces here promptly (before the next turn needs
+            // it); transient poll failures are benign and leave the last snapshot.
             debug!(error = %error, "Claude subscription keepalive tick failed");
         }
         sleep(KEEPALIVE_POLL).await;
@@ -123,29 +42,21 @@ pub async fn token_loop(state: AppState) {
 }
 
 async fn keepalive_once(state: &AppState) -> Result<()> {
-    let settings = queries::get_settings(&state.db).await?;
-    if settings.claude_auth_mode != ClaudeAuthMode::Subscription || !settings.claude_usage_token_set
-    {
-        // API-key mode or no OAuth login: nothing to keep alive, and clear any stale
-        // usage snapshot so the gauge does not show numbers from a prior login.
+    // Resolving the active credential refreshes its OAuth token ahead of expiry, so
+    // the next turn (or the first after a long idle) never blocks on a refresh.
+    let Some(active) = credentials::active_credential(state).await? else {
+        // No usable credential: clear any stale gauge snapshot.
+        state.set_usage(None);
+        return Ok(());
+    };
+
+    // Only a subscription OAuth login with the profile scope can report usage.
+    if active.kind != CredentialKind::SubscriptionOauth || !active.scopes.contains(USAGE_SCOPE) {
         state.set_usage(None);
         return Ok(());
     }
 
-    // Refresh ahead of expiry so the next turn (or the first turn after a long idle)
-    // never blocks on a refresh and a dead refresh token surfaces here promptly.
-    let access_token = fresh_inference_token(state).await?;
-
-    // The usage gauge needs `user:profile`, which the subscription consent does not
-    // grant; polling without it just 403s. Skip cleanly rather than spam the
-    // endpoint, leaving the UI to fall back to the rate-limit status.
-    let credentials = queries::get_usage_credentials(&state.db).await?;
-    if !credentials.scopes.contains(USAGE_SCOPE) {
-        state.set_usage(None);
-        return Ok(());
-    }
-
-    let usage = oauth::fetch_usage(&access_token)
+    let usage = oauth::fetch_usage(&active.token)
         .await
         .map_err(|error| eyre!("usage poll skipped: {error}"))?;
     state.set_usage(Some(SubscriptionUsage {
@@ -155,42 +66,4 @@ async fn keepalive_once(state: &AppState) -> Result<()> {
         seven_day_resets_at: usage.seven_day_resets_at,
     }));
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn credentials(expires_at: Option<chrono::DateTime<Utc>>) -> ClaudeUsageCredentials {
-        ClaudeUsageCredentials {
-            access_token: "access".into(),
-            refresh_token: "refresh".into(),
-            expires_at,
-            scopes: "user:inference".into(),
-        }
-    }
-
-    #[test]
-    fn token_well_within_its_lifetime_is_not_refreshed() {
-        let later = Utc::now() + chrono::Duration::hours(4);
-        assert!(!is_near_expiry(&credentials(Some(later))));
-    }
-
-    #[test]
-    fn token_within_the_skew_is_refreshed() {
-        let soon = Utc::now() + chrono::Duration::minutes(REFRESH_SKEW_MINUTES - 1);
-        assert!(is_near_expiry(&credentials(Some(soon))));
-    }
-
-    #[test]
-    fn expired_token_is_refreshed() {
-        // The multi-day-offline case: expiry is long past, so we refresh on return.
-        let past = Utc::now() - chrono::Duration::days(3);
-        assert!(is_near_expiry(&credentials(Some(past))));
-    }
-
-    #[test]
-    fn unknown_expiry_is_refreshed() {
-        assert!(is_near_expiry(&credentials(None)));
-    }
 }

--- a/api/src/orchestrator/thoughts.rs
+++ b/api/src/orchestrator/thoughts.rs
@@ -73,6 +73,10 @@ async fn summarize(
     settings: &Settings,
     thoughts: &[String],
 ) -> Result<Option<String>> {
+    // Run on the active credential (issue #341); skip cleanly if none is usable.
+    let Some(active) = super::credentials::active_credential(state).await? else {
+        return Ok(None);
+    };
     let args = TurnArgs {
         container: state.workspace.container().to_string(),
         working_dir: "/workspace".to_string(),
@@ -81,8 +85,9 @@ async fn summarize(
         // disturb) the shared task session.
         resume_session_id: None,
         model: settings.claude_model.clone(),
-        auth_mode: settings.claude_auth_mode,
-        oauth_token: super::subscription::fresh_inference_token(state).await?,
+        credential_kind: active.kind,
+        oauth_token: active.token,
+        base_url: active.base_url,
         github_token: queries::get_github_token(&state.db).await?,
         // A summary turn doesn't act as the task, so it gets no helper wiring.
         task_id: String::new(),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   IssueThread,
   JiraBoard,
   JiraDeployment,
+  LlmCredential,
   NetworkAccessLevel,
   PendingQuestion,
   Question,
@@ -507,7 +508,6 @@ export function resumeUsage() {
 }
 
 export type TokensRequest = {
-  claude_oauth_token?: string
   github_token?: string
   jira_api_token?: string
   github_webhook_secret?: string
@@ -518,25 +518,50 @@ export function setTokens(body: TokensRequest) {
   return apiClient.post('settings/tokens', { json: body }).json<Settings>()
 }
 
-// --- Claude authentication ---------------------------------------------------
+// --- LLM credentials (issue #341) --------------------------------------------
+// Multiple Claude credentials the agent rotates through by priority. The list
+// mutators all return the refreshed, masked list so the LLMs page re-renders.
+
+export function listCredentials() {
+  return apiClient.get('credentials').json<LlmCredential[]>()
+}
+
+// Persists a new priority order (first = highest priority) after a drag-drop.
+export function reorderCredentials(ids: string[]) {
+  return apiClient.post('credentials/reorder', { json: { ids } }).json<LlmCredential[]>()
+}
 
 export type OauthStartResponse = {
   authorize_url: string
 }
 
 // Begins a Claude subscription OAuth login; returns the consent URL to open.
-export function startClaudeOauth() {
-  return apiClient.post('settings/claude/oauth/start').json<OauthStartResponse>()
+export function startCredentialOauth() {
+  return apiClient.post('credentials/oauth/start').json<OauthStartResponse>()
 }
 
-// Completes the login with the code pasted from the consent callback page.
-export function finishClaudeOauth(code: string) {
-  return apiClient.post('settings/claude/oauth/finish', { json: { code } }).json<Settings>()
+// Completes the login with the pasted code, adding a subscription credential.
+export function finishCredentialOauth(code: string, label: string) {
+  return apiClient.post('credentials/oauth/finish', { json: { code, label } }).json<LlmCredential[]>()
 }
 
-// Stores an Anthropic API key and switches the agent to API-key auth.
-export function setClaudeApiKey(apiKey: string) {
-  return apiClient.post('settings/claude/api-key', { json: { api_key: apiKey } }).json<Settings>()
+// Adds a long-lived pasted subscription token (`claude setup-token`).
+export function addSetupTokenCredential(token: string, label: string) {
+  return apiClient.post('credentials/token', { json: { token, label } }).json<LlmCredential[]>()
+}
+
+// Adds an Anthropic API key.
+export function addApiKeyCredential(apiKey: string, label: string) {
+  return apiClient.post('credentials/api-key', { json: { api_key: apiKey, label } }).json<LlmCredential[]>()
+}
+
+// Renames or enables/disables a credential.
+export function updateCredential(id: string, body: { label?: string; enabled?: boolean }) {
+  return apiClient.patch(`credentials/${id}`, { json: body }).json<LlmCredential[]>()
+}
+
+export function deleteCredential(id: string) {
+  return apiClient.delete(`credentials/${id}`).json<{ deleted: boolean }>()
 }
 
 // --- Jira --------------------------------------------------------------------

--- a/frontend/src/lib/components/LlmCredentials.svelte
+++ b/frontend/src/lib/components/LlmCredentials.svelte
@@ -1,0 +1,382 @@
+<script lang="ts">
+  import type { CredentialKind, LlmCredential } from '$lib/types'
+  import type { DndEvent } from 'svelte-dnd-action'
+
+  import { onMount } from 'svelte'
+  import { toast } from 'svelte-sonner'
+  import { dndzone } from 'svelte-dnd-action'
+  import { GripVertical, Trash2, Plus, ExternalLink } from '@lucide/svelte'
+
+  import {
+    addApiKeyCredential,
+    addSetupTokenCredential,
+    deleteCredential,
+    extractApiError,
+    finishCredentialOauth,
+    listCredentials,
+    reorderCredentials,
+    startCredentialOauth,
+    updateCredential
+  } from '$lib/api'
+  import { Button, buttonVariants } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Label } from '$lib/components/ui/label'
+  import { Badge } from '$lib/components/ui/badge'
+  import { Switch } from '$lib/components/ui/switch'
+  import * as AlertDialog from '$lib/components/ui/alert-dialog'
+
+  const FLIP_MS = 150
+
+  // Human labels for each credential kind, shown on the row badge and add tabs.
+  const KIND_LABELS = {
+    subscription_oauth: 'Subscription',
+    setup_token: 'Setup token',
+    api_key: 'API key'
+  } as const satisfies Record<CredentialKind, string>
+
+  let credentials = $state<LlmCredential[]>([])
+  let loading = $state(true)
+
+  async function load() {
+    try {
+      credentials = await listCredentials()
+    }
+    catch (error) {
+      toast.error(await extractApiError(error, 'Could not load credentials'))
+    }
+    finally {
+      loading = false
+    }
+  }
+
+  onMount(load)
+
+  // --- Drag-and-drop priority reorder ----------------------------------------
+  function handleConsider(event: CustomEvent<DndEvent<LlmCredential>>) {
+    credentials = event.detail.items
+  }
+
+  async function handleFinalize(event: CustomEvent<DndEvent<LlmCredential>>) {
+    credentials = event.detail.items
+    try {
+      credentials = await reorderCredentials(credentials.map((credential) => credential.id))
+    }
+    catch (error) {
+      toast.error(await extractApiError(error, 'Could not save the new order'))
+      await load()
+    }
+  }
+
+  // --- Row actions -----------------------------------------------------------
+  async function toggleEnabled(credential: LlmCredential, enabled: boolean) {
+    try {
+      credentials = await updateCredential(credential.id, { enabled })
+    }
+    catch (error) {
+      toast.error(await extractApiError(error, 'Could not update the credential'))
+    }
+  }
+
+  async function saveLabel(credential: LlmCredential, label: string) {
+    if (label === credential.label) {
+      return
+    }
+    try {
+      credentials = await updateCredential(credential.id, { label })
+    }
+    catch (error) {
+      toast.error(await extractApiError(error, 'Could not rename the credential'))
+    }
+  }
+
+  let deleteTarget = $state<LlmCredential | null>(null)
+
+  async function confirmDelete() {
+    const target = deleteTarget
+    if (!target) {
+      return
+    }
+    try {
+      await deleteCredential(target.id)
+      deleteTarget = null
+      await load()
+    }
+    catch (error) {
+      toast.error(await extractApiError(error, 'Could not delete the credential'))
+    }
+  }
+
+  // --- Add a credential ------------------------------------------------------
+  let addKind = $state<CredentialKind>('subscription_oauth')
+  let addLabel = $state('')
+  let addToken = $state('')
+  let addApiKey = $state('')
+  let addBusy = $state(false)
+  let addError = $state<string | null>(null)
+  // The subscription OAuth flow is two-step: connect (opens a consent tab), then
+  // paste the code back.
+  let oauthUrl = $state<string | null>(null)
+  let oauthCode = $state('')
+
+  function resetAddForm() {
+    addLabel = ''
+    addToken = ''
+    addApiKey = ''
+    addError = null
+    oauthUrl = null
+    oauthCode = ''
+  }
+
+  function pickKind(kind: CredentialKind) {
+    addKind = kind
+    resetAddForm()
+  }
+
+  async function connectSubscription() {
+    addBusy = true
+    addError = null
+    try {
+      const response = await startCredentialOauth()
+      oauthUrl = response.authorize_url
+      window.open(response.authorize_url, '_blank', 'noopener,noreferrer')
+    }
+    catch (error) {
+      addError = await extractApiError(error, 'Could not start the login')
+    }
+    finally {
+      addBusy = false
+    }
+  }
+
+  async function completeSubscription() {
+    const code = oauthCode.trim()
+    if (!code) {
+      return
+    }
+    addBusy = true
+    addError = null
+    try {
+      credentials = await finishCredentialOauth(code, addLabel.trim())
+      resetAddForm()
+      toast.success('Subscription connected')
+    }
+    catch (error) {
+      addError = await extractApiError(error, 'Could not complete the login')
+    }
+    finally {
+      addBusy = false
+    }
+  }
+
+  async function addToken_() {
+    const token = addToken.trim()
+    if (!token) {
+      return
+    }
+    addBusy = true
+    addError = null
+    try {
+      credentials = await addSetupTokenCredential(token, addLabel.trim())
+      resetAddForm()
+      toast.success('Setup token added')
+    }
+    catch (error) {
+      addError = await extractApiError(error, 'Could not add the token')
+    }
+    finally {
+      addBusy = false
+    }
+  }
+
+  async function addKey() {
+    const key = addApiKey.trim()
+    if (!key) {
+      return
+    }
+    addBusy = true
+    addError = null
+    try {
+      credentials = await addApiKeyCredential(key, addLabel.trim())
+      resetAddForm()
+      toast.success('API key added')
+    }
+    catch (error) {
+      addError = await extractApiError(error, 'Could not add the API key')
+    }
+    finally {
+      addBusy = false
+    }
+  }
+</script>
+
+<div class="space-y-4">
+  <p class="text-sm text-muted-foreground">
+    The agent runs on the highest-priority credential. When one hits its usage limit it is
+    marked exhausted and the agent rotates to the next; only when every credential is exhausted
+    does it pause, until the soonest one resets. Drag to set priority (top runs first).
+  </p>
+
+  <!-- The priority-ordered list. -->
+  {#if loading}
+    <p class="text-sm text-muted-foreground">Loading…</p>
+  {:else if credentials.length === 0}
+    <p class="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+      No credentials yet. Add one below to let the agent run.
+    </p>
+  {:else}
+    <ul
+      class="space-y-2"
+      use:dndzone={{ items: credentials, flipDurationMs: FLIP_MS, dropTargetStyle: {} }}
+      onconsider={handleConsider}
+      onfinalize={handleFinalize}
+    >
+      {#each credentials as credential (credential.id)}
+        <li
+          class="flex items-center gap-3 rounded-lg border border-border bg-card p-3 {credential.enabled
+            ? ''
+            : 'opacity-60'}"
+        >
+          <GripVertical class="size-4 flex-none cursor-grab text-muted-foreground active:cursor-grabbing" />
+
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <Input
+                class="h-7 w-44 text-sm font-medium"
+                value={credential.label}
+                placeholder={KIND_LABELS[credential.kind]}
+                onblur={(event) => saveLabel(credential, event.currentTarget.value.trim())}
+              />
+              <Badge variant="outline">{KIND_LABELS[credential.kind]}</Badge>
+              {#if credential.active}
+                <Badge variant="outline" class="border-primary/50 text-primary">active</Badge>
+              {:else if credential.exhausted_until}
+                <Badge variant="outline" class="border-warning/50 text-warning">
+                  exhausted until {new Date(credential.exhausted_until).toLocaleString()}
+                </Badge>
+              {:else if credential.available}
+                <Badge variant="outline" class="border-success/40 text-success">ready</Badge>
+              {/if}
+            </div>
+            <div class="mt-1 flex flex-wrap items-center gap-x-3 text-xs text-muted-foreground">
+              {#if credential.account_email}<span>{credential.account_email}</span>{/if}
+              {#if credential.token_preview}<span class="font-mono">{credential.token_preview}</span>{/if}
+            </div>
+            {#if credential.last_error}
+              <p class="mt-1 text-xs break-words text-destructive">{credential.last_error}</p>
+            {/if}
+          </div>
+
+          <span title={credential.enabled ? 'Enabled' : 'Disabled'} class="flex-none">
+            <Switch
+              checked={credential.enabled}
+              onCheckedChange={(value) => toggleEnabled(credential, value)}
+              aria-label="Enable credential"
+            />
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            class="flex-none text-destructive hover:text-destructive"
+            title="Delete"
+            aria-label="Delete credential"
+            onclick={() => (deleteTarget = credential)}
+          >
+            <Trash2 class="size-4" />
+          </Button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <!-- Add a credential. -->
+  <div class="rounded-lg border border-border p-4">
+    <h3 class="text-sm font-semibold">Add a credential</h3>
+    <div class="mt-3 flex flex-wrap gap-1.5">
+      {#each Object.entries(KIND_LABELS) as [kind, kindLabel] (kind)}
+        <Button
+          variant={addKind === kind ? 'default' : 'outline'}
+          size="sm"
+          onclick={() => pickKind(kind as CredentialKind)}
+        >
+          {kindLabel}
+        </Button>
+      {/each}
+    </div>
+
+    <div class="mt-3 space-y-2">
+      <div class="grid gap-1.5">
+        <Label for="cred-label" class="text-xs text-muted-foreground">Label (optional)</Label>
+        <Input id="cred-label" bind:value={addLabel} placeholder="e.g. Personal Max plan" />
+      </div>
+
+      {#if addKind === 'subscription_oauth'}
+        <p class="text-xs text-muted-foreground">
+          Connect a Claude subscription. This opens a consent tab; paste the code it shows back here.
+        </p>
+        <Button size="sm" disabled={addBusy} onclick={connectSubscription}>
+          <ExternalLink class="size-4" /> Connect subscription
+        </Button>
+        {#if oauthUrl}
+          <div class="grid gap-1.5">
+            <a href={oauthUrl} target="_blank" rel="noopener noreferrer" class="text-xs underline">
+              Reopen the consent tab
+            </a>
+            <Input bind:value={oauthCode} placeholder="Paste the code from the consent page" />
+            <Button size="sm" disabled={addBusy} onclick={completeSubscription}>
+              {addBusy ? 'Completing…' : 'Complete login'}
+            </Button>
+          </div>
+        {/if}
+      {:else if addKind === 'setup_token'}
+        <p class="text-xs text-muted-foreground">
+          A long-lived subscription token from <code>claude setup-token</code> (starts with
+          <code>sk-ant-oat</code>). It runs the agent but reports no usage.
+        </p>
+        <Input type="password" bind:value={addToken} placeholder="sk-ant-oat01-…" />
+        <Button size="sm" disabled={addBusy} onclick={addToken_}>
+          <Plus class="size-4" /> {addBusy ? 'Adding…' : 'Add token'}
+        </Button>
+      {:else}
+        <p class="text-xs text-muted-foreground">
+          An Anthropic API key (starts with <code>sk-ant-api</code>). Billed per token; no usage gauge.
+        </p>
+        <Input type="password" bind:value={addApiKey} placeholder="sk-ant-api03-…" />
+        <Button size="sm" disabled={addBusy} onclick={addKey}>
+          <Plus class="size-4" /> {addBusy ? 'Adding…' : 'Add API key'}
+        </Button>
+      {/if}
+
+      {#if addError}
+        <p class="text-xs text-destructive">{addError}</p>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<AlertDialog.Root
+  open={deleteTarget !== null}
+  onOpenChange={(open) => {
+    if (!open) {
+      deleteTarget = null
+    }
+  }}
+>
+  <AlertDialog.Content>
+    {#if deleteTarget}
+      <AlertDialog.Header>
+        <AlertDialog.Title>
+          Delete this credential{deleteTarget.label ? ` (${deleteTarget.label})` : ''}?
+        </AlertDialog.Title>
+        <AlertDialog.Description>
+          The agent will no longer run on it. This cannot be undone; you can re-add it later.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+        <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={confirmDelete}>
+          Delete
+        </AlertDialog.Action>
+      </AlertDialog.Footer>
+    {/if}
+  </AlertDialog.Content>
+</AlertDialog.Root>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -165,8 +165,41 @@ export type AvailabilityWindow = {
   end_minute: number
 }
 
-// How the agent authenticates to Claude.
-export type ClaudeAuthMode = 'subscription' | 'api_key'
+// The kind of a stored LLM credential (issue #341), deciding how it authenticates
+// the Claude Code CLI.
+export type CredentialKind = 'subscription_oauth' | 'setup_token' | 'api_key'
+
+// A stored Claude credential as the LLMs settings page sees it (issue #341). The
+// raw secret is never sent; only a masked preview. Ordered by `position` (lower
+// runs first); the agent rotates to the next when the active one is rate-limited.
+export type LlmCredential = {
+  id: string
+  provider: string
+  kind: CredentialKind
+  label: string
+  position: number
+  enabled: boolean
+  // Masked preview of the stored secret, e.g. "sk-ant-****abcd"; null when unset.
+  token_preview: string | null
+  account_email: string
+  base_url: string
+  // While set and in the future, this credential is out of quota until then (ISO).
+  exhausted_until: string | null
+  // Last failure reason (an exhausted window, a dead refresh token); null = healthy.
+  last_error: string | null
+  // Usable right now (enabled, has a secret, not exhausted).
+  available: boolean
+  // The credential the agent is currently running on (highest-priority available).
+  active: boolean
+}
+
+// A compact summary of the active credential for the board header (issue #341).
+export type ActiveCredential = {
+  id: string
+  kind: CredentialKind
+  label: string
+  account_email: string
+}
 
 export type Settings = {
   org_name: string
@@ -181,14 +214,6 @@ export type Settings = {
   config_repo_error: string | null
   current_session_id: string | null
   updated_at: string
-  claude_token_set: boolean
-  // How the agent authenticates to Claude (subscription token vs API key).
-  claude_auth_mode: ClaudeAuthMode
-  // The connected Claude account's email (issue #269); empty when unknown
-  // (a manually pasted setup-token or API key returns no account identity).
-  claude_account_email: string
-  // Whether subscription usage credentials are stored (powers the usage gauge).
-  claude_usage_token_set: boolean
   github_token_set: boolean
   availability_enabled: boolean
   availability_timezone: string
@@ -236,8 +261,8 @@ export type Settings = {
   attention_sound_custom: boolean
   completion_sound_custom: boolean
   // Masked previews of the stored tokens (e.g. "sk-ant-****abcd"), or null when
-  // unset. The raw tokens are never sent.
-  claude_token_preview: string | null
+  // unset. The raw tokens are never sent. The Claude credentials live on the LLMs
+  // page now (issue #341), not here.
   github_token_preview: string | null
   jira_token_preview: string | null
   // Runtime signal: while set and in the future, the agent is in a brief global
@@ -569,6 +594,9 @@ export type BoardResponse = {
   // Setup-script edits the agent made to itself (issue #340), unacknowledged, for
   // the board banner that keeps the operator aware of the change.
   setup_script_changes: SetupScriptChange[]
+  // The Claude credential the agent is currently running on (issue #341), so the
+  // board header can show its account/label. Null when none is usable.
+  active_credential: ActiveCredential | null
 }
 
 // A pull request the task has opened. A task may span several repos, so it can

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { DndEvent } from 'svelte-dnd-action'
-  import type { AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, SetupScriptChange, Settings, SourceKind, Task, TaskColumn } from '$lib/types'
+  import type { ActiveCredential, AnomalousEmptyPr, HeartAttack, Railway, RepoSyncError, SetupScriptChange, Settings, SourceKind, Task, TaskColumn } from '$lib/types'
 
   import { onMount, onDestroy } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
@@ -67,6 +67,9 @@
   const FLIP_MS = 150
 
   let settings = $state<Settings | null>(null)
+  // The Claude credential the agent is currently running on (issue #341), shown in
+  // the board header. Null when none is usable.
+  let activeCredential = $state<ActiveCredential | null>(null)
   let suggestionCounts = $state<Record<string, number>>({})
   // Unacknowledged heart attacks (dead turns) the defibrillator recorded; shown
   // as a dismissible alert banner so the operator notices and can read the logs.
@@ -446,6 +449,7 @@
       }
     }
     setupScriptChanges = board.setup_script_changes
+    activeCredential = board.active_credential
     repoNames = Object.fromEntries(repos.map((repo) => [repo.id, repo.full_name]))
 
     // Group every card by railway, then by column. A lane with no cards still gets
@@ -1109,12 +1113,12 @@
     <div class="flex items-baseline gap-2">
       {#if settings}
         <strong class="text-base">{settings.org_name}</strong>
-        {#if settings.claude_account_email}
+        {#if activeCredential && (activeCredential.account_email || activeCredential.label)}
           <span
             class="text-sm text-muted-foreground"
-            title="Connected Claude account"
+            title="The Claude credential the agent is currently running on"
           >
-            • ({settings.claude_account_email})
+            • ({activeCredential.account_email || activeCredential.label})
           </span>
         {/if}
         {#if outsideSchedule}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -41,9 +41,6 @@
     runUpdate,
     setEnvVars,
     setTokens,
-    startClaudeOauth,
-    finishClaudeOauth,
-    setClaudeApiKey,
     resumeUsage,
     testJira,
     updateJiraBoard,
@@ -68,6 +65,7 @@
   import { Badge } from '$lib/components/ui/badge'
   import { Switch } from '$lib/components/ui/switch'
   import TimezonePicker from '$lib/components/TimezonePicker.svelte'
+  import LlmCredentials from '$lib/components/LlmCredentials.svelte'
 
   const CUSTOM_MODEL = '__custom__'
 
@@ -75,6 +73,7 @@
   // {#if active === '...'} wrapper; only the selected subpage is rendered.
   const SECTIONS = [
     { id: 'profile', label: 'Profile' },
+    { id: 'llms', label: 'LLMs' },
     { id: 'secrets', label: 'Secrets' },
     { id: 'config', label: 'Config repo' },
     { id: 'jira', label: 'Jira' },
@@ -119,14 +118,6 @@
   let githubWebhookSecretInput = $state('')
   let jiraWebhookSecretInput = $state('')
   let tokensMessage = $state<string | null>(null)
-
-  // Claude authentication (subscription OAuth vs API key).
-  let claudeAuthBusy = $state(false)
-  let claudeAuthError = $state<string | null>(null)
-  let claudeAuthMessage = $state<string | null>(null)
-  let oauthAuthorizeUrl = $state<string | null>(null)
-  let oauthCodeInput = $state('')
-  let claudeApiKeyInput = $state('')
 
   // Model picker: a dropdown of known ids plus a custom free-text fallback.
   let modelChoice = $state<string>(KNOWN_MODELS[0].value)
@@ -588,70 +579,6 @@
     tokensMessage = 'Saved to the database.'
   }
 
-  // Opens the Claude consent screen in a new tab; the operator pastes the code
-  // back to complete the login.
-  async function connectClaudeSubscription() {
-    claudeAuthError = null
-    claudeAuthMessage = null
-    claudeAuthBusy = true
-    try {
-      const { authorize_url } = await startClaudeOauth()
-      oauthAuthorizeUrl = authorize_url
-      window.open(authorize_url, '_blank', 'noopener,noreferrer')
-    }
-    catch (error) {
-      console.debug('startClaudeOauth failed', error)
-      claudeAuthError = 'Could not start the login. Check the API logs.'
-    }
-    finally {
-      claudeAuthBusy = false
-    }
-  }
-
-  async function completeClaudeLogin() {
-    const code = oauthCodeInput.trim()
-    if (!code) {
-      return
-    }
-    claudeAuthError = null
-    claudeAuthBusy = true
-    try {
-      settings = await finishClaudeOauth(code)
-      oauthAuthorizeUrl = null
-      oauthCodeInput = ''
-      claudeAuthMessage = 'Connected your Claude subscription.'
-    }
-    catch (error) {
-      console.debug('finishClaudeOauth failed', error)
-      claudeAuthError = 'Login failed. Paste the full code from the consent page, then try again.'
-    }
-    finally {
-      claudeAuthBusy = false
-    }
-  }
-
-  async function saveClaudeApiKey() {
-    const key = claudeApiKeyInput.trim()
-    if (!key) {
-      return
-    }
-    claudeAuthError = null
-    claudeAuthMessage = null
-    claudeAuthBusy = true
-    try {
-      settings = await setClaudeApiKey(key)
-      claudeApiKeyInput = ''
-      claudeAuthMessage = 'Saved your Anthropic API key.'
-    }
-    catch (error) {
-      console.debug('setClaudeApiKey failed', error)
-      claudeAuthError = 'Could not save the API key.'
-    }
-    finally {
-      claudeAuthBusy = false
-    }
-  }
-
   async function runRestart() {
     workspaceMessage = 'Restarting…'
     await restartWorkspace()
@@ -988,6 +915,21 @@
     </Card.Root>
     {/if}
 
+    {#if active === 'llms'}
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>LLMs</Card.Title>
+        <Card.Description>
+          The Claude credentials the agent runs on (issue #341). Add any number of subscriptions,
+          long-lived tokens, or API keys, and drag to set which is used first.
+        </Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <LlmCredentials />
+      </Card.Content>
+    </Card.Root>
+    {/if}
+
     {#if active === 'secrets'}
     <Card.Root>
       <Card.Header>
@@ -999,91 +941,12 @@
         </Card.Description>
       </Card.Header>
       <Card.Content class="space-y-5">
-        <div class="space-y-2">
-          <Label class="flex flex-wrap items-center gap-2">
-            Claude authentication
-            <Badge variant="outline" class={settings.claude_token_set ? 'border-success/40 text-success' : 'text-muted-foreground'}>
-              {#if !settings.claude_token_set}
-                not set
-              {:else if settings.claude_auth_mode === 'api_key'}
-                API key
-              {:else}
-                subscription
-              {/if}
-            </Badge>
-            {#if settings.claude_auth_mode === 'subscription' && settings.claude_usage_token_set}
-              <Badge variant="outline" class="border-success/40 text-success">usage gauge on</Badge>
-            {/if}
-          </Label>
-          <p class="text-sm text-muted-foreground">
-            Connect a Claude subscription (recommended) to run the agent and light up the live usage
-            gauge, or use an Anthropic API key. The subscription path is the same one-click login the
-            Claude Code CLI uses.
-          </p>
-
-          <!-- Claude subscription OAuth: opens consent, then paste the code back. -->
-          <div class="space-y-2 rounded-md border border-border p-3">
-            <div class="flex items-center justify-between gap-2">
-              <span class="text-sm font-medium">Claude subscription</span>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={claudeAuthBusy}
-                onclick={connectClaudeSubscription}
-              >
-                {settings.claude_token_set && settings.claude_auth_mode === 'subscription'
-                  ? 'Reconnect'
-                  : 'Connect'}
-              </Button>
-            </div>
-            {#if oauthAuthorizeUrl}
-              <p class="text-xs text-muted-foreground">
-                A consent tab opened. Approve it, copy the code it shows, and paste it below.
-                <a href={oauthAuthorizeUrl} target="_blank" rel="noopener noreferrer" class="underline">
-                  Reopen the tab
-                </a>.
-              </p>
-              <div class="flex gap-2">
-                <Input placeholder="paste the code here" autocomplete="off" bind:value={oauthCodeInput} />
-                <Button
-                  size="sm"
-                  disabled={claudeAuthBusy || !oauthCodeInput.trim()}
-                  onclick={completeClaudeLogin}
-                >
-                  Complete
-                </Button>
-              </div>
-            {/if}
-          </div>
-
-          <!-- Anthropic API key (no subscription usage gauge in this mode). -->
-          <div class="space-y-2 rounded-md border border-border p-3">
-            <span class="text-sm font-medium">Anthropic API key</span>
-            <div class="flex gap-2">
-              <Input
-                type="password"
-                autocomplete="off"
-                placeholder="sk-ant-api03-…"
-                bind:value={claudeApiKeyInput}
-              />
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={claudeAuthBusy || !claudeApiKeyInput.trim()}
-                onclick={saveClaudeApiKey}
-              >
-                Save
-              </Button>
-            </div>
-            <p class="text-xs text-muted-foreground">No subscription usage gauge applies in this mode.</p>
-          </div>
-
-          {#if claudeAuthError}
-            <p class="text-sm text-destructive">{claudeAuthError}</p>
-          {/if}
-          {#if claudeAuthMessage}
-            <p class="text-sm text-success">{claudeAuthMessage}</p>
-          {/if}
+        <div class="rounded-md border border-border p-3 text-sm text-muted-foreground">
+          Claude credentials moved to the
+          <button type="button" class="font-medium text-primary underline" onclick={() => (active = 'llms')}>
+            LLMs
+          </button>
+          tab, where you can add and prioritize several subscriptions, tokens, or API keys.
         </div>
         <div class="space-y-1.5">
           <Label for="gh-token" class="flex items-center gap-2">


### PR DESCRIPTION
Closes #341.

## Why

The settings page allowed only one Claude subscription/token/API key, and hitting a rate limit paused the whole agent until reset. This adds a first-class, priority-ordered credential system: add as many subscriptions, long-lived tokens, and API keys as you like, drag to prioritize, and the agent rotates to the next when one runs out of tokens.

## What changed

**Data model (migration `0049`)**
- New `llm_credentials` table: `kind` (`subscription_oauth` / `setup_token` / `api_key`), `label`, fractional `position` (priority), `enabled`, the inference `secret`, refreshing OAuth material, `account_email`, an `exhausted_until` rotation timer, `last_error`, and a provider-agnostic `provider` + `base_url`. The old per-credential columns are dropped from `settings` (the usage-pause columns stay); any existing credential migrates in as entry #1.
- Provider-agnostic on purpose: a non-Anthropic credential's `base_url` points at the LiteLLM sidecar's Anthropic endpoint (issue #342) so the same rotation drives future LLMs. Today all credentials are Anthropic.

**Rotation (`orchestrator::credentials`)**
- `active_credential` resolves the highest-priority usable credential (enabled, has a secret, not exhausted), refreshing its OAuth token ahead of expiry (serialized on the existing refresh lock).
- On a `rate_limit_event`, the active credential is marked `exhausted_until` the window reset and `reconcile_pause` rotates to the next by priority; only when every credential is exhausted is `settings.usage_paused_until` set to the soonest reset. `next_actionable_task` stays idle when no credential is usable.
- The turn exec injects the resolved credential per kind (`CLAUDE_CODE_OAUTH_TOKEN` vs `ANTHROPIC_API_KEY`), plus `ANTHROPIC_BASE_URL` when set. The board header and usage gauge follow the active credential. The secret scrubber covers every credential's secret + OAuth tokens.

**API**
- `GET /credentials` (masked view marking the active one), `POST /credentials/{oauth/start,oauth/finish,token,api-key,reorder}`, `PATCH`/`DELETE /credentials/:id`. Removed the old `/settings/claude/*` + `claude_oauth_token` token path.

**Frontend**
- New **Settings -> LLMs** subpage (`LlmCredentials.svelte`): a drag-to-prioritize list with per-row status (active / exhausted-until / ready / disabled), enable toggle, inline rename, delete, and add flows for subscription OAuth, setup token, and API key. The Secrets tab links to it. The board header shows the active credential's account/label.

## Testing

- `cargo +1.88 fmt --check`, `clippy --all-targets` (my files clean), `test` (181 pass, incl. new pure selection/availability/near-expiry tests).
- Migration verified on a real Postgres: the full chain applies; the data migration classifies an existing credential correctly (api_key -> api_key, subscription+refresh -> subscription_oauth, subscription without refresh -> setup_token) and drops the old columns/enum.
- `npm run check` (0 errors/warnings) and `npm run build`.
- Visual self-review via the Playwright MCP against a live API (ephemeral Postgres) with seeded credentials across every state: verified the LLMs list (active/exhausted/ready/disabled badges, masked previews, last_error), the end-to-end add-API-key flow, the board header showing the active credential's email, and no overflow at 375px and 1280px.