### PR TITLE
Idle the Tailscale container when TS_AUTHKEY is blank (#353)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,8 @@ MOONSHOT_API_KEY=
 # --- Tailscale ----------------------------------------------------------------
 # Auth key from https://login.tailscale.com/admin/settings/keys (reusable +
 # ephemeral recommended for a container). Leave blank to skip Tailscale and use
-# the raw host ports instead.
+# the raw host ports instead; its container then idles cleanly rather than
+# crash-looping on the missing key (issue #353).
 TS_AUTHKEY=
 # MagicDNS hostname this node registers as (https://<TS_HOSTNAME>.<tailnet>.ts.net).
 TS_HOSTNAME=seraphim

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,10 @@ scripts/    start.sh stop.sh restart.sh
   `/api/v1/tailscale/{status,up,down,reauth,restart}`): the tailnet URL, hosting
   status, connect/disconnect, and a login URL when the node needs auth. Status
   JSON parsing is pure + unit-tested. Container name from `TAILSCALE_CONTAINER`.
+  The compose service is always defined, but its entrypoint is guarded (issue
+  #353): a blank `TS_AUTHKEY` (the "skip Tailscale" case) idles the container with
+  `sleep infinity` instead of letting `containerboot` crash-loop against
+  `restart: unless-stopped`; a set key hands off to the normal `containerboot`.
 - `src/sources/` — `Source` enum (GitHub; Jira is a future variant), `github.rs`, `types.rs`.
 - `src/git/` — PR detection, CI-green check, squash-merge (octocrab).
 - `src/orchestrator/` — `mod.rs` (the loops), `provision.rs` (workspace provisioning), `prompt.rs`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,22 @@ services:
     container_name: seraphim-tailscale
     image: tailscale/tailscale:latest
     restart: unless-stopped
+    # A blank TS_AUTHKEY means "skip Tailscale" (see .env.example), but the stock
+    # containerboot entrypoint keeps exiting when it cannot authenticate, and
+    # `restart: unless-stopped` then thrashes it in a ~2-minute crash loop
+    # (issue #353). Guard the entrypoint: with no auth key, idle cleanly instead
+    # of looping; with one, hand off to the normal containerboot. The `$$` defers
+    # expansion to container runtime, so the key is read from the environment and
+    # never baked into the image's inspectable command.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ -z "$${TS_AUTHKEY:-}" ]; then
+          echo "seraphim: TS_AUTHKEY is blank; Tailscale disabled, idling (set TS_AUTHKEY in .env to enable)." >&2
+          exec sleep infinity
+        fi
+        exec /usr/local/bin/containerboot
     hostname: ${TS_HOSTNAME}
     environment:
       TS_AUTHKEY: ${TS_AUTHKEY}


### PR DESCRIPTION
Closes #353.

## Problem

`.env.example` documents that a blank `TS_AUTHKEY` skips Tailscale, but the stock `containerboot` entrypoint keeps exiting when it cannot authenticate, and the service's `restart: unless-stopped` then thrashes it in a ~2-minute crash loop (the operator observed `RestartCount=190` over ~6h, logs repeating "To authenticate, visit: ...").

## Fix

Guard the `tailscale` service entrypoint:

```yaml
entrypoint:
  - /bin/sh
  - -c
  - |
    if [ -z "$${TS_AUTHKEY:-}" ]; then
      echo "seraphim: TS_AUTHKEY is blank; Tailscale disabled, idling ..." >&2
      exec sleep infinity
    fi
    exec /usr/local/bin/containerboot
```

- **Blank/unset key:** log a notice and `exec sleep infinity`. The container stays running, so `restart: unless-stopped` never re-triggers, and there is no crash loop.
- **Set key:** hand off to the normal `/usr/local/bin/containerboot`, so behavior is unchanged for Tailscale users.

I chose the entrypoint guard over a compose profile so the service stays defined and default-up: operators who set a key keep Tailscale with no workflow change (no `--profile` flag, no `scripts/start.sh` branching), and the compose header comment ("`docker compose up -d` brings up ... a Tailscale node") stays accurate. The blank case is the only one that changes, and it now no-ops cleanly.

The `$$` defers expansion to container runtime, so the key is read from the environment (already passed via `environment: TS_AUTHKEY`) and is never baked into the entrypoint command, so it does not leak into `docker inspect`.

## Verification

Against the real `tailscale/tailscale:latest` image in throwaway containers (no compose, so the operator's live `seraphim-tailscale` is untouched):

- `/bin/sh` (busybox) and `/usr/local/bin/containerboot` both exist.
- The guard selects the idle branch for a blank or unset key and the boot branch for a set key; the idle branch runs `sleep` and never touches `containerboot` (no auth attempt, clean exit 0 in the sleep-2 test).
- `docker compose config` parses, and with a set key the secret appears only in the `environment:` value, never in the rendered entrypoint.
- Source-hygiene check passes.

Docs updated: `.env.example` and `CLAUDE.md`.

No app code or UI changed, so visual review is not applicable.