### PR TITLE
Make the board BulkActionBar mobile-safe at 375px (#350)

### DIFF
--- a/frontend/src/lib/components/BulkActionBar.svelte
+++ b/frontend/src/lib/components/BulkActionBar.svelte
@@ -148,15 +148,21 @@
   }
 </script>
 
+<!-- Mobile-safe (issue #350): cap the bar at the viewport width (matching
+     RepoBulkActionBar, issue #331). This bar has more actions than that one, so
+     capping alone still overflows; below sm it takes the full capped width and
+     wraps its actions onto multiple rows, then reverts to a single auto-width row
+     from sm up. -->
 <div
-  class="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl"
+  class="fixed bottom-6 left-1/2 z-50 flex w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl sm:w-auto sm:flex-nowrap"
   role="toolbar"
   aria-label="Bulk actions"
 >
-  <!-- Far left: count badge + the word "selected". -->
+  <!-- Far left: count badge + the word "selected" (label drops on narrow screens
+       so the compact bar stays within a 375px viewport). -->
   <div class="flex items-center gap-2 pl-1 pr-1">
     <Badge variant="default" class="tabular-nums">{count}</Badge>
-    <span class="text-sm text-muted-foreground">selected</span>
+    <span class="hidden text-sm text-muted-foreground sm:inline">selected</span>
   </div>
 
   <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>


### PR DESCRIPTION
Closes #350.

## Problem

The board's floating `BulkActionBar` had no max-width and always rendered the word "selected", so on a 375px viewport it overflowed both edges. It also has more actions than `RepoBulkActionBar` (Edit fields, Change status, Sort selected, Delete, plus the count and exit), so the issue #331 treatment alone is not enough here.

## Fix

Apply the `RepoBulkActionBar` mobile-safe treatment and extend it for the larger action set:

- Cap the bar at `max-w-[calc(100vw-1rem)]` and hide the "selected" label below `sm` (`hidden ... sm:inline`), matching `RepoBulkActionBar`.
- Because capping the box alone still pushed the buttons past the edge, below `sm` the bar takes the full capped width (`w-[calc(100vw-1rem)]`) and wraps its actions onto multiple rows (`flex-wrap`, `justify-center`); from `sm` up it reverts to a single auto-width row (`sm:w-auto sm:flex-nowrap`), unchanged from before.

## Why more than the sibling treatment

Measured in a browser at 375px: with `max-w` only (the plain issue #331 treatment), the bar box is clamped but the extra buttons overflow to a child right edge of **649px**, so Delete and the exit button render off-screen and are unreachable. The full-width wrap keeps every action on-screen and reachable.

## Verification (real browser, computed styles)

Rendered the actual component via a temporary probe route and measured with the Playwright MCP (probe removed before commit):

- **375px:** centered 359px-wide (`100vw - 1rem`), two-row pill, left=8 / right=367, `flex-wrap: wrap`, all children within the viewport, no document overflow, "selected" hidden.
- **1280px:** unchanged. Single centered auto-width row (723px), `flex-wrap: nowrap`, "selected" shown.

`yarn check` and `yarn build` pass.