### PR TITLE
Stop seraphim-ask posting malformed questions; reject blank prompts (#368)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,12 @@ operator notepad lives on the kanban board.
 - **`questions`** — decisions the agent escalated to the user, stored on the task
   (`prompt`, up to three suggested `options`, `status`, the chosen `answer`).
   Posted by the agent's `seraphim-ask` helper, answered in the task view, and
-  surfaced as toasts + native notifications + a sidebar.
+  surfaced as toasts + native notifications + a sidebar. A task stays
+  `waiting_for_input` until **every** question on it is answered, so a junk
+  question would block it forever; `POST /agent/questions` therefore rejects a
+  blank (empty or whitespace-only) `prompt` with a 400 rather than persisting it
+  (issue #368), and `seraphim-ask` handles `--help` and refuses a shell-mangled
+  JSON payload so a slip never posts one.
 - **`task_screenshots`** (issue #248) — screenshots the agent captured during a
   task (via the Playwright MCP, issue #243), so the operator sees what the agent
   saw. The agent's `seraphim-screenshot <file>` helper POSTs the raw image bytes to

--- a/api/src/http/questions.rs
+++ b/api/src/http/questions.rs
@@ -34,6 +34,27 @@ pub struct AskRequest {
     pub questions: Vec<AskQuestion>,
 }
 
+/// Why a batch of questions must be rejected with a 400, or `None` when it is
+/// postable (issue #368).
+///
+/// A blank-prompt question is the durable hazard: a question with no text can
+/// never be answered, so it silently blocks the task in `waiting_for_input`
+/// forever and pollutes the notifications sidebar. This guards the server against
+/// any buggy client (a `seraphim-ask --help` slip, a mangled JSON payload), not
+/// just today's, so a junk question is never persisted.
+fn rejection_reason(questions: &[AskQuestion]) -> Option<&'static str> {
+    if questions.is_empty() {
+        return Some("no questions provided");
+    }
+    if questions
+        .iter()
+        .any(|question| question.prompt.trim().is_empty())
+    {
+        return Some("a question prompt must not be empty");
+    }
+    None
+}
+
 /// `POST /api/v1/agent/questions` - the agent escalates one or more questions.
 ///
 /// Called from inside the workspace by `seraphim-ask`. The task is parked in
@@ -50,12 +71,8 @@ pub async fn ask(
         )
             .into_response());
     };
-    if body.questions.is_empty() {
-        return Ok((
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "no questions provided" })),
-        )
-            .into_response());
+    if let Some(reason) = rejection_reason(&body.questions) {
+        return Ok((StatusCode::BAD_REQUEST, Json(json!({ "error": reason }))).into_response());
     }
 
     let mut ids = Vec::with_capacity(body.questions.len());
@@ -63,8 +80,9 @@ pub async fn ask(
         // Keep at most the first few options; the UI always adds its own
         // "something else" and "decline" choices.
         let options: Vec<QuestionOption> = question.options.into_iter().take(MAX_OPTIONS).collect();
+        // Store the trimmed prompt so surrounding whitespace never persists.
         let created =
-            queries::create_question(&state.db, task.id, &question.prompt, &options).await?;
+            queries::create_question(&state.db, task.id, question.prompt.trim(), &options).await?;
         state.notify_question(task.id, task.title.clone(), created.prompt.clone());
         ids.push(created.id);
     }
@@ -126,4 +144,51 @@ pub async fn answer(
     state.notify_board();
 
     Ok(Json(answered).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rejection_reason, AskQuestion};
+
+    fn question(prompt: &str) -> AskQuestion {
+        AskQuestion {
+            prompt: prompt.to_owned(),
+            options: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_real_question_is_accepted() {
+        assert_eq!(rejection_reason(&[question("Which database?")]), None);
+    }
+
+    #[test]
+    fn an_empty_batch_is_rejected() {
+        assert_eq!(rejection_reason(&[]), Some("no questions provided"));
+    }
+
+    #[test]
+    fn a_blank_prompt_is_rejected() {
+        // The core of issue #368: a `--help` slip or a mangled payload can post a
+        // question with no real text, which would block the task forever. An empty
+        // or whitespace-only prompt is refused before it is ever persisted.
+        assert_eq!(
+            rejection_reason(&[question("")]),
+            Some("a question prompt must not be empty")
+        );
+        assert_eq!(
+            rejection_reason(&[question("   \n\t ")]),
+            Some("a question prompt must not be empty")
+        );
+    }
+
+    #[test]
+    fn one_blank_prompt_rejects_the_whole_batch() {
+        // A well-formed client never mixes in a blank prompt, so a blank anywhere
+        // signals a client bug worth surfacing loudly rather than silently dropping.
+        assert_eq!(
+            rejection_reason(&[question("Which database?"), question("  ")]),
+            Some("a question prompt must not be empty")
+        );
+    }
 }

--- a/workspace/seraphim-ask
+++ b/workspace/seraphim-ask
@@ -23,6 +23,44 @@ function fail(message) {
   process.exit(1)
 }
 
+// Prints usage to stdout for `--help` / `-h`, so the flag never falls through to
+// the post path and submits "--help" as an empty question (issue #368).
+function printUsage() {
+  console.log(
+    [
+      'seraphim-ask: escalate a decision to the human on the current task.',
+      '',
+      'Usage (the payload is JSON, passed as an argument or on stdin):',
+      '  seraphim-ask \'{"questions":[{"prompt":"Which DB?","options":[',
+      '                 {"title":"Postgres","description":"already used here"}]}]}\'',
+      '  echo \'<json>\' | seraphim-ask',
+      '',
+      'Prefer a heredoc on stdin so quotes and braces in the payload never hit the shell:',
+      "  seraphim-ask <<'JSON'",
+      '  {"questions":[{"prompt":"...","options":[{"title":"...","description":"..."}]}]}',
+      '  JSON',
+      '',
+      'A bare string, a single {prompt, options} object, or an array of those are also',
+      'accepted. Up to 3 options per question are kept; the UI adds "something else" and',
+      '"decline and chat". Requires SERAPHIM_API_URL and SERAPHIM_TASK_ID (injected by',
+      'the orchestrator). This does not block waiting for the answer.'
+    ].join('\n')
+  )
+}
+
+// The shared "your input was not usable JSON" guidance, so the JSON-parse failure
+// and the mangled-payload detection give the agent one consistent recovery path:
+// re-emit valid JSON via a heredoc (issue #368).
+function jsonGuidance(reason) {
+  return (
+    `${reason} Nothing was sent. Re-run with valid JSON. To avoid shell-quoting ` +
+    'problems with quotes and apostrophes inside the payload, pipe it on stdin via a heredoc:\n' +
+    "  seraphim-ask <<'JSON'\n" +
+    '  {"questions":[{"prompt":"...","options":[{"title":"...","description":"..."}]}]}\n' +
+    '  JSON'
+  )
+}
+
 // Reads the whole of stdin, for the `echo ... | seraphim-ask` form.
 function readStdin() {
   return new Promise((resolve) => {
@@ -57,6 +95,14 @@ function normalizeQuestions(parsed) {
 }
 
 async function main() {
+  // Handle --help / -h before anything else, so it prints usage and exits 0
+  // without needing the orchestrator env and without ever posting (issue #368).
+  const firstArg = process.argv[2]
+  if (firstArg === '-h' || firstArg === '--help') {
+    printUsage()
+    return
+  }
+
   if (!API_URL || !TASK_ID) {
     fail('SERAPHIM_API_URL and SERAPHIM_TASK_ID must be set (they are injected by the orchestrator)')
   }
@@ -79,13 +125,20 @@ async function main() {
     // loudly so the agent re-emits valid JSON instead of asking the user to read
     // raw JSON.
     if (trimmedInput.startsWith('{') || trimmedInput.startsWith('[')) {
+      fail(jsonGuidance(`the input looks like JSON but could not be parsed (${error.message}).`))
+    }
+    // Even without a leading brace, input carrying the JSON envelope's own keys is
+    // almost certainly a payload the shell mangled (it swallowed the opening brace,
+    // so part of the JSON leaked into what looks like a plain question). Do NOT post
+    // the broken fragment as a question's text (issue #368): that is exactly the
+    // corrupted "question" the operator then has to decline. Fail loudly so the
+    // agent re-emits valid JSON via a heredoc.
+    if (/"(?:questions|prompt|options)"\s*:/.test(trimmedInput)) {
       fail(
-        `the input looks like JSON but could not be parsed (${error.message}). ` +
-          'Nothing was sent. Re-run with valid JSON. To avoid shell-quoting problems ' +
-          'with quotes and apostrophes inside the payload, pipe it on stdin via a heredoc:\n' +
-          "  seraphim-ask <<'JSON'\n" +
-          '  {"questions":[{"prompt":"...","options":[{"title":"...","description":"..."}]}]}\n' +
-          '  JSON'
+        jsonGuidance(
+          'the input looks like a JSON payload the shell mangled (it carries JSON keys ' +
+            'but no wrapping braces).'
+        )
       )
     }
     // A genuinely plain, unquoted question string is still allowed as a shortcut.


### PR DESCRIPTION
## Problem

On task #363, `seraphim-ask` posted two junk questions: an empty one whose prompt was literally `--help`, and one whose prompt was a shell-mangled JSON blob. Each is a real `pending` row, and a task stays `waiting_for_input` until **every** question is answered, so a junk question silently blocks the task forever, pollutes the notifications sidebar, and forces the operator to decline garbage by hand.

Closes #368.

## Fix (three guards, from the durable one outward)

**Server (`POST /agent/questions`) — the durable backstop.** Reject a blank (empty or whitespace-only) `prompt` with a 400 rather than persisting it, and store the trimmed prompt. This protects against *any* buggy client, present or future, not just `seraphim-ask`. The logic is a pure `rejection_reason(&[AskQuestion]) -> Option<&str>` with unit tests (empty batch, blank prompt, whitespace prompt, one-blank-in-a-batch), so it is a CI regression guard with no DB needed.

**`seraphim-ask` `--help` / `-h`.** Print usage and exit 0 before anything else (no orchestrator env needed), so the flag never falls through to the post path and submits `--help` as an empty question.

**`seraphim-ask` mangled-JSON guard.** The body was already built with `JSON.stringify`; the corruption came from the agent's *shell* eating the opening brace of a JSON argument, leaving the remainder to be posted as a plain question. Now a "plain" input that carries the envelope's own keys (`"prompt":` / `"options":` / `"questions":`) without wrapping braces fails loudly with the existing heredoc guidance instead of posting the fragment. The JSON-parse-failure and mangled-payload paths now share one `jsonGuidance()` recovery message.

## Verification

- Helper (ran directly): `--help` and `-h` print usage and exit 0; a mangled fragment (`built tions": [{"prompt":...`) and broken JSON (`{"questions": [bad`) both fail without posting; a genuine plain question and a valid JSON payload still reach the post path (fail only on the unreachable test API, proving no false positive); `node --check` clean.
- Backend: 4 new `rejection_reason` unit tests pass; full suite green against real Postgres (193 tests); `cargo fmt --check` and `cargo clippy --all-targets --all-features` clean; repo control-char check passes.

## Notes

- The issue's optional "withdraw/supersede a bad question" idea is deliberately left out (a distinct feature), and the prevention guards here make it far less necessary. Filed as a follow-up.
- `seraphim-suggest` and `seraphim-followup` share the same missing-`--help` pattern but post to non-task-blocking endpoints; filed as a follow-up rather than widening this PR.

## Visual review

Skipped: backend + workspace-script change, no UI. The fix prevents junk questions from being created; the existing notifications/decline UI is unchanged.