### PR TITLE
Clone/remove repos in the workspace in realtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,17 @@ in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
   keep/on/off, `POST /repos/bulk/fields`) or deletes the selection
   (`POST /repos/bulk/delete`, with an aggregate blast-radius preview from
   `POST /repos/bulk/deletion-impact`). All three mirror the board's
-  `/tasks/bulk/*` handlers and notify the board once per action.
+  `/tasks/bulk/*` handlers and notify the board once per action. **Realtime
+  workspace sync (issue #343):** adding/enabling a repo (single add, org import,
+  bulk enable, railway reassign) clones it into the workspace **immediately in the
+  background** (`orchestrator::repo_sync::sync_repos` -> a spawned task ->
+  `provision::clone_repo`), so a fresh repo lands without waiting for the next full
+  provision, on a new dir that never disrupts the agent's in-flight turn. Removing
+  or disabling one queues its clone dir on `AppState::pending_removals`; the
+  railway's agent loop drains it **between tasks** (never mid-turn) and `rm -rf`s
+  the dir (`repo_sync::apply_pending_removals`, only into a running container).
+  Removal is guarded to a flat `/workspace/{name}` (unsafe names skipped), and the
+  config dir `.claude` is never touched.
 - **`tasks`** — the cards: `source_kind`, `external_id`, `repo_id`, `title`,
   `board_column`, `position` (fractional rank), `status`, `branch`, `pr_url`,
   `error`, `hold` (agent skips this card), `blocking` (serialize the queue while

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -851,6 +851,19 @@ pub async fn get_repository(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Repo
         .await
 }
 
+/// The repositories for a set of ids (any order). Used by the bulk repo endpoints
+/// to reconcile the workspace after a bulk enable/disable or before a bulk delete
+/// (issue #343).
+pub async fn list_repositories_by_ids(
+    pool: &PgPool,
+    ids: &[Uuid],
+) -> sqlx::Result<Vec<Repository>> {
+    sqlx::query_as::<_, Repository>("SELECT * FROM repositories WHERE id = ANY($1)")
+        .bind(ids)
+        .fetch_all(pool)
+        .await
+}
+
 pub async fn get_repository_by_full_name(
     pool: &PgPool,
     full_name: &str,

--- a/api/src/http/repos.rs
+++ b/api/src/http/repos.rs
@@ -11,6 +11,7 @@ use crate::db::models::{RepoDeletionImpact, ReposDeletionImpact, Repository, Rev
 use crate::db::queries;
 use crate::git;
 use crate::orchestrator::provision::repo_dir_name;
+use crate::orchestrator::repo_sync;
 use crate::state::AppState;
 
 /// `GET /api/v1/repos`
@@ -150,6 +151,9 @@ pub async fn upsert(
         body.setup_script_always_run,
     )
     .await?;
+    // Realtime: clone the added/enabled repo into the workspace now, in the
+    // background (or queue its removal if it was disabled) (issue #343).
+    repo_sync::sync_repos(&state, vec![repo.clone()]);
     state.notify_board();
     Ok(Json(repo))
 }
@@ -177,6 +181,8 @@ pub async fn update(
         body.setup_script_always_run,
     )
     .await?;
+    // Realtime: reconcile the workspace to the edited repo's state (issue #343).
+    repo_sync::sync_repos(&state, vec![repo.clone()]);
     state.notify_board();
     Ok(Json(repo))
 }
@@ -195,7 +201,13 @@ pub async fn delete(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    // Capture the row before deleting so we can remove its workspace clone; the
+    // row (and its railway/name) is gone after the delete (issue #343).
+    let removed = queries::get_repository(&state.db, id).await?;
     queries::delete_repository(&state.db, id).await?;
+    if let Some(repo) = removed {
+        repo_sync::queue_removals(&state, &[repo]);
+    }
     state.notify_board();
     Ok(Json(json!({ "deleted": true })))
 }
@@ -239,6 +251,12 @@ pub async fn bulk_fields(
 ) -> ApiResult<Json<serde_json::Value>> {
     let updated =
         queries::bulk_set_repo_fields(&state.db, &body.ids, body.enabled, body.sync_issues).await?;
+    // Realtime: an `enabled` flip clones the newly-enabled repos or queues the
+    // disabled ones for removal (issue #343). Skip when only `sync_issues` changed.
+    if body.enabled.is_some() {
+        let affected = queries::list_repositories_by_ids(&state.db, &body.ids).await?;
+        repo_sync::sync_repos(&state, affected);
+    }
     state.notify_board();
     Ok(Json(json!({ "updated": updated })))
 }
@@ -249,7 +267,11 @@ pub async fn bulk_delete(
     State(state): State<AppState>,
     Json(body): Json<BulkRepoIdsRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    // Capture the rows before deleting so their workspace clones can be removed
+    // between tasks (issue #343).
+    let removed = queries::list_repositories_by_ids(&state.db, &body.ids).await?;
     let deleted = queries::delete_repositories(&state.db, &body.ids).await?;
+    repo_sync::queue_removals(&state, &removed);
     state.notify_board();
     Ok(Json(json!({ "deleted": deleted })))
 }
@@ -272,12 +294,13 @@ pub async fn import_org(
     let discovered = git::list_org_repos(&github, &body.owner).await?;
 
     let mut imported = 0_usize;
+    let mut added = Vec::new();
     for repo in &discovered {
         let existed = queries::get_repository_by_full_name(&state.db, &repo.full_name)
             .await?
             .is_some();
         // Newly discovered repos inherit the global branch template (override later).
-        queries::create_repository_if_absent(
+        let created = queries::create_repository_if_absent(
             &state.db,
             &repo.full_name,
             &repo.clone_url,
@@ -289,9 +312,13 @@ pub async fn import_org(
         .await?;
         if !existed {
             imported += 1;
+            added.push(created);
         }
     }
 
+    // Realtime: clone every newly-imported repo into the workspace now, in the
+    // background, so a big org import lands immediately (issue #343).
+    repo_sync::sync_repos(&state, added);
     state.notify_board();
     Ok(Json(json!({
         "discovered": discovered.len(),

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -20,6 +20,9 @@ mod prompt;
 // seed endpoint (#216), so this module is crate-visible rather than orchestrator-private.
 pub(crate) mod provision;
 mod railway;
+// Realtime add/remove of repos in the workspace (issue #343): the HTTP repo
+// endpoints call `sync_repos` / `queue_removals`, the agent loop drains removals.
+pub(crate) mod repo_sync;
 mod review;
 mod subscription;
 mod thoughts;
@@ -1036,10 +1039,12 @@ pub async fn move_repo_to_railway(
     repo_id: uuid::Uuid,
     target_railway_id: uuid::Uuid,
 ) -> Result<std::result::Result<Repository, RailwayActionError>> {
-    if queries::get_repository(&state.db, repo_id).await?.is_none()
-        || queries::get_railway(&state.db, target_railway_id)
-            .await?
-            .is_none()
+    let Some(before) = queries::get_repository(&state.db, repo_id).await? else {
+        return Ok(Err(RailwayActionError::NotFound));
+    };
+    if queries::get_railway(&state.db, target_railway_id)
+        .await?
+        .is_none()
     {
         return Ok(Err(RailwayActionError::NotFound));
     }
@@ -1052,6 +1057,13 @@ pub async fn move_repo_to_railway(
         return Ok(Err(RailwayActionError::NotFound));
     };
     info!(repo_id = %repo.id, full_name = %repo.full_name, railway_id = %target_railway_id, "moved repo to railway");
+    // Realtime (issue #343): the clone is now stale on the old railway, so queue its
+    // removal there (applied between that lane's tasks), and clone it into the new
+    // railway in the background. A no-op when the railway is unchanged.
+    if before.railway_id != repo.railway_id {
+        repo_sync::queue_removals(state, std::slice::from_ref(&before));
+    }
+    repo_sync::sync_repos(state, vec![repo.clone()]);
     state.notify_board();
     Ok(Ok(repo))
 }
@@ -1311,6 +1323,14 @@ async fn agent_loop(state: AppState, handle: RailwayHandle) {
                 continue;
             }
         };
+
+        // Apply any repo removals queued while the agent was busy (issue #343). This
+        // runs between tasks - the loop only reaches here after a turn completes -
+        // so a running turn is never disrupted. Cheap in-memory check first, so an
+        // idle lane does no Docker work when there is nothing to remove.
+        if state.has_pending_removals(handle.id) {
+            repo_sync::apply_pending_removals(&state, &handle).await;
+        }
 
         match next_actionable_task(&state, &railway).await {
             Ok(Some((task, mode))) => {

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -218,6 +218,53 @@ pub async fn provision_workspace(state: &AppState, handle: &RailwayHandle) -> Re
     run(state, handle.container(), &script).await
 }
 
+/// Clones (or, if already cloned, fetches) a single repo into the railway's
+/// container, out of band from a full provision (issue #343). The realtime add path
+/// so a newly-added repo lands in the workspace immediately rather than only on the
+/// next full provision. Idempotent, and it never re-runs the setup script on an
+/// existing clone (that stays a per-task concern, #275), so re-running it for an
+/// edited repo just refreshes the clone and its `CLAUDE.md`.
+///
+/// AGENTS.md and the config repo already exist from the full provision, so this
+/// writes only this repo's `CLAUDE.md`, not the shared prelude.
+pub async fn clone_repo(state: &AppState, handle: &RailwayHandle, repo: &Repository) -> Result<()> {
+    let script = format!("set -e\n{}", repo_block(repo, false));
+    run(state, handle.container(), &script).await
+}
+
+/// Removes the given repo clone directories from the railway's container (issue
+/// #343). Best-effort `rm -rf`; a missing dir is a no-op. Applied between the
+/// agent's tasks so a running turn is never disrupted. Unsafe names (empty, `.`,
+/// `..`, or containing `/`) are skipped so this can only ever delete a flat repo
+/// clone under `/workspace`.
+pub async fn remove_repo_dirs(
+    state: &AppState,
+    handle: &RailwayHandle,
+    dir_names: &[String],
+) -> Result<()> {
+    let script = removal_script(dir_names);
+    if script.is_empty() {
+        return Ok(());
+    }
+    run(state, handle.container(), &script).await
+}
+
+/// Whether a name is safe to `rm -rf` as a direct child of `/workspace`: a
+/// non-empty flat name, never `.`/`..` or a path that could escape the directory.
+fn is_safe_repo_dir(name: &str) -> bool {
+    !name.is_empty() && name != "." && name != ".." && !name.contains('/')
+}
+
+/// Builds the `rm -rf` script for the removal dirs, skipping any unsafe name. The
+/// `--` and quoting keep a repo name that starts with `-` or contains spaces safe.
+fn removal_script(dir_names: &[String]) -> String {
+    let mut script = String::new();
+    for name in dir_names.iter().filter(|name| is_safe_repo_dir(name)) {
+        script.push_str(&format!("rm -rf -- \"/workspace/{name}\"\n"));
+    }
+    script
+}
+
 /// Bash that returns a repo's working tree to a clean state before a checkout.
 ///
 /// A turn interrupted mid-merge/rebase (e.g. the API restarting during a
@@ -420,7 +467,9 @@ async fn run(state: &AppState, container: &str, script: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{branch_prep_snippet, repo_block, submodule_update_snippet};
+    use super::{
+        branch_prep_snippet, is_safe_repo_dir, removal_script, repo_block, submodule_update_snippet,
+    };
     use crate::db::models::Repository;
     use chrono::Utc;
     use uuid::Uuid;
@@ -522,5 +571,39 @@ mod tests {
                 || script.contains("submodule update --init --recursive")
         );
         assert!(script.contains("exit 1"));
+    }
+
+    #[test]
+    fn removal_script_rms_each_safe_dir_and_skips_unsafe_ones() {
+        let script = removal_script(&[
+            "Plunder".to_string(),
+            "my.repo".to_string(),
+            // Unsafe names must never make it into an `rm`.
+            "..".to_string(),
+            ".".to_string(),
+            "a/b".to_string(),
+            String::new(),
+        ]);
+        assert!(script.contains("rm -rf -- \"/workspace/Plunder\""));
+        assert!(script.contains("rm -rf -- \"/workspace/my.repo\""));
+        // No traversal or nested path can be emitted.
+        assert!(!script.contains("/workspace/.."));
+        assert!(!script.contains("/workspace/a/b"));
+        // Two safe dirs -> exactly two rm lines.
+        assert_eq!(script.matches("rm -rf --").count(), 2);
+        // An all-unsafe (or empty) input yields no script, so nothing runs.
+        assert!(removal_script(&["..".to_string()]).is_empty());
+        assert!(removal_script(&[]).is_empty());
+    }
+
+    #[test]
+    fn is_safe_repo_dir_rejects_traversal_and_paths() {
+        assert!(is_safe_repo_dir("Plunder"));
+        assert!(is_safe_repo_dir("my.repo-1_x"));
+        assert!(!is_safe_repo_dir(""));
+        assert!(!is_safe_repo_dir("."));
+        assert!(!is_safe_repo_dir(".."));
+        assert!(!is_safe_repo_dir("a/b"));
+        assert!(!is_safe_repo_dir("/etc"));
     }
 }

--- a/api/src/orchestrator/repo_sync.rs
+++ b/api/src/orchestrator/repo_sync.rs
@@ -1,0 +1,112 @@
+//! Realtime add/remove of repos in the workspace (issue #343).
+//!
+//! Adding a repo clones it into the workspace immediately, in the background, so a
+//! freshly-added repo lands without waiting for the next full provision (the bug the
+//! issue reports: "we added a lot of repos and nothing happened"). The clone runs as
+//! its own `docker exec` on a new directory, so it never blocks the HTTP response
+//! and never disrupts the agent's in-flight turn (a different repo dir).
+//!
+//! Removing a repo is deferred: the clone dir is queued and `rm -rf`'d by the
+//! railway's agent loop BETWEEN tasks, so the agent's work is never interrupted.
+
+use tracing::{info, warn};
+
+use crate::db::models::Repository;
+use crate::docker::ContainerState;
+use crate::state::AppState;
+
+use super::provision;
+use super::railway::{self, RailwayHandle};
+
+/// Reconciles the workspace to a set of just-mutated repos (issue #343): the enabled
+/// ones are cloned into their railway in the background; the disabled ones have their
+/// clone dir queued for removal between tasks. One call handles the add, edit, and
+/// enable/disable paths uniformly by converging each repo to its desired state.
+pub fn sync_repos(state: &AppState, repos: Vec<Repository>) {
+    // A disabled repo should not sit in the workspace (a full provision only clones
+    // enabled repos), so queue its clone dir for removal.
+    for repo in repos.iter().filter(|repo| !repo.enabled) {
+        state.queue_repo_removal(
+            repo.railway_id,
+            provision::repo_dir_name(&repo.full_name).to_string(),
+        );
+    }
+
+    let to_clone: Vec<Repository> = repos.into_iter().filter(|repo| repo.enabled).collect();
+    if to_clone.is_empty() {
+        return;
+    }
+
+    // Clone in one background task, sequentially, so importing an org of dozens of
+    // repos does not fan out into dozens of concurrent clones.
+    let state = state.clone();
+    tokio::spawn(async move {
+        for repo in to_clone {
+            if let Err(error) = clone_one(&state, &repo).await {
+                warn!(repo = %repo.full_name, %error, "background repo clone failed");
+            }
+        }
+    });
+}
+
+/// Queues the given (typically just-deleted) repos' clone dirs for removal between
+/// tasks. Deleted repos are gone from the DB, so the caller passes the rows it
+/// captured before the delete.
+pub fn queue_removals(state: &AppState, repos: &[Repository]) {
+    for repo in repos {
+        state.queue_repo_removal(
+            repo.railway_id,
+            provision::repo_dir_name(&repo.full_name).to_string(),
+        );
+    }
+}
+
+/// Clones one repo into its railway's container, but only when that container is
+/// already running: `main`'s always is, and a stopped non-`main` railway will clone
+/// the repo on its next provision (`ensure_running`), so there is no need to spin a
+/// container up just to pre-clone.
+async fn clone_one(state: &AppState, repo: &Repository) -> eyre::Result<()> {
+    let handle = railway::handle_for(state, repo.railway_id).await?;
+    if !container_running(state, &handle).await? {
+        return Ok(());
+    }
+    provision::clone_repo(state, &handle, repo).await?;
+    info!(repo = %repo.full_name, "cloned a newly-added repo into the workspace");
+    Ok(())
+}
+
+/// Applies a railway's queued repo removals, called by the agent loop between tasks
+/// (issue #343). Only removes from a running container (never starts one just to
+/// clean up); on failure the dirs are re-queued so the next tick retries.
+pub async fn apply_pending_removals(state: &AppState, handle: &RailwayHandle) {
+    match container_running(state, handle).await {
+        Ok(true) => {}
+        // Stopped/absent: leave the dirs queued until the container is next running.
+        Ok(false) => return,
+        Err(error) => {
+            warn!(error = %error, railway_id = %handle.id, "could not check container state for repo removal");
+            return;
+        }
+    }
+
+    let dirs = state.take_pending_removals(handle.id);
+    if dirs.is_empty() {
+        return;
+    }
+    match provision::remove_repo_dirs(state, handle, &dirs).await {
+        Ok(()) => {
+            info!(count = dirs.len(), railway_id = %handle.id, "removed queued repo clone dirs between tasks")
+        }
+        Err(error) => {
+            warn!(error = %error, railway_id = %handle.id, "failed to remove queued repo clone dirs; re-queuing");
+            for dir in dirs {
+                state.queue_repo_removal(handle.id, dir);
+            }
+        }
+    }
+}
+
+/// Whether a railway's container is currently running (so an exec would succeed).
+async fn container_running(state: &AppState, handle: &RailwayHandle) -> eyre::Result<bool> {
+    Ok(state.workspace.container_state(handle.container()).await? == ContainerState::Running)
+}

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared application state and the server-sent-event broadcast bus.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -193,6 +193,12 @@ pub struct AppState {
     /// post-turn handling (session persist, task move) if it changed, so a reset
     /// that lands mid-turn is never undone by the turn it interrupted.
     reset_epoch: Arc<AtomicU64>,
+    /// Repo clone dirs queued for removal from a railway's workspace, keyed by
+    /// `railway_id` (issue #343). A removed/disabled repo enqueues its flat clone
+    /// dir here; the railway's agent loop drains it BETWEEN tasks (never mid-turn)
+    /// and `rm -rf`s the dirs. Ephemeral: a restart re-provisions from the DB and a
+    /// stale dir is harmless (the agent never touches an un-tracked dir).
+    pending_removals: Arc<RwLock<HashMap<Uuid, HashSet<String>>>>,
     /// Static self-update config (the build's commit/branch + host paths).
     pub update: crate::config::UpdateConfig,
     /// The cached result of the last self-update check, refreshed hourly.
@@ -248,6 +254,7 @@ impl AppState {
             usage: Arc::new(RwLock::new(None)),
             claude_token_refresh: Arc::new(AsyncMutex::new(())),
             reset_epoch: Arc::new(AtomicU64::new(0)),
+            pending_removals: Arc::new(RwLock::new(HashMap::new())),
             update,
             update_status: Arc::new(RwLock::new(update_status)),
         }
@@ -289,6 +296,38 @@ impl AppState {
     /// follow this with [`Self::notify_board`] so the navbar status updates live.
     pub fn set_cooldown_until(&self, until: Option<DateTime<Utc>>) {
         *self.cooldown_until.write().expect("cooldown lock poisoned") = until;
+    }
+
+    /// Queues a repo clone dir for removal from a railway's workspace (issue #343).
+    /// The railway's agent loop drains this between tasks. Idempotent (a set), so
+    /// enqueuing the same dir twice removes it once.
+    pub fn queue_repo_removal(&self, railway_id: Uuid, dir_name: String) {
+        self.pending_removals
+            .write()
+            .expect("pending removals lock poisoned")
+            .entry(railway_id)
+            .or_default()
+            .insert(dir_name);
+    }
+
+    /// Whether a railway has repo removals waiting. A cheap in-memory check the
+    /// agent loop makes each tick before doing any Docker work.
+    pub fn has_pending_removals(&self, railway_id: Uuid) -> bool {
+        self.pending_removals
+            .read()
+            .expect("pending removals lock poisoned")
+            .get(&railway_id)
+            .is_some_and(|dirs| !dirs.is_empty())
+    }
+
+    /// Takes (and clears) a railway's queued removal dirs.
+    pub fn take_pending_removals(&self, railway_id: Uuid) -> Vec<String> {
+        self.pending_removals
+            .write()
+            .expect("pending removals lock poisoned")
+            .remove(&railway_id)
+            .map(|dirs| dirs.into_iter().collect())
+            .unwrap_or_default()
     }
 
     /// The live token usage of one railway's in-progress turn, if it is generating.


### PR DESCRIPTION
Closes #343.

## Why

Adding repos did nothing to the workspace until the next full provision (the reported scenario: "we added a lot of repos and nothing happened"). This makes repo changes take effect in the workspace in realtime, following the issue's two rules: clone additions immediately in the background (without disturbing the agent), and defer removals to between the agent's tasks.

## What changed

**Adds → immediate background clone.** Any mutation that adds/enables a repo (single add `POST /repos`, edit `PUT /repos/:id`, `POST /repos/bulk/fields` enable, `POST /repos/import-org`, and the railway-reassign path) calls `orchestrator::repo_sync::sync_repos`, which spawns a background task that clones each enabled repo into its railway via `provision::clone_repo`. It runs as its own `docker exec` on a new directory, so the HTTP response returns immediately and the agent's in-flight turn (a different repo dir) is never disrupted. Cloning only happens into an already-running container (`main` always is; a stopped railway clones on its next provision), and an org import clones sequentially in one task rather than fanning out.

**Removes/disables → deferred cleanup between tasks.** Deleting (`DELETE /repos/:id`, `POST /repos/bulk/delete`), disabling, or reassigning a repo queues its clone dir on `AppState::pending_removals`. The railway's agent loop drains the queue at the top of its iteration, which is only reached between tasks, so a running turn is never interrupted (`repo_sync::apply_pending_removals`). Removal only touches a running container and re-queues on failure.

**Safety.** `provision::remove_repo_dirs` only ever `rm -rf`s a flat `/workspace/{name}`; unsafe names (empty, `.`, `..`, or containing `/`) are skipped, and the `.claude` config dir is never a repo dir, so it is never removed. This is unit-tested.

## Testing

- `cargo +1.88 fmt --check` and `test` (184 pass, incl. new `removal_script` / `is_safe_repo_dir` safety tests). New-file clippy is clean (the one `push_str(&format!(..))` hit matches the file's established idiom).
- End-to-end against a live API (ephemeral Postgres) pointed at a throwaway container built from the workspace image (never the operator's real container): adding a repo cloned it in ~2s; deleting it removed the dir between agent-loop ticks (~6s, `.claude` preserved); disabling via `PUT` converged to removal (~4s). Logs confirmed both `repo_sync` paths.
- No UI changes, so visual self-review was skipped (backend-only).