### PR TITLE
Let the agent toggle setup_script_always_run via the Seraphim MCP (#348)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,13 @@ operator notepad lives on the kanban board.
   `POST /agent/setup-scripts/{repo,base}` (`http/setup_scripts.rs`). Every edit
   replaces a repo's `setup_script` or the global `base_setup_script` and records a
   row here with the before/after, `target` (`repo`|`base`), `summary` (the agent's
-  one-line why), and the `task_id` it was working. The change is **never silent**:
+  one-line why), and the `task_id` it was working. `update_repo_setup_script` can
+  also toggle the repo's `setup_script_always_run` flag (issue #348): its
+  `setup_script` is optional and an `always_run` bool sets the flag, so the agent
+  can make its own setup edit re-run before every task on the existing clone, not
+  just on first clone. A flag toggle is recorded on the same row (`always_run`:
+  `NULL` when untouched, else the value set) so the audit and banner stay honest.
+  The change is **never silent**:
   the board shows the unacknowledged ones in a banner (via the board payload) and a
   one-time toast + native notification fires (`ServerEvent::SetupScriptChanged`),
   cleared by `POST /setup-changes/:id/ack`. No-op edits are rejected so the audit

--- a/api/migrations/0050_setup_script_change_always_run.sql
+++ b/api/migrations/0050_setup_script_change_always_run.sql
@@ -1,0 +1,10 @@
+-- Let a recorded setup-script change also capture a `setup_script_always_run`
+-- toggle (issue #348). The agent can now flip a repo's "re-run before every task"
+-- flag through the Seraphim MCP, so a setup edit it just made actually runs on the
+-- existing clone before the next task, not only on first clone / full provision.
+--
+-- NULL means this change did not touch the flag (every historical row, and any
+-- pure script edit); TRUE/FALSE records the value the change set the flag to, so
+-- the board banner and the audit trail read honestly.
+ALTER TABLE setup_script_changes
+    ADD COLUMN always_run BOOLEAN;

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -503,6 +503,10 @@ pub struct SetupScriptChange {
     pub repo_full_name: Option<String>,
     pub old_script: String,
     pub new_script: String,
+    /// When this change toggled the repo's `setup_script_always_run` flag (issue
+    /// #348), the value it set the flag to; `None` when the change left the flag
+    /// untouched (a `base` change, or a pure `setup_script` edit).
+    pub always_run: Option<bool>,
     /// The agent's one-line reason, shown to the operator so the change is explained.
     pub summary: String,
     pub acknowledged: bool,

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -1206,22 +1206,29 @@ pub async fn delete_repositories(pool: &PgPool, ids: &[Uuid]) -> sqlx::Result<u6
     Ok(result.rows_affected())
 }
 
-/// Replaces a single repo's `setup_script`, leaving everything else untouched.
+/// Replaces a repo's `setup_script` and, when `always_run` is `Some`, its
+/// `setup_script_always_run` flag (issue #348), leaving everything else untouched.
+/// `None` leaves the flag as is, so a pure script edit never disturbs it.
 ///
-/// Used by the agent's self-service setup-script MCP (issue #340), which sends
-/// only the new script, so this is a targeted update rather than the full
-/// [`update_repository`] upsert. Returns the updated row.
+/// Used by the agent's self-service setup-script MCP (issues #340, #348), so this
+/// is a targeted update rather than the full [`update_repository`] upsert. Returns
+/// the updated row.
 pub async fn update_repo_setup_script(
     pool: &PgPool,
     id: Uuid,
     setup_script: &str,
+    always_run: Option<bool>,
 ) -> sqlx::Result<Repository> {
     sqlx::query_as::<_, Repository>(
-        "UPDATE repositories SET setup_script = $2, updated_at = now() \
+        "UPDATE repositories \
+         SET setup_script = $2, \
+             setup_script_always_run = COALESCE($3, setup_script_always_run), \
+             updated_at = now() \
          WHERE id = $1 RETURNING *",
     )
     .bind(id)
     .bind(setup_script)
+    .bind(always_run)
     .fetch_one(pool)
     .await
 }
@@ -1248,6 +1255,9 @@ pub async fn update_base_setup_script(pool: &PgPool, setup_script: &str) -> sqlx
 ///
 /// `repo_id` / `repo_full_name` are set for a `"repo"` target and left `None` for a
 /// `"base"` one. `task_id` attributes the change to the task being worked.
+/// `always_run` is `Some` only when the change toggled the repo's
+/// `setup_script_always_run` flag (issue #348); `None` records a change that left
+/// the flag untouched (a `base` change or a pure `setup_script` edit).
 #[allow(clippy::too_many_arguments)]
 pub async fn record_setup_script_change(
     pool: &PgPool,
@@ -1257,12 +1267,13 @@ pub async fn record_setup_script_change(
     repo_full_name: Option<&str>,
     old_script: &str,
     new_script: &str,
+    always_run: Option<bool>,
     summary: &str,
 ) -> sqlx::Result<SetupScriptChange> {
     sqlx::query_as::<_, SetupScriptChange>(
         "INSERT INTO setup_script_changes \
-           (task_id, target, repo_id, repo_full_name, old_script, new_script, summary) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *",
+           (task_id, target, repo_id, repo_full_name, old_script, new_script, always_run, summary) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *",
     )
     .bind(task_id)
     .bind(target)
@@ -1270,6 +1281,7 @@ pub async fn record_setup_script_change(
     .bind(repo_full_name)
     .bind(old_script)
     .bind(new_script)
+    .bind(always_run)
     .bind(summary)
     .fetch_one(pool)
     .await

--- a/api/src/http/setup_scripts.rs
+++ b/api/src/http/setup_scripts.rs
@@ -75,7 +75,15 @@ pub struct UpdateRepoScriptRequest {
     pub task_id: Option<Uuid>,
     /// The repo to edit: its `owner/name`, its short name, or its id.
     pub repo: String,
-    pub setup_script: String,
+    /// The full replacement `setup_script`. Optional (issue #348): omit it to
+    /// toggle `always_run` alone, leaving the script unchanged.
+    #[serde(default)]
+    pub setup_script: Option<String>,
+    /// When set, turn the repo's `setup_script_always_run` flag on or off (issue
+    /// #348) so the script re-runs before every task on the existing clone, not
+    /// just on first clone / full provision. `None` leaves the flag as is.
+    #[serde(default)]
+    pub always_run: Option<bool>,
     /// A one-line reason, shown to the operator so the change is explained.
     #[serde(default)]
     pub summary: String,
@@ -88,19 +96,24 @@ pub struct SetupScriptChangeResponse {
     pub change: SetupScriptChange,
 }
 
-/// `POST /api/v1/agent/setup-scripts/repo` - replace a repo's `setup_script`.
+/// `POST /api/v1/agent/setup-scripts/repo` - update a repo's `setup_script` and/or
+/// its `setup_script_always_run` flag (issue #348).
 ///
-/// Resolves the repo by id, `owner/name`, or unambiguous short name; a no-op edit
-/// (unchanged script) is rejected so the audit log holds only real changes.
+/// Resolves the repo by id, `owner/name`, or unambiguous short name. `setup_script`
+/// is optional (omit it to toggle `always_run` alone), and `always_run` sets the
+/// flag so the script re-runs before every task on the existing clone. A no-op
+/// (nothing actually changes) is rejected so the audit log holds only real changes.
 pub async fn update_repo(
     State(state): State<AppState>,
     Json(body): Json<UpdateRepoScriptRequest>,
 ) -> ApiResult<Response> {
-    if body.setup_script.len() > MAX_SETUP_SCRIPT_BYTES {
-        return Ok(bad_request(&format!(
-            "setup_script is too large ({} bytes; max {MAX_SETUP_SCRIPT_BYTES})",
-            body.setup_script.len()
-        )));
+    if let Some(script) = &body.setup_script {
+        if script.len() > MAX_SETUP_SCRIPT_BYTES {
+            return Ok(bad_request(&format!(
+                "setup_script is too large ({} bytes; max {MAX_SETUP_SCRIPT_BYTES})",
+                script.len()
+            )));
+        }
     }
 
     let repos = queries::list_repositories(&state.db).await?;
@@ -120,14 +133,28 @@ pub async fn update_repo(
         }
     };
 
-    if repo.setup_script == body.setup_script {
+    // The script defaults to its current value, so a caller can toggle `always_run`
+    // alone without resending the script.
+    let new_script = body
+        .setup_script
+        .unwrap_or_else(|| repo.setup_script.clone());
+    let plan = plan_repo_change(
+        &repo.setup_script,
+        repo.setup_script_always_run,
+        &new_script,
+        body.always_run,
+    );
+
+    if !plan.changed {
         return Ok(bad_request(
-            "the setup script is unchanged; edit it to something different or leave it as is.",
+            "nothing to change: send a different setup_script, or an always_run value \
+             that differs from the current one.",
         ));
     }
 
     let old_script = repo.setup_script.clone();
-    let updated = queries::update_repo_setup_script(&state.db, repo.id, &body.setup_script).await?;
+    let updated =
+        queries::update_repo_setup_script(&state.db, repo.id, &new_script, body.always_run).await?;
     let change = queries::record_setup_script_change(
         &state.db,
         body.task_id,
@@ -136,6 +163,7 @@ pub async fn update_repo(
         Some(&updated.full_name),
         &old_script,
         &updated.setup_script,
+        plan.flag_change,
         body.summary.trim(),
     )
     .await?;
@@ -183,6 +211,8 @@ pub async fn update_base(
         None,
         &old_script,
         &updated.base_setup_script,
+        // The base script has no per-repo always-run flag.
+        None,
         body.summary.trim(),
     )
     .await?;
@@ -211,6 +241,34 @@ fn announce(state: &AppState, change: &SetupScriptChange, target_label: &str) {
         target_label.to_string(),
         change.summary.clone(),
     );
+}
+
+/// What a requested repo setup-script edit actually changes.
+struct RepoChangePlan {
+    /// The `setup_script_always_run` value to record, set only when the flag flips.
+    flag_change: Option<bool>,
+    /// Whether anything changed at all (the script, the flag, or both).
+    changed: bool,
+}
+
+/// Decides what an `update_repo` request changes, so a no-op is rejected and the
+/// audit records the flag transition only when it truly flips (a resent-but-equal
+/// `always_run` is not a change). Pure, so the guard is unit-tested.
+fn plan_repo_change(
+    current_script: &str,
+    current_always_run: bool,
+    new_script: &str,
+    requested_always_run: Option<bool>,
+) -> RepoChangePlan {
+    let script_changed = new_script != current_script;
+    let flag_change = match requested_always_run {
+        Some(value) if value != current_always_run => Some(value),
+        _ => None,
+    };
+    RepoChangePlan {
+        flag_change,
+        changed: script_changed || flag_change.is_some(),
+    }
 }
 
 fn bad_request(message: &str) -> Response {
@@ -257,7 +315,7 @@ fn resolve_repo<'a>(repos: &'a [Repository], reference: &str) -> RepoMatch<'a> {
 mod tests {
     use uuid::Uuid;
 
-    use super::{resolve_repo, RepoMatch};
+    use super::{plan_repo_change, resolve_repo, RepoMatch};
     use crate::db::models::Repository;
 
     fn repo(id: Uuid, full_name: &str) -> Repository {
@@ -310,5 +368,50 @@ mod tests {
         assert!(matches!(resolve_repo(&repos, "web"), RepoMatch::Ambiguous));
         assert!(matches!(resolve_repo(&repos, "acme/web"), RepoMatch::One(r) if r.id == a));
         assert!(matches!(resolve_repo(&repos, "other/web"), RepoMatch::One(r) if r.id == b));
+    }
+
+    #[test]
+    fn plan_rejects_a_pure_no_op() {
+        // Same script, and either no flag request or the same flag value.
+        let plan = plan_repo_change("yarn install", false, "yarn install", None);
+        assert!(!plan.changed);
+        assert_eq!(plan.flag_change, None);
+
+        let plan = plan_repo_change("yarn install", false, "yarn install", Some(false));
+        assert!(!plan.changed, "resending the same flag value is a no-op");
+        assert_eq!(plan.flag_change, None);
+    }
+
+    #[test]
+    fn plan_detects_a_script_edit() {
+        let plan = plan_repo_change("yarn install", true, "yarn install --immutable", None);
+        assert!(plan.changed);
+        // The flag was not requested, so it is left untouched (not recorded).
+        assert_eq!(plan.flag_change, None);
+    }
+
+    #[test]
+    fn plan_records_a_flag_flip_even_without_a_script_edit() {
+        // Toggle on with the script unchanged.
+        let plan = plan_repo_change("yarn install", false, "yarn install", Some(true));
+        assert!(plan.changed);
+        assert_eq!(plan.flag_change, Some(true));
+
+        // Toggle off with the script unchanged.
+        let plan = plan_repo_change("yarn install", true, "yarn install", Some(false));
+        assert!(plan.changed);
+        assert_eq!(plan.flag_change, Some(false));
+    }
+
+    #[test]
+    fn plan_captures_a_combined_script_and_flag_change() {
+        let plan = plan_repo_change(
+            "yarn install",
+            false,
+            "yarn install --immutable",
+            Some(true),
+        );
+        assert!(plan.changed);
+        assert_eq!(plan.flag_change, Some(true));
     }
 }

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -686,10 +686,13 @@ const SETUP_SCRIPT_AUTONOMY: &str = "\n\
     tools list the current base and per-repo setup scripts and update a repo's \
     `setup_script` or the global environment setup. Prefer editing a repo's \
     `setup_script` for a repo-specific step and the base setup only for a truly \
-    global tool. Read the current script first, make a minimal, correct edit, and \
-    pass a one-line `summary` explaining why. Every change is recorded and surfaced \
-    to the operator, so keep edits genuine and safe; if you are unsure, recommend it \
-    with `seraphim-suggest` instead.\n";
+    global tool. A repo's `setup_script` only re-runs before every task when its \
+    `setup_script_always_run` flag is on; if your edit must take effect on the next \
+    task (not just after a fresh clone), also pass `always_run: true` in the same \
+    `update_repo_setup_script` call. Read the current script first, make a minimal, \
+    correct edit, and pass a one-line `summary` explaining why. Every change is \
+    recorded and surfaced to the operator, so keep edits genuine and safe; if you \
+    are unsure, recommend it with `seraphim-suggest` instead.\n";
 
 /// Guidance, appended to every task prompt, on bubbling up follow-up work (#272).
 const FOLLOW_UP_SUGGESTIONS: &str = "\n\

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -358,6 +358,9 @@ export type SetupScriptChange = {
   repo_full_name: string | null
   old_script: string
   new_script: string
+  // When the change toggled the repo's setup_script_always_run flag (issue #348),
+  // the value it set it to; null when the flag was left untouched.
+  always_run: boolean | null
   // The agent's one-line reason for the change.
   summary: string
   acknowledged: boolean

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1059,6 +1059,13 @@
           {#if change.summary}
             <span class="block">{change.summary}</span>
           {/if}
+          {#if change.always_run !== null}
+            <span class="mt-1 block text-xs opacity-80">
+              {change.always_run
+                ? 'Now re-runs before every task on the existing clone.'
+                : 'Now runs only on first clone / full provision.'}
+            </span>
+          {/if}
           <pre
             class="mt-1 max-h-40 overflow-auto rounded-md border border-border bg-muted/40 p-2 font-mono text-xs whitespace-pre-wrap">{change.new_script ||
               '(empty script)'}</pre>

--- a/workspace/seraphim-mcp
+++ b/workspace/seraphim-mcp
@@ -46,10 +46,14 @@ const TOOLS = [
   {
     name: 'update_repo_setup_script',
     description:
-      "Replace a repository's setup_script (runs after each clone; before every task " +
-      'when setup_script_always_run is on). Use this to bake in a repo-specific setup ' +
-      'step you had to run by hand, e.g. installing dependencies. Read the current ' +
-      'script with list_setup_scripts first and send the full new script. The change ' +
+      "Update a repository's setup_script and/or its setup_script_always_run flag. " +
+      'The setup_script runs after each clone; when always_run is on it ALSO re-runs ' +
+      'before every task on the existing clone (not just first clone), so a setup ' +
+      'edit takes effect on the next task. Provide setup_script (the full replacement ' +
+      'script) to change the script, always_run (true/false) to toggle the flag, or ' +
+      'both. Read the current values with list_setup_scripts first. Use this to bake ' +
+      'in a repo-specific step you had to run by hand, e.g. installing dependencies, ' +
+      'and turn on always_run when that step must run before every task. The change ' +
       'is recorded and shown to the operator.',
     inputSchema: {
       type: 'object',
@@ -60,14 +64,23 @@ const TOOLS = [
         },
         setup_script: {
           type: 'string',
-          description: 'The full new setup script (replaces the existing one).'
+          description:
+            'The full new setup script (replaces the existing one). Omit to leave the ' +
+            'script unchanged and only toggle always_run.'
+        },
+        always_run: {
+          type: 'boolean',
+          description:
+            "Turn on to re-run this repo's setup_script before every task on the " +
+            'existing clone (not just first clone / full provision); off to run it only ' +
+            'on first clone. Omit to leave the flag unchanged.'
         },
         summary: {
           type: 'string',
           description: 'A one-line reason for the change, shown to the operator.'
         }
       },
-      required: ['repo', 'setup_script', 'summary'],
+      required: ['repo', 'summary'],
       additionalProperties: false
     }
   },
@@ -141,13 +154,28 @@ async function callTool(name, args) {
   }
 
   if (name === 'update_repo_setup_script') {
-    const change = await apiPost('/api/v1/agent/setup-scripts/repo', {
+    const body = {
       task_id: TASK_ID,
       repo: String(args?.repo ?? ''),
-      setup_script: String(args?.setup_script ?? ''),
       summary: String(args?.summary ?? '')
-    })
-    return `Updated the setup script for ${change?.change?.repo_full_name ?? args?.repo}. The operator has been notified.`
+    }
+    // Send only the fields the caller supplied: an omitted setup_script leaves the
+    // script as is, and an omitted always_run leaves the flag as is.
+    if (args?.setup_script !== undefined) {
+      body.setup_script = String(args.setup_script)
+    }
+    if (args?.always_run !== undefined) {
+      body.always_run = Boolean(args.always_run)
+    }
+    const change = await apiPost('/api/v1/agent/setup-scripts/repo', body)
+    const alwaysRun = change?.change?.always_run
+    const flagNote =
+      alwaysRun === true
+        ? ' It will now re-run before every task on the existing clone.'
+        : alwaysRun === false
+          ? ' It will now run only on first clone / full provision.'
+          : ''
+    return `Updated the setup script for ${change?.change?.repo_full_name ?? args?.repo}.${flagNote} The operator has been notified.`
   }
 
   if (name === 'update_base_setup_script') {


### PR DESCRIPTION
Closes #348.

## Problem

The Seraphim MCP (issue #340) lets the agent edit a repo's `setup_script`, but a repo without `setup_script_always_run` only re-runs its script on first clone / full provision. So an agent-applied edit may not take effect before the next task on an existing clone, which defeats the point of applying it.

## Change

Extend the existing repo setup-script edit path (MCP tool `update_repo_setup_script` + `POST /api/v1/agent/setup-scripts/repo`) so the agent can also toggle the flag:

- `setup_script` is now **optional**, and a new **`always_run`** boolean sets `setup_script_always_run`. The agent can edit the script, toggle the flag, or do both in one call. Omitting a field leaves it unchanged (SQL `COALESCE`, so a pure script edit never disturbs the flag).
- A **no-op is still rejected**: the request must change the script or flip the flag to something different.
- The flag transition is recorded so it is **never silent**: `setup_script_changes` gains a nullable `always_run` column (migration `0050`) that is `NULL` when the change did not touch the flag, else the value it set. The board banner shows "Now re-runs before every task on the existing clone." / "Now runs only on first clone / full provision." reusing the sibling note's exact design tokens.
- The standing prompt instruction (`SETUP_SCRIPT_AUTONOMY`) now tells the agent to pass `always_run: true` when its edit must take effect on the next task.

The change-planning logic (what changed, and whether to record a flag flip) is a pure, unit-tested helper (`plan_repo_change`).

## Testing

- `cargo +1.88 fmt --check`, `clippy` (no new warnings), and `cargo test` (187 passed, incl. 4 new `plan_repo_change` tests) all pass.
- Ran the embedded migrations against a throwaway Postgres (`pg-ephemeral`); `0050` applies cleanly and a direct insert of both a flag-only toggle row (`always_run = true`) and a script-edit row (`always_run = NULL`) succeeds.
- Frontend `yarn check`, `yarn test`, and `yarn build` pass.
- Source-hygiene check and `node --check` on the MCP server pass.

## Visual review

The only UI change is one conditional line appended to the existing setup-script-change board banner, using the exact same tokens (`mt-1 block text-xs opacity-80`) as the adjacent base-target note directly below it. Rendering it live requires a seeded backend (an unacknowledged `setup_script_change` with `always_run` set), which is disproportionate for a one-line additive note, so I verified it via type-check/build and design-token parity with its sibling rather than a live browser render.