### PR TITLE
Host self-updater script and installer (#346)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,6 +682,23 @@ turn is in progress, pauses the agent, then launches a detached `docker:cli`
 The UI then polls `/version` and reloads when the commit changes. `HOST_REPO_DIR`
 is the only new required env for the in-app update (the check works without it).
 
+**Host self-updater (issue #346, `scripts/update.*` + `scripts/install.*`):** a
+host-side alternative to the in-app button, for keeping a deployment current with
+no clicks. `scripts/update.sh` (Linux/macOS/Git Bash) and `scripts/update.ps1`
+(Windows PowerShell 5.1+) run one pass: only on `main`/`develop`, only when the
+tree is clean and behind its upstream, they wait for the agent to catch up (the
+`agent_caught_up` flag on `GET /update/status`, true when To Do / In Progress /
+In Review hold no agent action items), pause it (`POST /settings/pause`, which the
+board reflects), drain the in-flight turn (`agent_working`), `git pull --ff-only`,
+relaunch via `scripts/start.sh` (or `docker compose up -d --build` on Windows),
+then resume unless the operator had it paused. The update proceeds even if the API
+is unreachable (no graceful pause then). `scripts/install.sh` installs a systemd
+timer (`seraphim-update.{service,timer}`, default 15 min; prints cron instructions
+when `systemctl` is absent); `scripts/install.ps1` registers the `SeraphimSelfUpdater`
+Scheduled Task. `uninstall.*` remove them. All knobs are `SERAPHIM_*` env vars
+(see `scripts/README.md`). This path does its own `git pull` + compose on the host,
+so it needs no `HOST_REPO_DIR` and no updater container.
+
 ## LiteLLM proxy sidecar (issue #342)
 
 Groundwork toward running the agent on any LiteLLM-supported LLM (OpenAI, xAI

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1314,6 +1314,28 @@ pub async fn any_task_in_progress(pool: &PgPool) -> sqlx::Result<bool> {
     .await
 }
 
+/// Whether the agent has no remaining action items (issue #346): nothing queued
+/// in To Do, nothing In Progress, and no In Review PR still waiting on an agent
+/// turn (a CI fix, a merge-conflict resolve, or review-comment addressing).
+/// Cards parked on an external or human wait (awaiting review, CI-blocked) do not
+/// count, since the agent is not the one holding them up. This mirrors the work
+/// `next_actionable_task` would pull, so it is the authoritative "caught up"
+/// signal: the host self-updater waits for it before restarting the stack, so a
+/// rebuild never interrupts a live turn or drops queued work.
+pub async fn agent_caught_up(pool: &PgPool) -> sqlx::Result<bool> {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT NOT EXISTS(\
+             SELECT 1 FROM tasks \
+             WHERE board_column = 'in_progress' \
+                OR (board_column = 'todo' AND hold = FALSE) \
+                OR (board_column = 'in_review' AND hold = FALSE \
+                    AND status IN ('ci_failing', 'merge_conflict', 'addressing_review'))\
+         )",
+    )
+    .fetch_one(pool)
+    .await
+}
+
 pub async fn get_task(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Task>> {
     sqlx::query_as::<_, Task>("SELECT * FROM tasks WHERE id = $1")
         .bind(id)

--- a/api/src/http/update.rs
+++ b/api/src/http/update.rs
@@ -36,15 +36,21 @@ pub struct UpdateStatusResponse {
     agent_paused: bool,
     /// Whether a turn is actively running (the Update button is disabled then).
     agent_working: bool,
+    /// Whether the agent has no remaining action items across To Do, In Progress,
+    /// and In Review (issue #346). The host self-updater waits for this before it
+    /// restarts the stack, so a rebuild lands at a natural lull.
+    agent_caught_up: bool,
 }
 
 async fn status_response(state: &AppState) -> ApiResult<UpdateStatusResponse> {
     let settings = queries::get_settings(&state.db).await?;
     let working = queries::any_task_in_progress(&state.db).await?;
+    let caught_up = queries::agent_caught_up(&state.db).await?;
     Ok(UpdateStatusResponse {
         status: state.update_status(),
         agent_paused: settings.agent_paused,
         agent_working: working,
+        agent_caught_up: caught_up,
     })
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,84 @@
+# Seraphim host scripts
+
+Wrappers the operator runs on the host that hosts the Docker stack.
+
+| Script | Platform | Purpose |
+|---|---|---|
+| `start.sh` / `stop.sh` / `restart.sh` | Linux, macOS, Git Bash | Bring the compose stack up, down, or restart it. |
+| `update.sh` / `update.ps1` | Linux + macOS / Windows | Run one safe self-update pass. |
+| `install.sh` / `install.ps1` | Linux (systemd) / Windows | Install the updater to run on a timer. |
+| `uninstall.sh` / `uninstall.ps1` | Linux / Windows | Remove the scheduled updater. |
+
+## Self-updater (issue #346)
+
+Keeps a deployment current with its branch. One pass:
+
+1. Confirm the checkout is on an updatable branch (`main` or `develop`) and the
+   working tree is clean.
+2. `git fetch` and confirm the branch is behind its upstream (there is work to pull).
+3. Wait for the agent to reach a lull (no To Do / In Progress / In Review action
+   items), then pause it and wait for any in-flight turn to finish.
+4. `git pull --ff-only`, then rebuild and relaunch the compose stack.
+5. Resume the agent, unless the operator had it paused before the update.
+
+The agent's "caught up" and "working" states come from `GET /api/v1/update/status`;
+the pause/resume calls hit `POST /api/v1/settings/pause`. If the API is
+unreachable, the update still runs (without the graceful pause).
+
+### One-off
+
+```bash
+# Linux / macOS / Git Bash
+bash ./scripts/update.sh
+```
+
+```powershell
+# Windows (PowerShell)
+powershell -ExecutionPolicy Bypass -File .\scripts\update.ps1
+```
+
+### Install on a timer
+
+```bash
+# Linux (systemd timer, default every 15 min). Uses sudo to write unit files.
+bash ./scripts/install.sh
+```
+
+```powershell
+# Windows (Scheduled Task, default every 15 min). Docker Desktop must be running.
+powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1
+```
+
+On Linux the installer writes `/etc/systemd/system/seraphim-update.{service,timer}`
+and enables the timer. If `systemctl` is absent it prints ready-to-paste cron
+instructions instead (including how to install `cronie`/`cron`). Windows registers
+a Scheduled Task named `SeraphimSelfUpdater`.
+
+### Configuration
+
+Both updaters read these environment variables (defaults in parentheses):
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `SERAPHIM_REPO_DIR` | the script's repo | Path to the Seraphim checkout to update. |
+| `SERAPHIM_API_URL` | `http://localhost:27182` | API base URL for pause/status. |
+| `SERAPHIM_UPDATE_BRANCHES` | `main develop` | Branches the updater may fast-forward. |
+| `SERAPHIM_CAUGHT_UP_TIMEOUT` | `3600` | Seconds to wait for a lull before pausing anyway (`0` = forever). |
+| `SERAPHIM_DRAIN_TIMEOUT` | `1800` | Seconds to wait for the current turn to finish after pausing. |
+| `SERAPHIM_HEALTH_TIMEOUT` | `300` | Seconds to wait for the API after the rebuild before resuming. |
+| `SERAPHIM_POLL_SECONDS` | `10` | Seconds between status polls while waiting. |
+
+Installer-only knobs:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `SERAPHIM_UPDATE_INTERVAL` (Linux) | `15min` | systemd time span between runs. |
+| `SERAPHIM_UPDATE_INTERVAL_MINUTES` (Windows) | `15` | Minutes between runs. |
+| `SERAPHIM_UPDATE_USER` (Linux) | invoking user | Account the timer runs as (must be in the `docker` group). |
+
+### Requirements
+
+`git`, `curl` (Linux), and Docker with the Compose plugin. The updater checks for
+each and prints an install command if one is missing. systemd (`systemctl`) is
+used on Linux and ships on RHEL and Debian; the Windows path uses the built-in
+`ScheduledTasks` module.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+  Install the Seraphim host self-updater as a Windows Scheduled Task (issue #346).
+
+.DESCRIPTION
+  Registers a task that runs scripts/update.ps1 on an interval (default every 15
+  minutes) as the current user, so the host keeps itself up to date. Docker
+  Desktop must be running for the update to rebuild the stack.
+
+    powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1
+
+  Uninstall with scripts/uninstall.ps1.
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-Env([string]$Name, [string]$Default) {
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrEmpty($value)) { return $Default } else { return $value }
+}
+
+$RepoDir = Get-Env 'SERAPHIM_REPO_DIR' (Resolve-Path "$PSScriptRoot\..").Path
+$IntervalMinutes = [int](Get-Env 'SERAPHIM_UPDATE_INTERVAL_MINUTES' '15')
+$TaskName = 'SeraphimSelfUpdater'
+$UpdateScript = Join-Path $RepoDir 'scripts\update.ps1'
+
+function Write-Log([string]$Message) { Write-Host "[seraphim-install] $Message" }
+
+if (-not (Test-Path $UpdateScript)) { Write-Log "Cannot find $UpdateScript"; exit 1 }
+if (-not (Get-Command Register-ScheduledTask -ErrorAction SilentlyContinue)) {
+  Write-Log 'The ScheduledTasks module is unavailable. Register a task manually with schtasks.exe, or run update.ps1 from your own scheduler.'
+  exit 1
+}
+
+Write-Log "Installing scheduled task '$TaskName' (runs as '$env:USERNAME', every $IntervalMinutes min)."
+
+$action = New-ScheduledTaskAction `
+  -Execute 'powershell.exe' `
+  -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$UpdateScript`"" `
+  -WorkingDirectory $RepoDir
+
+# Repeat from one minute after registration. A 10-year duration is effectively
+# indefinite and avoids the out-of-range error some Windows builds raise for
+# [TimeSpan]::MaxValue.
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+  -RepetitionInterval (New-TimeSpan -Minutes $IntervalMinutes) `
+  -RepetitionDuration (New-TimeSpan -Days 3650)
+
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -MultipleInstances IgnoreNew
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+  -Settings $settings -Principal $principal -Force | Out-Null
+
+Write-Log 'Done. The updater is installed and scheduled.'
+Write-Log "Run now:   Start-ScheduledTask -TaskName $TaskName"
+Write-Log "Inspect:   Get-ScheduledTask -TaskName $TaskName | Get-ScheduledTaskInfo"
+Write-Log "Uninstall: powershell -ExecutionPolicy Bypass -File `"$($RepoDir)\scripts\uninstall.ps1`""
+Write-Log 'Note: Docker Desktop must be running (and you logged on) for scheduled updates to rebuild the stack.'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Install the Seraphim host self-updater as a systemd timer (issue #346).
+#
+# Registers a system service + timer that runs scripts/update.sh on an interval
+# (default every 15 minutes), so the host keeps itself up to date. Both RHEL and
+# Debian ship systemd, so a timer needs no extra packages; if systemd is absent,
+# this prints ready-to-paste cron instructions instead.
+#
+#   bash ./scripts/install.sh            # install and start the timer
+#   sudo bash ./scripts/install.sh       # same, if your user can't sudo unattended
+#
+# Uninstall with scripts/uninstall.sh.
+set -euo pipefail
+
+REPO_DIR="${SERAPHIM_REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+# How often to poll for updates, as a systemd time span (e.g. 15min, 1h).
+INTERVAL="${SERAPHIM_UPDATE_INTERVAL:-15min}"
+# The account the updater runs as. It must be in the docker group and able to run
+# `docker compose`. Defaults to the invoking user (not root).
+RUN_USER="${SERAPHIM_UPDATE_USER:-${SUDO_USER:-$USER}}"
+
+SERVICE_NAME="seraphim-update"
+SERVICE_PATH="/etc/systemd/system/${SERVICE_NAME}.service"
+TIMER_PATH="/etc/systemd/system/${SERVICE_NAME}.timer"
+UPDATE_SCRIPT="${REPO_DIR}/scripts/update.sh"
+
+log() { printf '[seraphim-install] %s\n' "$*"; }
+
+[ -f "$UPDATE_SCRIPT" ] || { echo "Cannot find $UPDATE_SCRIPT" >&2; exit 1; }
+chmod +x "$UPDATE_SCRIPT"
+
+# Prefer sudo only when we are not already root, so the script works both ways.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+# --- Fall back to cron instructions when systemd is unavailable ---------------
+if ! command -v systemctl >/dev/null 2>&1; then
+  cat >&2 <<EOF
+[seraphim-install] systemd (systemctl) was not found on this host.
+
+Install the updater with cron instead. Ensure cron is installed:
+  RHEL:   sudo dnf install -y cronie && sudo systemctl enable --now crond
+  Debian: sudo apt install -y cron   && sudo systemctl enable --now cron
+
+Then add this line to your crontab ("crontab -e"), which runs the updater
+every 15 minutes:
+  */15 * * * * SERAPHIM_REPO_DIR='${REPO_DIR}' ${UPDATE_SCRIPT} >> /tmp/seraphim-update.log 2>&1
+EOF
+  exit 1
+fi
+
+log "Installing ${SERVICE_NAME}.service and .timer (runs as '${RUN_USER}', every ${INTERVAL})."
+
+# The service is a oneshot that runs a single update pass. Config the updater
+# reads from the environment is pinned here so timer runs match a manual run.
+$SUDO tee "$SERVICE_PATH" >/dev/null <<EOF
+[Unit]
+Description=Seraphim host self-updater (one update pass)
+Documentation=https://github.com/JalapenoLabs/Seraphim
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=${RUN_USER}
+WorkingDirectory=${REPO_DIR}
+Environment=SERAPHIM_REPO_DIR=${REPO_DIR}
+ExecStart=${UPDATE_SCRIPT}
+# A rebuild (docker compose --build) can run well past the 90s oneshot default,
+# and the updater waits for the agent to drain; never time it out mid-update.
+TimeoutStartSec=infinity
+EOF
+
+$SUDO tee "$TIMER_PATH" >/dev/null <<EOF
+[Unit]
+Description=Run the Seraphim host self-updater every ${INTERVAL}
+Documentation=https://github.com/JalapenoLabs/Seraphim
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=${INTERVAL}
+Persistent=true
+Unit=${SERVICE_NAME}.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+$SUDO systemctl daemon-reload
+$SUDO systemctl enable --now "${SERVICE_NAME}.timer"
+
+log "Done. The updater is installed and scheduled."
+log "Next runs:   systemctl list-timers ${SERVICE_NAME}.timer"
+log "Run now:     sudo systemctl start ${SERVICE_NAME}.service"
+log "View logs:   journalctl -u ${SERVICE_NAME}.service -f"
+log "Uninstall:   bash ${REPO_DIR}/scripts/uninstall.sh"

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,20 @@
+<#
+.SYNOPSIS
+  Remove the Seraphim host self-updater Scheduled Task (issue #346).
+
+    powershell -ExecutionPolicy Bypass -File .\scripts\uninstall.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$TaskName = 'SeraphimSelfUpdater'
+
+function Write-Log([string]$Message) { Write-Host "[seraphim-uninstall] $Message" }
+
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+  Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+  Write-Log "Removed scheduled task '$TaskName'."
+}
+else {
+  Write-Log "No scheduled task named '$TaskName' found."
+}

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Remove the Seraphim host self-updater systemd timer (issue #346).
+#
+#   bash ./scripts/uninstall.sh
+set -euo pipefail
+
+SERVICE_NAME="seraphim-update"
+SERVICE_PATH="/etc/systemd/system/${SERVICE_NAME}.service"
+TIMER_PATH="/etc/systemd/system/${SERVICE_NAME}.timer"
+
+log() { printf '[seraphim-uninstall] %s\n' "$*"; }
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  log "systemd not found. If you installed a cron entry, remove it with 'crontab -e'."
+  exit 0
+fi
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+$SUDO systemctl disable --now "${SERVICE_NAME}.timer" 2>/dev/null || true
+$SUDO rm -f "$TIMER_PATH" "$SERVICE_PATH"
+$SUDO systemctl daemon-reload
+
+log "Removed the Seraphim self-updater timer and service."

--- a/scripts/update.ps1
+++ b/scripts/update.ps1
@@ -1,0 +1,184 @@
+<#
+.SYNOPSIS
+  Keep a Seraphim host deployment up to date on Windows (issue #346).
+
+.DESCRIPTION
+  One safe, idempotent update pass, mirroring scripts/update.sh:
+    1. Confirm the checkout is on an updatable branch (main/develop) and clean.
+    2. Fetch and confirm the branch is behind its upstream.
+    3. Wait for the agent to catch up, then pause it so nothing new starts.
+    4. git pull --ff-only, then rebuild and relaunch the compose stack.
+    5. Resume the agent, unless the operator had it paused before we started.
+
+  Run directly:   powershell -ExecutionPolicy Bypass -File .\scripts\update.ps1
+  Install a task: powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1
+
+  Every knob is an environment variable with a sensible default. See scripts/README.md.
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Read an environment variable, falling back to a default. Kept 5.1-compatible
+# (no `??`), since Windows 11 ships Windows PowerShell 5.1 by default.
+function Get-Env([string]$Name, [string]$Default) {
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrEmpty($value)) { return $Default } else { return $value }
+}
+
+# --- Configuration -----------------------------------------------------------
+
+$RepoDir   = Get-Env 'SERAPHIM_REPO_DIR' (Resolve-Path "$PSScriptRoot\..").Path
+$ApiUrl    = Get-Env 'SERAPHIM_API_URL' 'http://localhost:27182'
+$Branches  = (Get-Env 'SERAPHIM_UPDATE_BRANCHES' 'main develop') -split '\s+'
+$CaughtUpTimeout = [int](Get-Env 'SERAPHIM_CAUGHT_UP_TIMEOUT' '3600')
+$DrainTimeout    = [int](Get-Env 'SERAPHIM_DRAIN_TIMEOUT' '1800')
+$HealthTimeout   = [int](Get-Env 'SERAPHIM_HEALTH_TIMEOUT' '300')
+$PollSeconds     = [int](Get-Env 'SERAPHIM_POLL_SECONDS' '10')
+
+$Api = ($ApiUrl.TrimEnd('/')) + '/api/v1'
+
+# --- Helpers -----------------------------------------------------------------
+
+function Write-Log([string]$Message) {
+  Write-Host ("{0} [seraphim-update] {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Message)
+}
+
+function Assert-Command([string]$Name, [string]$Hint) {
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    Write-Log "Missing required command: $Name"
+    Write-Log "Install it, then re-run: $Hint"
+    exit 1
+  }
+}
+
+function Test-ApiReachable {
+  try { Invoke-RestMethod -Method Get -Uri "$Api/ping" -TimeoutSec 5 | Out-Null; return $true }
+  catch { return $false }
+}
+
+function Get-AgentStatus {
+  try { return Invoke-RestMethod -Method Get -Uri "$Api/update/status" -TimeoutSec 10 }
+  catch { return $null }
+}
+
+function Set-Paused([bool]$Paused) {
+  $body = @{ paused = $Paused } | ConvertTo-Json -Compress
+  try { Invoke-RestMethod -Method Post -Uri "$Api/settings/pause" -Body $body -ContentType 'application/json' -TimeoutSec 10 | Out-Null; return $true }
+  catch { return $false }
+}
+
+# --- Preconditions -----------------------------------------------------------
+
+Assert-Command git 'https://git-scm.com/download/win'
+Assert-Command docker 'https://docs.docker.com/desktop/install/windows-install/'
+try { docker compose version | Out-Null }
+catch { Write-Log 'The Docker Compose plugin is missing (install Docker Desktop).'; exit 1 }
+
+Set-Location $RepoDir
+if (-not (Test-Path (Join-Path $RepoDir '.git'))) { Write-Log "$RepoDir is not a git checkout."; exit 1 }
+
+$Branch = (git rev-parse --abbrev-ref HEAD).Trim()
+if ($Branches -notcontains $Branch) {
+  Write-Log "On branch '$Branch', which is not in updatable branches ($($Branches -join ', ')). Nothing to do."
+  exit 0
+}
+
+if ((git status --porcelain)) {
+  Write-Log 'Working tree is not clean; refusing to update. Commit or stash local changes first.'
+  exit 0
+}
+
+# --- Is there anything to pull? ----------------------------------------------
+
+Write-Log "Fetching $Branch from origin..."
+git fetch --quiet origin $Branch
+if ($LASTEXITCODE -ne 0) { Write-Log 'git fetch failed (check network and repo access).'; exit 1 }
+
+$Local  = (git rev-parse HEAD).Trim()
+$Remote = (git rev-parse "origin/$Branch").Trim()
+$Base   = (git merge-base HEAD "origin/$Branch").Trim()
+
+if ($Local -eq $Remote) { Write-Log "Already up to date ($($Local.Substring(0,7))). Nothing to do."; exit 0 }
+if ($Local -ne $Base)   { Write-Log "Local $Branch has diverged from origin (can't fast-forward); refusing to update."; exit 0 }
+Write-Log "Update available: $($Local.Substring(0,7)) -> $($Remote.Substring(0,7))."
+
+# --- Reach a stopping point, then pause --------------------------------------
+
+# When we pause the agent ourselves, we resume it after the rebuild; when the
+# operator already had it paused, we leave it paused.
+$wasPaused = $null
+
+if (Test-ApiReachable) {
+  $status = Get-AgentStatus
+  if ($null -ne $status) { $wasPaused = [bool]$status.agent_paused }
+
+  # Nudge the UI to re-check for updates (best effort).
+  try { Invoke-RestMethod -Method Post -Uri "$Api/update/check" -TimeoutSec 10 | Out-Null } catch { }
+
+  Write-Log 'Waiting for the agent to catch up (no To Do / In Progress / In Review action items)...'
+  $waited = 0
+  while ($true) {
+    $status = Get-AgentStatus
+    if ($null -ne $status -and $status.agent_caught_up) { Write-Log 'Agent is caught up.'; break }
+    if ($CaughtUpTimeout -ne 0 -and $waited -ge $CaughtUpTimeout) {
+      Write-Log "Still busy after ${CaughtUpTimeout}s; pausing and draining the current turn instead."
+      break
+    }
+    Start-Sleep -Seconds $PollSeconds
+    $waited += $PollSeconds
+  }
+
+  Write-Log 'Pausing the agent for the update.'
+  if (-not (Set-Paused $true)) { Write-Log 'Could not pause the agent via the API; continuing anyway.' }
+
+  Write-Log 'Waiting for the current turn to finish...'
+  $waited = 0
+  while ($true) {
+    $status = Get-AgentStatus
+    if ($null -eq $status -or -not $status.agent_working) { Write-Log 'No turn in flight.'; break }
+    if ($waited -ge $DrainTimeout) { Write-Log "Turn still running after ${DrainTimeout}s; proceeding with the update."; break }
+    Start-Sleep -Seconds $PollSeconds
+    $waited += $PollSeconds
+  }
+}
+else {
+  Write-Log "API not reachable at ${ApiUrl}; updating without pausing (the stack may be down)."
+}
+
+# --- Pull and relaunch -------------------------------------------------------
+
+Write-Log 'Pulling latest source...'
+git pull --ff-only --quiet origin $Branch
+if ($LASTEXITCODE -ne 0) { Write-Log 'git pull failed.'; exit 1 }
+
+Write-Log 'Rebuilding and relaunching the stack...'
+if (-not (Test-Path (Join-Path $RepoDir '.env'))) {
+  Write-Log 'No .env found. Copy .env.example to .env and fill it in first.'
+  exit 1
+}
+# Mirror scripts/start.sh: stamp the running build with the host commit/branch and
+# tell the API where the repo lives, so the in-app update check works too.
+$env:GIT_SHA = $Local
+$env:GIT_BRANCH = $Branch
+if (-not $env:HOST_REPO_DIR) { $env:HOST_REPO_DIR = $RepoDir }
+docker compose up -d --build
+if ($LASTEXITCODE -ne 0) { Write-Log 'docker compose up failed.'; exit 1 }
+
+# --- Resume ------------------------------------------------------------------
+
+if ($wasPaused -eq $false) {
+  Write-Log 'Waiting for the API to come back healthy before resuming the agent...'
+  $waited = 0
+  while (-not (Test-ApiReachable)) {
+    if ($waited -ge $HealthTimeout) { Write-Log "API did not become healthy within ${HealthTimeout}s; leaving the agent paused."; exit 0 }
+    Start-Sleep -Seconds $PollSeconds
+    $waited += $PollSeconds
+  }
+  Write-Log 'Resuming the agent.'
+  if (-not (Set-Paused $false)) { Write-Log 'Could not resume the agent via the API; resume it from the UI.' }
+}
+elseif ($wasPaused -eq $true) {
+  Write-Log 'Agent was paused before the update; leaving it paused.'
+}
+
+Write-Log "Update complete: now on $($Remote.Substring(0,7))."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Keep a Seraphim host deployment up to date (issue #346).
+#
+# One safe, idempotent update pass:
+#   1. Confirm the checkout is on an updatable branch (main/develop) and clean.
+#   2. Fetch and confirm the branch is behind its upstream (there is work to pull).
+#   3. Wait for the agent to reach a natural lull (nothing left to do), then pause
+#      it so nothing new starts while the stack is coming down and back up.
+#   4. git pull --ff-only, then rebuild and relaunch the compose stack.
+#   5. Resume the agent, unless the operator had it paused before we started.
+#
+# Run it directly for a one-off update:  bash ./scripts/update.sh
+# Install it to run on a timer instead:  bash ./scripts/install.sh
+#
+# Every knob is an environment variable with a sensible default, so the installer
+# can pin them per host without editing this file. See scripts/README.md.
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+
+# The repo to update. Defaults to the checkout this script lives in.
+REPO_DIR="${SERAPHIM_REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+# The API base URL (host port 27182 by default). Used to pause/resume the agent
+# and read its "caught up" state; the update still runs if the API is unreachable.
+API_URL="${SERAPHIM_API_URL:-http://localhost:27182}"
+# Branches this updater is allowed to fast-forward. Space-separated.
+UPDATE_BRANCHES="${SERAPHIM_UPDATE_BRANCHES:-main develop}"
+# How long to wait for the agent to become caught up before pausing anyway, in
+# seconds. 0 waits indefinitely. After the wait we still pause and drain the live
+# turn, so a busy board updates at the next turn boundary rather than never.
+CAUGHT_UP_TIMEOUT="${SERAPHIM_CAUGHT_UP_TIMEOUT:-3600}"
+# How long to wait for the in-flight turn to finish after pausing, in seconds.
+DRAIN_TIMEOUT="${SERAPHIM_DRAIN_TIMEOUT:-1800}"
+# How long to wait for the API to come back healthy after the rebuild, in seconds.
+HEALTH_TIMEOUT="${SERAPHIM_HEALTH_TIMEOUT:-300}"
+# Seconds between status polls while waiting.
+POLL_SECONDS="${SERAPHIM_POLL_SECONDS:-10}"
+
+API="${API_URL%/}/api/v1"
+
+# --- Helpers -----------------------------------------------------------------
+
+log() {
+  printf '%s [seraphim-update] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+# Ensure a required command exists, or explain how to install it and stop.
+require_cmd() {
+  local cmd="$1" hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "Missing required command: $cmd" >&2
+    log "Install it, then re-run: $hint" >&2
+    exit 1
+  fi
+}
+
+# Read one top-level boolean field from a flat JSON response, without needing jq
+# (the /update/status body is flat, so a targeted match is safe and dependency
+# free). Prints "true", "false", or nothing when the field is absent.
+json_bool() {
+  local field="$1" body="$2"
+  printf '%s' "$body" | grep -o "\"${field}\":[[:space:]]*\(true\|false\)" | head -n1 |
+    grep -o '\(true\|false\)' || true
+}
+
+api_reachable() {
+  curl -fsS --max-time 5 "${API}/ping" >/dev/null 2>&1
+}
+
+api_status() {
+  curl -fsS --max-time 10 "${API}/update/status" 2>/dev/null || true
+}
+
+set_paused() {
+  local paused="$1"
+  curl -fsS --max-time 10 -X POST "${API}/settings/pause" \
+    -H 'Content-Type: application/json' \
+    -d "{\"paused\":${paused}}" >/dev/null 2>&1
+}
+
+# --- Preconditions -----------------------------------------------------------
+
+require_cmd git "https://git-scm.com/downloads"
+require_cmd curl "sudo dnf install curl  (RHEL)  |  sudo apt install curl  (Debian)"
+require_cmd docker "https://docs.docker.com/engine/install/"
+if ! docker compose version >/dev/null 2>&1; then
+  die "The Docker Compose plugin is missing. Install it (see https://docs.docker.com/compose/install/)."
+fi
+
+cd "$REPO_DIR" || die "Repo directory not found: $REPO_DIR"
+[ -d .git ] || die "$REPO_DIR is not a git checkout."
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if ! printf '%s' " $UPDATE_BRANCHES " | grep -q " $BRANCH "; then
+  log "On branch '$BRANCH', which is not in updatable branches ($UPDATE_BRANCHES). Nothing to do."
+  exit 0
+fi
+
+# The working tree must be clean so a fast-forward never clobbers local edits.
+if [ -n "$(git status --porcelain)" ]; then
+  log "Working tree is not clean; refusing to update. Commit or stash local changes first."
+  exit 0
+fi
+
+# --- Is there anything to pull? ----------------------------------------------
+
+log "Fetching $BRANCH from origin..."
+git fetch --quiet origin "$BRANCH" || die "git fetch failed (check network and repo access)."
+
+LOCAL="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse "origin/${BRANCH}")"
+BASE="$(git merge-base HEAD "origin/${BRANCH}")"
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  log "Already up to date (${LOCAL:0:7}). Nothing to do."
+  exit 0
+fi
+if [ "$LOCAL" != "$BASE" ]; then
+  log "Local $BRANCH has diverged from origin (can't fast-forward); refusing to update. Reconcile manually."
+  exit 0
+fi
+log "Update available: ${LOCAL:0:7} -> ${REMOTE:0:7}."
+
+# --- Reach a stopping point, then pause --------------------------------------
+
+# When we pause the agent ourselves, we resume it after the rebuild; when the
+# operator already had it paused, we leave it paused.
+was_paused="unknown"
+
+if api_reachable; then
+  status="$(api_status)"
+  was_paused="$(json_bool agent_paused "$status")"
+  [ -n "$was_paused" ] || was_paused="unknown"
+
+  # Nudge the UI to re-check for updates so the "update available" indicator
+  # reflects reality while we work (best effort).
+  curl -fsS --max-time 10 -X POST "${API}/update/check" >/dev/null 2>&1 || true
+
+  log "Waiting for the agent to catch up (no To Do / In Progress / In Review action items)..."
+  waited=0
+  while :; do
+    status="$(api_status)"
+    caught_up="$(json_bool agent_caught_up "$status")"
+    [ "$caught_up" = "true" ] && { log "Agent is caught up."; break; }
+    if [ "$CAUGHT_UP_TIMEOUT" -ne 0 ] && [ "$waited" -ge "$CAUGHT_UP_TIMEOUT" ]; then
+      log "Still busy after ${CAUGHT_UP_TIMEOUT}s; pausing and draining the current turn instead."
+      break
+    fi
+    sleep "$POLL_SECONDS"
+    waited=$((waited + POLL_SECONDS))
+  done
+
+  log "Pausing the agent for the update."
+  set_paused true || log "Could not pause the agent via the API; continuing anyway." >&2
+
+  # Draining: pausing stops new work but never aborts the current turn, so wait
+  # for any in-flight turn to finish before we take the stack down.
+  log "Waiting for the current turn to finish..."
+  waited=0
+  while :; do
+    status="$(api_status)"
+    working="$(json_bool agent_working "$status")"
+    [ "$working" != "true" ] && { log "No turn in flight."; break; }
+    if [ "$waited" -ge "$DRAIN_TIMEOUT" ]; then
+      log "Turn still running after ${DRAIN_TIMEOUT}s; proceeding with the update."
+      break
+    fi
+    sleep "$POLL_SECONDS"
+    waited=$((waited + POLL_SECONDS))
+  done
+else
+  log "API not reachable at ${API_URL}; updating without pausing (the stack may be down)."
+fi
+
+# --- Pull and relaunch -------------------------------------------------------
+
+log "Pulling latest source..."
+git pull --ff-only --quiet origin "$BRANCH" || die "git pull failed."
+
+log "Rebuilding and relaunching the stack..."
+# start.sh stamps GIT_SHA/GIT_BRANCH/HOST_REPO_DIR and runs `docker compose up -d
+# --build`, so reuse it rather than duplicating that logic here.
+"$REPO_DIR/scripts/start.sh"
+
+# --- Resume ------------------------------------------------------------------
+
+if [ "$was_paused" = "false" ]; then
+  log "Waiting for the API to come back healthy before resuming the agent..."
+  waited=0
+  while ! api_reachable; do
+    if [ "$waited" -ge "$HEALTH_TIMEOUT" ]; then
+      log "API did not become healthy within ${HEALTH_TIMEOUT}s; leaving the agent paused." >&2
+      exit 0
+    fi
+    sleep "$POLL_SECONDS"
+    waited=$((waited + POLL_SECONDS))
+  done
+  log "Resuming the agent."
+  set_paused false || log "Could not resume the agent via the API; resume it from the UI." >&2
+elif [ "$was_paused" = "true" ]; then
+  log "Agent was paused before the update; leaving it paused."
+fi
+
+log "Update complete: now on ${REMOTE:0:7}."


### PR DESCRIPTION
Closes #346.

Host-side scripts that keep a Seraphim deployment current with its branch, as an alternative to the in-app Update button. They do their own `git pull` + compose rebuild on the host, so they work even when the API is down and need no updater container or `HOST_REPO_DIR`.

## What a run does

`scripts/update.sh` (Linux/macOS/Git Bash) and `scripts/update.ps1` (Windows PowerShell 5.1+) run one safe, idempotent pass:

1. Only on `main`/`develop` (configurable), and only when the working tree is clean.
2. `git fetch` and confirm the branch is behind its upstream (there is work to pull); a diverged branch is refused rather than force-updated.
3. Wait for the agent to catch up (no To Do / In Progress / In Review action items), then pause it and wait for any in-flight turn to drain.
4. `git pull --ff-only`, then rebuild and relaunch the compose stack.
5. Resume the agent, unless the operator had it paused before the update.

If the API is unreachable, the update still runs (without the graceful pause).

## Installers

- `scripts/install.sh` writes `/etc/systemd/system/seraphim-update.{service,timer}` and enables the timer (default every 15 minutes). systemd ships on RHEL and Debian; if `systemctl` is absent it prints ready-to-paste cron instructions, including how to install `cronie`/`cron`.
- `scripts/install.ps1` registers the `SeraphimSelfUpdater` Scheduled Task (default every 15 minutes).
- `scripts/uninstall.sh` / `scripts/uninstall.ps1` remove them.

Missing prerequisites (`git`, `curl`, Docker + Compose plugin) are detected and reported with an install command. The oneshot systemd service disables its start timeout so a long build or drain is never killed. Every knob is a `SERAPHIM_*` environment variable, documented in `scripts/README.md`.

## API

The "caught up" and "working" signals come from the API. `GET /api/v1/update/status` gains an authoritative `agent_caught_up` flag (backed by `queries::agent_caught_up`), true when nothing sits in To Do or In Progress and no In Review PR is queued for an agent turn (CI fix, conflict resolve, or review-comment addressing). This mirrors what `next_actionable_task` would pull, so the script never parses the board.

## Banner (bonus)

The updater pings the API to pause the agent (`POST /settings/pause`), which the board reflects as a paused state, and refreshes the update-available check, giving the operator a visible signal while the update runs. No new UI was added.

## Testing

- `cargo +1.88 fmt --check`, `clippy`, and `test` (183 passed) all pass; source-hygiene check passes.
- `bash -n` on every shell script; smoke-tested the branch and clean-tree gates.
- Verified the `json_bool` extractor against a representative `/update/status` body.
- No `pwsh` in the build environment, so the PowerShell scripts were reviewed for Windows PowerShell 5.1 compatibility (no `??`, long finite task duration, standard cmdlets) rather than executed.

Visual review: not applicable, no UI change (the "banner" reuses the existing pause state).