### PR TITLE
Rework the Suggestions page: group by repo and task, multi-select, cards (#364)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,11 @@ SvelteKit, **SPA** (`src/routes/+layout.ts` sets `ssr = false`), adapter-node.
 in `src/lib/components/`, pages in `src/routes/`. `src/hooks.server.ts` proxies
 `/api/*` to the API in production; `vite.config.ts` proxies it in dev.
 
+**Dev server / visual review:** `cd frontend && yarn dev` runs Vite on
+`http://localhost:5173`, proxying `/api/*` to the API (`localhost:27182`), so the
+API must be up. Key routes: `/` (kanban board), `/suggestions`, `/settings`,
+`/task/<id>`. Checks: `yarn check` (svelte-check), `yarn test` (vitest), `yarn build`.
+
 **Settings IA (issue #344):** a Stripe-style landing grid at `/settings`
 (`routes/settings/+page.svelte`) links to one dedicated page per category at
 `/settings/[section]`. The grid and each page header are driven by a single
@@ -261,9 +266,15 @@ operator notepad lives on the kanban board.
   per-task checkboxes, a top-nav **Suggestions** tab (`/suggestions`, issue #324)
   aggregates every recommendation across all tasks for bulk triage:
   `GET /suggestions` (`queries::list_all_suggestions`) returns each suggestion plus
-  its task's title/source/repo link (`AggregatedSuggestion`), and the page reuses
-  the same ack and create-issue actions, with open items on top and acknowledged
-  ones in a greyed, hover-revealed bottom section.
+  its task's title/source/repo-link and its repo `full_name` + issue ref/url
+  (`AggregatedSuggestion`). The page (reworked in issue #364) groups the list by
+  **repo, then by originating task** (`lib/suggestions.ts`, pure + unit-tested), each
+  task headed by a clickable issue badge (`#123`) and its full name. Each suggestion
+  is a `SuggestionCard`: title-first, a three-line clamped description that expands on
+  click, small kind badge, and the `SuggestionCreateButton` split dropdown, which now
+  also carries the mark-complete / reopen action (the old left toggle is gone). Rows
+  multi-select with shift-click range like the board, and a `SuggestionBulkBar` marks
+  a batch complete or reopens it. Open items on top, acknowledged ones greyed below.
 - **`setup_script_changes`** (issue #340) — setup-script edits the agent made to
   **itself** through the **Seraphim MCP** (`workspace/seraphim-mcp`), so it can
   apply an environment optimization it spots (e.g. "add `cd frontend && yarn

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -855,6 +855,14 @@ pub struct AggregatedSuggestion {
     pub task_source: SourceKind,
     /// Whether that task has a linked repo (a GitHub issue needs one).
     pub task_repo_linked: bool,
+    /// The linked repo's `owner/name`, so the Suggestions page groups by repo
+    /// (issue #364). `None` for a task with no linked repo.
+    pub repo_full_name: Option<String>,
+    /// The originating task's issue number or key (GitHub `#123`, a Jira key),
+    /// shown as a compact badge so the suggestion's origin is unambiguous.
+    pub task_external_id: String,
+    /// The originating task's source-ticket URL, for a direct link to the issue.
+    pub task_url: String,
 }
 
 /// A recorded "heart attack": a turn that died mid-flight (the agent hung with no

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -3224,8 +3224,11 @@ pub async fn list_all_suggestions(pool: &PgPool) -> sqlx::Result<Vec<AggregatedS
         "SELECT s.id, s.task_id, s.title, s.detail, s.kind, s.acknowledged, \
                 s.created_at, s.acknowledged_at, \
                 t.title AS task_title, t.source_kind AS task_source, \
-                (t.repo_id IS NOT NULL) AS task_repo_linked \
+                (t.repo_id IS NOT NULL) AS task_repo_linked, \
+                r.full_name AS repo_full_name, \
+                t.external_id AS task_external_id, t.url AS task_url \
          FROM environment_suggestions s JOIN tasks t ON t.id = s.task_id \
+         LEFT JOIN repositories r ON r.id = t.repo_id \
          ORDER BY s.created_at DESC",
     )
     .fetch_all(pool)

--- a/frontend/src/lib/components/SuggestionBulkBar.svelte
+++ b/frontend/src/lib/components/SuggestionBulkBar.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  // A floating bottom bar for the Suggestions page multi-select (issue #364),
+  // mirroring the board's BulkActionBar. The two bulk actions a suggestion
+  // supports are marking a batch complete and reopening it; both are reversible,
+  // so neither needs a confirmation modal.
+  import { Check, RotateCcw, X } from '@lucide/svelte'
+
+  import { Badge } from './ui/badge'
+  import { Button } from './ui/button'
+
+  let {
+    count,
+    onMarkComplete,
+    onReopen,
+    onClear
+  }: {
+    count: number
+    onMarkComplete: () => Promise<void>
+    onReopen: () => Promise<void>
+    onClear: () => void
+  } = $props()
+
+  let busy = $state(false)
+  const noneSelected = $derived(count === 0)
+
+  async function run(action: () => Promise<void>) {
+    busy = true
+    try {
+      await action()
+    } finally {
+      busy = false
+    }
+  }
+</script>
+
+<!-- Capped at the viewport width and wrapping below sm, matching BulkActionBar so
+     it stays usable on a 375px screen. -->
+<div
+  class="fixed bottom-6 left-1/2 z-50 flex w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl sm:w-auto sm:flex-nowrap"
+  role="toolbar"
+  aria-label="Bulk suggestion actions"
+>
+  <div class="flex items-center gap-2 pl-1 pr-1">
+    <Badge variant="default" class="tabular-nums">{count}</Badge>
+    <span class="hidden text-sm text-muted-foreground sm:inline">selected</span>
+  </div>
+
+  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+
+  <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={() => run(onMarkComplete)}>
+    <Check class="size-4" />
+    Mark complete
+  </Button>
+
+  <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={() => run(onReopen)}>
+    <RotateCcw class="size-4" />
+    Reopen
+  </Button>
+
+  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    title="Clear selection"
+    aria-label="Clear selection and exit multi-select"
+    onclick={onClear}
+  >
+    <X class="size-4" />
+  </Button>
+</div>

--- a/frontend/src/lib/components/SuggestionCard.svelte
+++ b/frontend/src/lib/components/SuggestionCard.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  // One suggestion on the Suggestions page (issue #364): a selection checkbox, the
+  // title as the headline, the smart create-issue dropdown (which now also carries
+  // the mark-complete action), a description clamped to three lines that expands on
+  // click, and the small kind badge along the bottom. The title leads; the detail
+  // stays out of the way until wanted.
+  import type { AggregatedSuggestion, EnvSuggestion } from '$lib/types'
+
+  import { ChevronRight } from '@lucide/svelte'
+
+  import { Checkbox } from '$lib/components/ui/checkbox'
+  import SuggestionCreateButton from './SuggestionCreateButton.svelte'
+
+  let {
+    suggestion,
+    selected = false,
+    onselect,
+    onacknowledge,
+    oncreated
+  }: {
+    suggestion: AggregatedSuggestion
+    selected?: boolean
+    // Carries the mouse event so the page can resolve a shift-click range select.
+    onselect: (event: MouseEvent) => void
+    onacknowledge: (next: boolean) => void
+    oncreated: (updated: EnvSuggestion) => void
+  } = $props()
+
+  let expanded = $state(false)
+  let detailElement = $state<HTMLParagraphElement>()
+  // Whether the clamped detail actually overflows three lines. Measured only while
+  // collapsed (when expanded, scrollHeight equals clientHeight), so the value stays
+  // truthy through an expand and the toggle never flickers away mid-read.
+  let overflowing = $state(false)
+
+  $effect(() => {
+    // Re-measure whenever the detail text changes or the row collapses again.
+    void suggestion.detail
+    if (!expanded && detailElement) {
+      overflowing = detailElement.scrollHeight > detailElement.clientHeight + 1
+    }
+  })
+
+  const canExpand = $derived(overflowing || expanded)
+
+  function suppressShiftSelection(event: MouseEvent) {
+    // Shift-clicking with a caret elsewhere would extend a text selection; stop it
+    // so a range select stays a clean click.
+    if (event.shiftKey) {
+      event.preventDefault()
+    }
+  }
+</script>
+
+<div
+  class="flex items-start gap-3 rounded-lg border bg-card p-3 transition-colors {selected
+    ? 'border-primary ring-1 ring-primary/40'
+    : 'border-border hover:border-border/80'} {suggestion.acknowledged ? 'opacity-70' : ''}"
+>
+  <!-- Selection checkbox: a button so the click carries the shiftKey for range
+       selection; the Checkbox inside is purely visual. -->
+  <button
+    type="button"
+    role="checkbox"
+    aria-checked={selected}
+    aria-label={selected ? 'Deselect suggestion' : 'Select suggestion'}
+    onmousedown={suppressShiftSelection}
+    onclick={onselect}
+    class="mt-0.5 flex-none cursor-pointer"
+  >
+    <Checkbox checked={selected} tabindex={-1} aria-hidden="true" class="pointer-events-none" />
+  </button>
+
+  <div class="flex min-w-0 flex-1 flex-col gap-1.5">
+    <!-- Headline row: the title leads, the smart dropdown sits opposite it. -->
+    <div class="flex items-start justify-between gap-3">
+      <h4
+        class="min-w-0 flex-1 text-sm font-semibold leading-snug {suggestion.acknowledged
+          ? 'text-muted-foreground line-through'
+          : 'text-foreground'}"
+      >
+        {suggestion.title}
+      </h4>
+      <SuggestionCreateButton
+        {suggestion}
+        source={suggestion.task_source}
+        repoLinked={suggestion.task_repo_linked}
+        acknowledged={suggestion.acknowledged}
+        {oncreated}
+        {onacknowledge}
+      />
+    </div>
+
+    <!-- Description: clamped to three lines, click the chevron or the text to
+         expand, but only when it actually overflows. -->
+    {#if suggestion.detail}
+      {#if canExpand}
+        <button
+          type="button"
+          onclick={() => (expanded = !expanded)}
+          aria-expanded={expanded}
+          title={expanded ? 'Collapse' : 'Expand'}
+          class="flex w-full items-start gap-1.5 text-left"
+        >
+          <ChevronRight
+            class="mt-0.5 size-3.5 flex-none text-muted-foreground transition-transform {expanded
+              ? 'rotate-90'
+              : ''}"
+          />
+          <p
+            bind:this={detailElement}
+            class="min-w-0 flex-1 whitespace-pre-wrap break-words text-xs leading-relaxed text-muted-foreground {expanded
+              ? ''
+              : 'line-clamp-3'}"
+          >
+            {suggestion.detail}
+          </p>
+        </button>
+      {:else}
+        <p
+          bind:this={detailElement}
+          class="whitespace-pre-wrap break-words pl-5 text-xs leading-relaxed text-muted-foreground line-clamp-3"
+        >
+          {suggestion.detail}
+        </p>
+      {/if}
+    {/if}
+
+    <!-- Bottom badges: small, secondary. The kind badge stays as-is. -->
+    <div class="flex flex-wrap items-center gap-2 pl-5">
+      <span class="rounded border border-border px-1.5 py-0 text-[10px] text-muted-foreground">
+        {suggestion.kind === 'follow_up' ? '🧹 Follow-up' : '💡 Environment'}
+      </span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/lib/components/SuggestionCreateButton.svelte
+++ b/frontend/src/lib/components/SuggestionCreateButton.svelte
@@ -7,7 +7,7 @@
   import type { EnvSuggestion, SourceKind } from '$lib/types'
   import type { CreateIssueTarget } from '$lib/api'
 
-  import { ChevronDown, LoaderCircle } from '@lucide/svelte'
+  import { Check, ChevronDown, LoaderCircle, RotateCcw } from '@lucide/svelte'
   import { toast } from 'svelte-sonner'
 
   import { createIssueFromSuggestion } from '$lib/api'
@@ -16,14 +16,22 @@
     suggestion,
     source,
     repoLinked = false,
-    oncreated
+    acknowledged = false,
+    oncreated,
+    onacknowledge
   }: {
     suggestion: EnvSuggestion
     // Where the ticket was originally created from; the default action mirrors it.
     source: SourceKind
     // Whether the task has a linked repo (a GitHub issue needs one).
     repoLinked?: boolean
+    // The suggestion's current done state, so the ack item reads "Mark as
+    // complete" or "Reopen". Only consulted when `onacknowledge` is given.
+    acknowledged?: boolean
     oncreated: (updated: EnvSuggestion) => void
+    // When provided, the dropdown gains a mark-complete / reopen action, so the
+    // Suggestions page can retire the separate toggle switch (issue #364).
+    onacknowledge?: (next: boolean) => void
   } = $props()
 
   const LABELS: Record<CreateIssueTarget, string> = {
@@ -81,6 +89,11 @@
     }
   }
 
+  function acknowledgeFromMenu() {
+    open = false
+    onacknowledge?.(!acknowledged)
+  }
+
   function onWindowPointerDown(event: MouseEvent) {
     if (open && wrapper && !wrapper.contains(event.target as Node)) open = false
   }
@@ -122,6 +135,24 @@
       role="menu"
       class="absolute right-0 top-full z-50 mt-1 min-w-[12rem] overflow-hidden rounded-md border border-border bg-card py-1 text-xs shadow-lg"
     >
+      {#if onacknowledge}
+        <!-- The done toggle lives here now, not as a switch on the row (issue #364). -->
+        <button
+          type="button"
+          role="menuitem"
+          onclick={acknowledgeFromMenu}
+          class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-foreground transition-colors hover:bg-secondary"
+        >
+          {#if acknowledged}
+            <RotateCcw class="size-3.5 flex-none text-muted-foreground" />
+            <span>Reopen</span>
+          {:else}
+            <Check class="size-3.5 flex-none text-muted-foreground" />
+            <span>Mark as complete</span>
+          {/if}
+        </button>
+        <div class="my-1 h-px bg-border" role="separator"></div>
+      {/if}
       {#each OPTIONS as target (target)}
         <button
           type="button"

--- a/frontend/src/lib/suggestions.test.ts
+++ b/frontend/src/lib/suggestions.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+
+import type { AggregatedSuggestion } from './types'
+import {
+  flattenGroupedSuggestionIds,
+  groupSuggestionsByRepoAndTask,
+  repoGroupLabel,
+  taskBadgeLabel
+} from './suggestions'
+
+// A minimal suggestion for the grouping tests; only the fields grouping reads
+// need to be realistic, the rest carry harmless defaults.
+function suggestion(overrides: Partial<AggregatedSuggestion>): AggregatedSuggestion {
+  return {
+    id: 'suggestion-1',
+    task_id: 'task-1',
+    title: 'A suggestion',
+    detail: '',
+    kind: 'follow_up',
+    acknowledged: false,
+    created_at: '2026-06-16T01:00:00.000Z',
+    acknowledged_at: null,
+    task_title: 'Task one',
+    task_source: 'github',
+    task_repo_linked: true,
+    repo_full_name: 'JalapenoLabs/crew',
+    task_external_id: '1',
+    task_url: 'https://github.com/JalapenoLabs/crew/issues/1',
+    ...overrides
+  }
+}
+
+describe('groupSuggestionsByRepoAndTask', () => {
+  it('groups by repo, then by task, preserving input order', () => {
+    const suggestions: AggregatedSuggestion[] = [
+      suggestion({ id: 'a', repo_full_name: 'org/one', task_id: 't1' }),
+      suggestion({ id: 'b', repo_full_name: 'org/one', task_id: 't1' }),
+      suggestion({ id: 'c', repo_full_name: 'org/one', task_id: 't2' }),
+      suggestion({ id: 'd', repo_full_name: 'org/two', task_id: 't3' })
+    ]
+
+    const groups = groupSuggestionsByRepoAndTask(suggestions)
+
+    expect(groups.map((group) => group.repoFullName)).toEqual(['org/one', 'org/two'])
+    expect(groups[0].tasks.map((task) => task.taskId)).toEqual(['t1', 't2'])
+    expect(groups[0].tasks[0].suggestions.map((entry) => entry.id)).toEqual(['a', 'b'])
+    expect(groups[0].tasks[1].suggestions.map((entry) => entry.id)).toEqual(['c'])
+    expect(groups[1].tasks[0].suggestions.map((entry) => entry.id)).toEqual(['d'])
+  })
+
+  it('moves the unlinked-repo bucket to the end', () => {
+    const suggestions: AggregatedSuggestion[] = [
+      suggestion({ id: 'a', repo_full_name: null, task_id: 't1' }),
+      suggestion({ id: 'b', repo_full_name: 'org/one', task_id: 't2' })
+    ]
+
+    const groups = groupSuggestionsByRepoAndTask(suggestions)
+
+    expect(groups.map((group) => group.repoFullName)).toEqual(['org/one', null])
+  })
+
+  it('keeps two tasks with the same title but different repos separate', () => {
+    const suggestions: AggregatedSuggestion[] = [
+      suggestion({ id: 'a', repo_full_name: 'org/one', task_id: 't1', task_title: 'Same' }),
+      suggestion({ id: 'b', repo_full_name: 'org/two', task_id: 't2', task_title: 'Same' })
+    ]
+
+    const groups = groupSuggestionsByRepoAndTask(suggestions)
+
+    expect(groups).toHaveLength(2)
+    expect(groups[0].tasks).toHaveLength(1)
+    expect(groups[1].tasks).toHaveLength(1)
+  })
+})
+
+describe('flattenGroupedSuggestionIds', () => {
+  it('lists ids in render order across every group, for range selection', () => {
+    const suggestions: AggregatedSuggestion[] = [
+      suggestion({ id: 'a', repo_full_name: 'org/one', task_id: 't1' }),
+      suggestion({ id: 'b', repo_full_name: 'org/one', task_id: 't2' }),
+      suggestion({ id: 'c', repo_full_name: null, task_id: 't3' })
+    ]
+
+    const ordered = flattenGroupedSuggestionIds(groupSuggestionsByRepoAndTask(suggestions))
+
+    // 'c' is unlinked so its group sorts last, even though it came in second-to-none.
+    expect(ordered).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('repoGroupLabel', () => {
+  it('names the repo, or a clear fallback for the unlinked bucket', () => {
+    expect(repoGroupLabel('JalapenoLabs/crew')).toBe('JalapenoLabs/crew')
+    expect(repoGroupLabel(null)).toBe('No repository')
+  })
+})
+
+describe('taskBadgeLabel', () => {
+  it('prefixes a numeric GitHub issue with #, and shows other refs verbatim', () => {
+    expect(taskBadgeLabel('364', 'github')).toBe('#364')
+    expect(taskBadgeLabel('PROJ-12', 'jira')).toBe('PROJ-12')
+    expect(taskBadgeLabel('abc123', 'github')).toBe('abc123')
+  })
+})

--- a/frontend/src/lib/suggestions.ts
+++ b/frontend/src/lib/suggestions.ts
@@ -1,0 +1,102 @@
+// Grouping for the Suggestions page (issue #364): the aggregated list is grouped
+// by repository, then by the originating task, so the operator can see at a glance
+// which repo a suggestion belongs to and which issue kicked it off. The flatten
+// helper produces the display-order list the page uses to resolve shift-click
+// range selection. Pure logic, unit-tested; the page renders the result.
+import type { AggregatedSuggestion, SourceKind } from './types'
+
+// The suggestions raised while working one task, kept in their incoming order.
+export type SuggestionTaskGroup = {
+  taskId: string
+  taskTitle: string
+  taskExternalId: string
+  taskUrl: string
+  taskSource: SourceKind
+  suggestions: AggregatedSuggestion[]
+}
+
+// One repository's tasks. `repoFullName` is `null` for suggestions whose task has
+// no linked repo; that bucket sorts last under a "No repository" heading.
+export type SuggestionRepoGroup = {
+  repoFullName: string | null
+  tasks: SuggestionTaskGroup[]
+}
+
+// Groups suggestions by repo, then by task, preserving the input order within and
+// between groups (the page sorts newest-first before calling this, so the newest
+// suggestion's repo and task lead). The unlinked-repo bucket is moved to the end,
+// since it is the catch-all rather than a real repository.
+export function groupSuggestionsByRepoAndTask(
+  suggestions: AggregatedSuggestion[]
+): SuggestionRepoGroup[] {
+  const repoGroups: SuggestionRepoGroup[] = []
+  const repoIndexByName = new Map<string, number>()
+  // A task belongs to exactly one repo, so its id alone locates its task group.
+  const taskIndexById = new Map<string, number>()
+
+  for (const suggestion of suggestions) {
+    const repoKey = suggestion.repo_full_name ?? ''
+    let repoIndex = repoIndexByName.get(repoKey)
+    if (repoIndex === undefined) {
+      repoIndex = repoGroups.length
+      repoIndexByName.set(repoKey, repoIndex)
+      repoGroups.push({ repoFullName: suggestion.repo_full_name, tasks: [] })
+    }
+    const repoGroup = repoGroups[repoIndex]
+
+    let taskIndex = taskIndexById.get(suggestion.task_id)
+    if (taskIndex === undefined) {
+      taskIndex = repoGroup.tasks.length
+      taskIndexById.set(suggestion.task_id, taskIndex)
+      repoGroup.tasks.push({
+        taskId: suggestion.task_id,
+        taskTitle: suggestion.task_title,
+        taskExternalId: suggestion.task_external_id,
+        taskUrl: suggestion.task_url,
+        taskSource: suggestion.task_source,
+        suggestions: []
+      })
+    }
+    repoGroup.tasks[taskIndex].suggestions.push(suggestion)
+  }
+
+  // The catch-all "no repository" bucket sorts last; real repos keep their order.
+  return repoGroups.sort((first, second) => {
+    if (first.repoFullName === null) {
+      return 1
+    }
+    if (second.repoFullName === null) {
+      return -1
+    }
+    return 0
+  })
+}
+
+// The suggestion ids in the exact order they render, so a shift-click can resolve
+// the contiguous range between the anchor and the clicked row across every group.
+export function flattenGroupedSuggestionIds(groups: SuggestionRepoGroup[]): string[] {
+  const ids: string[] = []
+  for (const repoGroup of groups) {
+    for (const taskGroup of repoGroup.tasks) {
+      for (const suggestion of taskGroup.suggestions) {
+        ids.push(suggestion.id)
+      }
+    }
+  }
+  return ids
+}
+
+// A short, human label for a repo group heading: the repo name, or a clear
+// fallback for the unlinked bucket.
+export function repoGroupLabel(repoFullName: string | null): string {
+  return repoFullName ?? 'No repository'
+}
+
+// Formats a task's issue reference as a compact badge label: GitHub issue numbers
+// read as `#123`, while Jira keys and internal ids are shown verbatim.
+export function taskBadgeLabel(externalId: string, source: SourceKind): string {
+  if (source === 'github' && /^\d+$/.test(externalId)) {
+    return `#${externalId}`
+  }
+  return externalId
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -476,6 +476,13 @@ export type AggregatedSuggestion = EnvSuggestion & {
   task_title: string
   task_source: SourceKind
   task_repo_linked: boolean
+  // The linked repo's `owner/name`, so the Suggestions page groups by repo (issue
+  // #364). `null` for a task with no linked repo.
+  repo_full_name: string | null
+  // The originating task's issue number or key (GitHub `#123`, a Jira key), shown
+  // as a compact badge, plus the source-ticket URL for a direct link.
+  task_external_id: string
+  task_url: string
 }
 
 // A decision the agent escalated to the user.

--- a/frontend/src/routes/suggestions/+page.svelte
+++ b/frontend/src/routes/suggestions/+page.svelte
@@ -1,16 +1,26 @@
 <script lang="ts">
-  // The Suggestions hub (issue #324): every recommendation the agent has made,
-  // across every task, in one aggregated list so the operator manages them in bulk
-  // instead of jumping ticket to ticket. Each row keeps the same one-click controls
-  // as the task view: check it off as done, or turn it into a tracked issue. Done
-  // items drop to a greyed-out bottom section (revealed on hover) and all are shown.
-  import type { AggregatedSuggestion } from '$lib/types'
+  // The Suggestions hub (issue #324, reworked in #364): every recommendation the
+  // agent has made, across every task. Grouped by repository and then by the task
+  // that raised them, so the operator can tell at a glance what a suggestion
+  // belongs to. Each suggestion is a card with the title leading, a create-issue /
+  // mark-complete dropdown, and an expandable clamped description. Rows multi-select
+  // (with shift-click range) for bulk mark-complete / reopen, like the kanban board.
+  import type { AggregatedSuggestion, EnvSuggestion } from '$lib/types'
+  import type { SuggestionRepoGroup, SuggestionTaskGroup } from '$lib/suggestions'
 
   import { onMount, onDestroy } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
 
   import { acknowledgeSuggestion, listAllSuggestions } from '$lib/api'
-  import { Switch } from '$lib/components/ui/switch'
-  import SuggestionCreateButton from '$lib/components/SuggestionCreateButton.svelte'
+  import {
+    flattenGroupedSuggestionIds,
+    groupSuggestionsByRepoAndTask,
+    repoGroupLabel,
+    taskBadgeLabel
+  } from '$lib/suggestions'
+  import { Badge } from '$lib/components/ui/badge'
+  import SuggestionBulkBar from '$lib/components/SuggestionBulkBar.svelte'
+  import SuggestionCard from '$lib/components/SuggestionCard.svelte'
 
   let suggestions = $state<AggregatedSuggestion[]>([])
   let loading = $state(true)
@@ -22,19 +32,93 @@
   const open = $derived(
     suggestions
       .filter((suggestion) => !suggestion.acknowledged)
-      .sort((a, b) => b.created_at.localeCompare(a.created_at))
+      .sort((first, second) => second.created_at.localeCompare(first.created_at))
   )
   const done = $derived(
     suggestions
       .filter((suggestion) => suggestion.acknowledged)
-      .sort((a, b) =>
-        (b.acknowledged_at ?? b.created_at).localeCompare(a.acknowledged_at ?? a.created_at)
+      .sort((first, second) =>
+        (second.acknowledged_at ?? second.created_at).localeCompare(
+          first.acknowledged_at ?? first.created_at
+        )
       )
   )
+
+  const openGroups = $derived(groupSuggestionsByRepoAndTask(open))
+  const doneGroups = $derived(groupSuggestionsByRepoAndTask(done))
+
+  // The full render order (open, then done), so a shift-click resolves a range that
+  // may span task and repo groups.
+  const orderedIds = $derived([
+    ...flattenGroupedSuggestionIds(openGroups),
+    ...flattenGroupedSuggestionIds(doneGroups)
+  ])
+
+  // --- Multi-select (issue #364) ---------------------------------------------
+  let selected = new SvelteSet<string>()
+  // The last row toggled on, the anchor a shift-click extends a range from.
+  let anchorId = $state<string | null>(null)
+
+  function select(id: string, event: MouseEvent) {
+    if (event.shiftKey && anchorId && orderedIds.includes(anchorId) && orderedIds.includes(id)) {
+      // Range select: fill in every row between the anchor and this one, inclusive.
+      const anchorIndex = orderedIds.indexOf(anchorId)
+      const clickedIndex = orderedIds.indexOf(id)
+      const low = Math.min(anchorIndex, clickedIndex)
+      const high = Math.max(anchorIndex, clickedIndex)
+      for (let index = low; index <= high; index += 1) {
+        selected.add(orderedIds[index])
+      }
+      return
+    }
+    if (selected.has(id)) {
+      selected.delete(id)
+    } else {
+      selected.add(id)
+    }
+    anchorId = id
+  }
+
+  function clearSelection() {
+    selected.clear()
+    anchorId = null
+  }
+
+  async function bulkAcknowledge(next: boolean) {
+    const ids = [...selected]
+    if (ids.length === 0) {
+      return
+    }
+    // Optimistically flip every selected row, then persist. On any failure, resync
+    // from the server so the UI never lies about what was actually saved.
+    const stamp = next ? new Date().toISOString() : null
+    for (const id of ids) {
+      const match = suggestions.find((suggestion) => suggestion.id === id)
+      if (match) {
+        match.acknowledged = next
+        match.acknowledged_at = stamp
+      }
+    }
+    clearSelection()
+    const results = await Promise.allSettled(
+      ids.map((id) => acknowledgeSuggestion(id, next))
+    )
+    if (results.some((result) => result.status === 'rejected')) {
+      console.debug('some bulk acknowledgements failed, reloading', results)
+      await load()
+    }
+  }
 
   async function load() {
     try {
       suggestions = await listAllSuggestions()
+      // Drop any selection that no longer exists (acted on elsewhere, or deleted).
+      const present = new Set(suggestions.map((suggestion) => suggestion.id))
+      for (const id of selected) {
+        if (!present.has(id)) {
+          selected.delete(id)
+        }
+      }
     } catch (error) {
       console.debug('failed to load suggestions', error)
     } finally {
@@ -42,25 +126,28 @@
     }
   }
 
-  async function toggle(suggestion: AggregatedSuggestion) {
-    // Optimistically flip so the switch feels instant, then persist; revert on
-    // failure so the UI never lies about what was actually saved (mirrors the task
-    // view). Toggling `acknowledged` re-sorts the row into the right section.
-    const next = !suggestion.acknowledged
-    suggestion.acknowledged = next
-    suggestion.acknowledged_at = next ? new Date().toISOString() : null
+  async function toggle(id: string, next: boolean) {
+    // Optimistically flip so the action feels instant, then persist; revert on
+    // failure so the UI never lies about what was actually saved.
+    const match = suggestions.find((suggestion) => suggestion.id === id)
+    if (!match) {
+      console.debug('toggle called for an unknown suggestion', id)
+      return
+    }
+    match.acknowledged = next
+    match.acknowledged_at = next ? new Date().toISOString() : null
     try {
-      await acknowledgeSuggestion(suggestion.id, next)
+      await acknowledgeSuggestion(id, next)
     } catch (error) {
       console.debug('failed to update suggestion, reverting', error)
-      suggestion.acknowledged = !next
-      suggestion.acknowledged_at = !next ? new Date().toISOString() : null
+      match.acknowledged = !next
+      match.acknowledged_at = !next ? new Date().toISOString() : null
     }
   }
 
   // The create-issue button marks the suggestion done on the server; reflect that
   // locally so the row drops to the done section without waiting for a refetch.
-  function onCreated(updated: { id: string; acknowledged_at: string | null }) {
+  function onCreated(updated: EnvSuggestion) {
     const match = suggestions.find((suggestion) => suggestion.id === updated.id)
     if (match) {
       match.acknowledged = true
@@ -79,69 +166,54 @@
   onDestroy(() => eventSource?.close())
 </script>
 
-{#snippet row(suggestion: AggregatedSuggestion)}
-  <li
-    class="flex items-start justify-between gap-3 py-2 {suggestion.acknowledged
-      ? 'opacity-60 transition-opacity hover:opacity-100'
-      : ''}"
-  >
-    <button
-      type="button"
-      role="switch"
-      aria-checked={suggestion.acknowledged}
-      onclick={() => toggle(suggestion)}
-      class="flex min-w-0 flex-1 cursor-pointer items-start gap-2 text-left"
+{#snippet taskGroupBlock(taskGroup: SuggestionTaskGroup)}
+  <div class="flex flex-col gap-1.5">
+    <!-- The originating task: a clickable issue badge plus its full name, so the
+         suggestion's origin is unambiguous and never clipped. -->
+    <a
+      href={`/task/${taskGroup.taskId}`}
+      class="group flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
     >
-      <Switch
-        checked={suggestion.acknowledged}
-        tabindex={-1}
-        aria-hidden="true"
-        class="mt-0.5 pointer-events-none"
-      />
-      <span class="flex min-w-0 flex-col gap-0.5">
-        <span class="flex flex-wrap items-center gap-2">
-          <span
-            class="text-sm font-medium {suggestion.acknowledged
-              ? 'text-muted-foreground line-through'
-              : ''}"
-          >
-            {suggestion.title}
-          </span>
-          <span class="rounded border border-border px-1.5 py-0 text-[10px] text-muted-foreground">
-            {suggestion.kind === 'follow_up' ? '🧹 Follow-up' : '💡 Environment'}
-          </span>
-        </span>
-        {#if suggestion.detail}
-          <span class="whitespace-pre-wrap text-xs text-muted-foreground">{suggestion.detail}</span>
-        {/if}
-      </span>
-    </button>
-    <div class="flex flex-none flex-col items-end gap-1.5">
-      <a
-        href={`/task/${suggestion.task_id}`}
-        title={suggestion.task_title}
-        class="max-w-[10rem] truncate text-xs text-muted-foreground underline hover:text-foreground"
-      >
-        {suggestion.task_title}
-      </a>
-      {#if !suggestion.acknowledged}
-        <SuggestionCreateButton
+      <Badge variant="secondary" class="flex-none tabular-nums group-hover:bg-secondary/80">
+        {taskBadgeLabel(taskGroup.taskExternalId, taskGroup.taskSource)}
+      </Badge>
+      <span class="truncate group-hover:underline">{taskGroup.taskTitle}</span>
+    </a>
+    <!-- The task's suggestions, boxed together. -->
+    <div class="flex flex-col gap-2">
+      {#each taskGroup.suggestions as suggestion (suggestion.id)}
+        <SuggestionCard
           {suggestion}
-          source={suggestion.task_source}
-          repoLinked={suggestion.task_repo_linked}
+          selected={selected.has(suggestion.id)}
+          onselect={(event) => select(suggestion.id, event)}
+          onacknowledge={(next) => toggle(suggestion.id, next)}
           oncreated={onCreated}
         />
-      {/if}
+      {/each}
     </div>
-  </li>
+  </div>
 {/snippet}
 
-<div class="mx-auto flex max-w-3xl flex-col gap-4 p-6">
+{#snippet repoGroups(groups: SuggestionRepoGroup[])}
+  {#each groups as repoGroup (repoGroup.repoFullName ?? '__none__')}
+    <div class="flex flex-col gap-3">
+      <h3 class="text-sm font-semibold tracking-tight">
+        {repoGroupLabel(repoGroup.repoFullName)}
+      </h3>
+      {#each repoGroup.tasks as taskGroup (taskGroup.taskId)}
+        {@render taskGroupBlock(taskGroup)}
+      {/each}
+    </div>
+  {/each}
+{/snippet}
+
+<div class="mx-auto flex max-w-3xl flex-col gap-4 p-6 pb-24">
   <header>
     <h1 class="text-xl font-bold tracking-tight">Suggestions</h1>
     <p class="mt-0.5 text-sm text-muted-foreground">
-      Every recommendation the agent has made across all tasks. Check one off once you have handled
-      it, or one-click it into a tracked issue.
+      Every recommendation the agent has made across all tasks, grouped by repo and the task that
+      raised it. Select rows to act on them in bulk, one-click one into a tracked issue, or mark it
+      complete once you have handled it.
     </p>
   </header>
 
@@ -152,28 +224,29 @@
       No suggestions yet. The agent records environment tips and follow-up work as it runs.
     </p>
   {:else}
-    <section class="rounded-lg border border-warning/50 bg-card p-3">
+    <section class="flex flex-col gap-6 rounded-lg border border-warning/50 bg-card/40 p-4">
       <h2 class="text-sm font-semibold">Open ({open.length})</h2>
       {#if open.length === 0}
-        <p class="mt-1 text-xs text-muted-foreground">Nothing open. Everything has been handled.</p>
+        <p class="text-xs text-muted-foreground">Nothing open. Everything has been handled.</p>
       {:else}
-        <ul class="mt-2 divide-y divide-border">
-          {#each open as suggestion (suggestion.id)}
-            {@render row(suggestion)}
-          {/each}
-        </ul>
+        {@render repoGroups(openGroups)}
       {/if}
     </section>
 
     {#if done.length}
-      <section class="rounded-lg border border-border bg-card p-3">
+      <section class="flex flex-col gap-6 rounded-lg border border-border bg-card/40 p-4 opacity-80">
         <h2 class="text-sm font-semibold text-muted-foreground">Done ({done.length})</h2>
-        <ul class="mt-2 divide-y divide-border">
-          {#each done as suggestion (suggestion.id)}
-            {@render row(suggestion)}
-          {/each}
-        </ul>
+        {@render repoGroups(doneGroups)}
       </section>
     {/if}
   {/if}
 </div>
+
+{#if selected.size > 0}
+  <SuggestionBulkBar
+    count={selected.size}
+    onMarkComplete={() => bulkAcknowledge(true)}
+    onReopen={() => bulkAcknowledge(false)}
+    onClear={clearSelection}
+  />
+{/if}


### PR DESCRIPTION
## What

Reworks `/suggestions` from a flat, hard-to-triage list into a grouped, multi-select workspace. Closes #364.

## Changes

**Per-repo, per-task grouping.** The list is grouped by repository, then by the originating task. Each task is headed by a clickable issue badge (`#123`) and its full, un-clipped name, linking to the task. Grouping is a pure, unit-tested helper (`lib/suggestions.ts`).

**Multi-select + bulk actions.** Rows carry a selection checkbox and support shift-click range select (like the kanban board). A floating `SuggestionBulkBar` marks a batch complete or reopens it.

**Better suggestion cards.** Each suggestion is a `SuggestionCard`:
- The title leads (the main point of interest).
- The description clamps to three lines and expands on click (only when it actually overflows).
- The small kind badge (follow-up / environment) sits along the bottom.
- Layout matches the brief: `title <-> create dropdown`, then `collapse arrow + description`, then badges.

**Mark-complete moved into the dropdown.** The left toggle switch is gone; `SuggestionCreateButton` now carries a "Mark as complete" / "Reopen" action, so the split button is the action hub (per the brief).

**Backend.** `AggregatedSuggestion` and `list_all_suggestions` now include the repo `full_name` (for grouping) and the task's `external_id` + `url` (for the badge and link), via a `LEFT JOIN repositories`.

## Tests / checks

- New vitest suite for the grouping helper (`lib/suggestions.test.ts`, 6 cases); full frontend suite green (19).
- `yarn check` (svelte-check) 0 errors, `yarn build` succeeds.
- Backend `cargo fmt --check` and `cargo clippy --all-targets --all-features` clean; the new SQL validated directly against the live schema (returns `external_id` / `url` / `full_name`).
- Repo control-char check passes.

## Visual review

Skipped the live browser review: the Playwright MCP browser tools are not available in this environment. The UI was built by reusing the repo's existing primitives and patterns (Badge, Checkbox, dropdown, the `BulkActionBar` floating-bar style, and the task page's `line-clamp-3` expand/collapse) and its spacing tokens, and it type-checks and builds clean. Recorded the dev-server command in `CLAUDE.md` for the next run.