### PR TITLE
Clear "waiting for input" the moment the last question is answered (#366)

### DIFF
--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -3412,6 +3412,37 @@ pub async fn count_pending_questions(pool: &PgPool, task_id: Uuid) -> sqlx::Resu
     .await
 }
 
+/// Unparks a task the moment its last question is answered (issue #366).
+///
+/// When the agent asks, the task is parked in `waiting_for_input`; it only left
+/// that status when the single-threaded agent loop happened to resume it, so the
+/// "waiting for input" badge lingered on the board (persisting across refreshes,
+/// since it is real DB state) while the loop was paused, busy with another task,
+/// or catching up on a batch the user answered at once. This flips the task back
+/// to `queued` the instant nothing is pending, so the badge clears deterministically.
+///
+/// One atomic, guarded statement: it fires only for a task still parked in
+/// `waiting_for_input` with no pending question left, so it is a no-op if the task
+/// already moved on (the loop resumed it, it was re-queued or failed) or still has
+/// another question open. The answers stay `acknowledged = FALSE`, so
+/// [`pick_resume_ready`] still resumes the task and delivers them. Returns whether
+/// it cleared the parking.
+pub async fn clear_waiting_for_input_when_answered(
+    pool: &PgPool,
+    task_id: Uuid,
+) -> sqlx::Result<bool> {
+    let result = sqlx::query(
+        "UPDATE tasks SET status = 'queued', updated_at = now() \
+         WHERE id = $1 AND status = 'waiting_for_input' \
+           AND NOT EXISTS (SELECT 1 FROM questions q \
+                           WHERE q.task_id = $1 AND q.status = 'pending')",
+    )
+    .bind(task_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
 /// A task that is parked on a question whose answer has arrived but not yet been
 /// delivered to the agent: in progress, nothing pending, at least one answered
 /// question still unacknowledged. This is what the agent loop resumes.
@@ -4234,6 +4265,105 @@ mod tests {
         assert!(
             !has_active_blocking_task(&pool, railway_id).await.unwrap(),
             "a non-blocking task in review must not gate the queue"
+        );
+
+        db.teardown().await;
+    }
+
+    /// Answering the last pending question must unpark the task immediately, so the
+    /// "waiting for input" badge clears deterministically instead of lingering until
+    /// the agent loop resumes it (issue #366).
+    ///
+    /// DB-gated: runs only when `DATABASE_URL` is set (the CI test job's throwaway
+    /// Postgres, or `pg-ephemeral` locally); otherwise it skips.
+    #[tokio::test]
+    async fn answering_the_last_question_unparks_the_task() {
+        let Some(db) = setup_throwaway_db("seraphim_issue366_test").await else {
+            return;
+        };
+        let pool = db.pool.clone();
+
+        // A task parked in progress, waiting on two questions.
+        let task = create_internal_task(&pool, "waiting-for-input badge", "", "open", &[], 1.0)
+            .await
+            .expect("create the parked task");
+        move_task(&pool, task.id, TaskColumn::InProgress, task.position)
+            .await
+            .expect("move it into In Progress");
+        set_task_status(&pool, task.id, TaskStatus::WaitingForInput)
+            .await
+            .expect("park it waiting for input");
+        let first = create_question(&pool, task.id, "which auth library?", &[])
+            .await
+            .expect("first question");
+        let second = create_question(&pool, task.id, "which database?", &[])
+            .await
+            .expect("second question");
+
+        // Answering the first leaves one pending, so the task stays parked.
+        answer_question(
+            &pool,
+            first.id,
+            QuestionStatus::Answered,
+            AnswerKind::Custom,
+            "jwt",
+        )
+        .await
+        .expect("answer the first");
+        let cleared = clear_waiting_for_input_when_answered(&pool, task.id)
+            .await
+            .expect("attempt to unpark");
+        assert!(
+            !cleared,
+            "a task with a still-pending question stays parked"
+        );
+        assert_eq!(
+            get_task(&pool, task.id).await.unwrap().unwrap().status,
+            TaskStatus::WaitingForInput,
+            "the badge stays until every question is answered",
+        );
+
+        // Answering the last one unparks it at once, back to queued for the resume.
+        answer_question(
+            &pool,
+            second.id,
+            QuestionStatus::Answered,
+            AnswerKind::Custom,
+            "postgres",
+        )
+        .await
+        .expect("answer the last");
+        let cleared = clear_waiting_for_input_when_answered(&pool, task.id)
+            .await
+            .expect("unpark");
+        assert!(cleared, "answering the last question unparks the task");
+        assert_eq!(
+            get_task(&pool, task.id).await.unwrap().unwrap().status,
+            TaskStatus::Queued,
+            "the waiting-for-input badge clears immediately",
+        );
+
+        // The answers are still undelivered, so the resume loop picks the task up.
+        let resumable = pick_resume_ready(&pool, task.railway_id)
+            .await
+            .expect("query resume-ready tasks");
+        assert_eq!(
+            resumable.map(|resumed| resumed.id),
+            Some(task.id),
+            "the task is still resume-ready after unparking",
+        );
+
+        // Guard: a task the loop already resumed (Working) is left untouched.
+        set_task_status(&pool, task.id, TaskStatus::Working)
+            .await
+            .expect("the loop resumes it");
+        let cleared = clear_waiting_for_input_when_answered(&pool, task.id)
+            .await
+            .expect("no-op unpark");
+        assert!(!cleared, "a task no longer parked is not touched");
+        assert_eq!(
+            get_task(&pool, task.id).await.unwrap().unwrap().status,
+            TaskStatus::Working,
         );
 
         db.teardown().await;

--- a/api/src/http/questions.rs
+++ b/api/src/http/questions.rs
@@ -114,6 +114,13 @@ pub async fn answer(
     };
     let answered = queries::answer_question(&state.db, id, status, body.kind, &body.text).await?;
 
+    // Unpark the task the instant its last question is answered (issue #366): flip
+    // it off `waiting_for_input` so the board badge clears immediately and
+    // deterministically, instead of lingering until the single-threaded agent loop
+    // gets around to resuming it. The answers stay unacknowledged, so
+    // `pick_resume_ready` still resumes the task and delivers them.
+    queries::clear_waiting_for_input_when_answered(&state.db, question.task_id).await?;
+
     // The board reflects the status, and once nothing is pending the agent loop
     // picks the task up to resume (see `queries::pick_resume_ready`).
     state.notify_board();


### PR DESCRIPTION
## Problem

Answering a task's questions did not clear its "waiting for input" badge. The badge lingered on the board and **persisted across refreshes**, because it is real DB state: `waiting for input` is a persisted `TaskStatus`, not a derived value.

Closes #366.

## Root cause

When the agent asks, the task is parked in `waiting_for_input` (`POST /agent/questions`). Nothing reset that status on answer: the code relied on the single-threaded agent loop resuming the task (`work_task` → `Working`) to move it off `waiting_for_input`. So while the loop was **paused, busy with another task, or working through a batch the user answered all at once**, the answered tasks kept the badge indefinitely. The answer handler only called `notify_board()`, so a refresh re-fetched the same stale `waiting_for_input` status.

## Fix

`POST /questions/:id/answer` now unparks the task the instant its **last** pending question is answered, via one atomic, guarded statement:

```sql
UPDATE tasks SET status = 'queued', updated_at = now()
WHERE id = $1 AND status = 'waiting_for_input'
  AND NOT EXISTS (SELECT 1 FROM questions q WHERE q.task_id = $1 AND q.status = 'pending')
```

- **Deterministic:** flips `waiting_for_input` → `queued` immediately, so the badge clears without waiting for the loop. `notify_board()` (already called) ticks the live board, so it updates on-screen at once, not just on the next manual refresh.
- **Race-safe / idempotent:** a no-op if the task already moved on (the loop resumed it, or it was re-queued/failed) or still has another question pending. Answering a non-last question leaves it parked.
- **No lost work:** the answered questions stay `acknowledged = FALSE`, so `pick_resume_ready` (which keys on the questions table + `in_progress` column, not the task status) still resumes the task and delivers the answers. `queued` is chosen over `working` so it does not falsely read as the single active turn.

Declining a question resolves it the same way (it is no longer `pending`), so declining the last one also unparks the task.

## Tests

Added a DB-gated test (`answering_the_last_question_unparks_the_task`): two pending questions stay parked after the first answer; the last answer flips the status to `queued`; the task remains resume-ready; and a task already resumed to `Working` is left untouched. Full backend suite green (188 tests) against real Postgres; `cargo fmt --check` and `cargo clippy --all-targets --all-features` clean.

## Visual review

Skipped: this is a backend state fix with no UI/layout change (the card renders the existing `queued` status badge instead of `waiting for input` through the same mechanism), and the board already refetches on the board SSE tick.