### PR TITLE
Scope the empty-PR anomaly banner to active tasks (#369)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -620,10 +620,14 @@ operator notepad lives on the kanban board.
      `ServerEvent::AnomalousEmptyPr` (toast + native notification) on the transition
      into the anomaly, and the board payload carries a derived, self-clearing
      `anomalous_empty_prs` list (`queries::list_anomalous_empty_prs`, open +
-     `is_empty` + not `is_draft`) that drives a dismissible banner, mirroring the
-     repo-sync-error banner; it drops off once the PR gains changes, closes, or is
-     marked draft. Non-empty, non-draft (ready) PRs follow the normal review-gate +
-     auto-merge flow.
+     `is_empty` + not `is_draft`, and only for tasks still in an active column) that
+     drives a self-clearing banner, mirroring the repo-sync-error banner; it drops off
+     once the PR gains changes, closes, is marked draft, or its task settles. Tasks in
+     a terminal column (`done`, `ignored`) never raise the banner (issue #369): the
+     review loop only refreshes `pr_state` while it still gates a task, so a settled
+     task's PR could otherwise leave `pr_state` stuck at `'open'` and the banner
+     permanently raised; a settled task's PR is not an anomaly. Non-empty, non-draft
+     (ready) PRs follow the normal review-gate + auto-merge flow.
    - **Review-comment gate (issues #255, #270):** a green PR is NEVER squash-merged
      while it carries review work, no matter its approval state. The merge gate is
      exactly **CI green AND zero unresolved review threads AND no outstanding

--- a/api/src/db/queries.rs
+++ b/api/src/db/queries.rs
@@ -2743,11 +2743,19 @@ pub async fn list_open_task_prs(pool: &PgPool) -> sqlx::Result<Vec<TaskPullReque
 /// blocker (issue #304) and is excluded; only the unexpected ones surface. Derived
 /// live from the tracked PR rows, so the banner clears itself the moment a PR gains
 /// changes, is closed, or is marked draft, with no separate state to reconcile.
+///
+/// PRs on tasks in a terminal column (`done`, `ignored`) are excluded (issue #369).
+/// `pr_state` is only refreshed while the review loop still gates a task, so once a
+/// task settles the loop stops refreshing its PR rows; a PR closed outside Seraphim
+/// then leaves `pr_state` stuck at `'open'` and the banner could never self-clear.
+/// A settled task's PR is not an anomaly, so scoping the query to still-active tasks
+/// keeps the banner self-clearing without adding any dismiss state to reconcile.
 pub async fn list_anomalous_empty_prs(pool: &PgPool) -> sqlx::Result<Vec<AnomalousEmptyPr>> {
     sqlx::query_as::<_, AnomalousEmptyPr>(
         "SELECT pr.task_id, t.title AS task_title, pr.repo_full_name, pr.pr_number, pr.pr_url \
          FROM task_pull_requests pr JOIN tasks t ON t.id = pr.task_id \
          WHERE pr.pr_state = 'open' AND pr.is_empty = TRUE AND pr.is_draft = FALSE \
+           AND t.board_column NOT IN ('done'::task_column, 'ignored'::task_column) \
          ORDER BY pr.updated_at DESC",
     )
     .fetch_all(pool)
@@ -4364,6 +4372,83 @@ mod tests {
         assert_eq!(
             get_task(&pool, task.id).await.unwrap().unwrap().status,
             TaskStatus::Working,
+        );
+
+        db.teardown().await;
+    }
+
+    /// An empty open PR raises the anomaly banner only while its task is still active;
+    /// once the task settles into a terminal column (`done`, `ignored`) the banner
+    /// self-clears (issue #369). Without this, a task whose PR is closed outside
+    /// Seraphim after the review loop stops refreshing it would leave `pr_state` stuck
+    /// at `'open'` and the banner permanently raised, with no dismiss affordance.
+    ///
+    /// DB-gated: runs only when `DATABASE_URL` is set (the CI test job's throwaway
+    /// Postgres, or `pg-ephemeral` locally); otherwise it skips.
+    #[tokio::test]
+    async fn a_terminal_task_never_raises_the_empty_pr_banner() {
+        let Some(db) = setup_throwaway_db("seraphim_issue369_test").await else {
+            return;
+        };
+        let pool = db.pool.clone();
+
+        // A task in review with an open, non-draft, empty PR: the exact anomaly the
+        // banner exists to surface.
+        let task = create_internal_task(&pool, "empty-pr anomaly", "", "open", &[], 1.0)
+            .await
+            .expect("create the task");
+        move_task(&pool, task.id, TaskColumn::InReview, task.position)
+            .await
+            .expect("move it into In Review");
+        upsert_task_pr(
+            &pool,
+            task.id,
+            None,
+            "JalapenoLabs/crew",
+            64,
+            "https://github.com/JalapenoLabs/crew/pull/64",
+            "deadbeef",
+            "passing",
+            "open",
+            false,
+            true,
+        )
+        .await
+        .expect("record the empty open PR");
+
+        let anomalies = list_anomalous_empty_prs(&pool)
+            .await
+            .expect("list anomalies");
+        assert_eq!(
+            anomalies.iter().map(|pr| pr.task_id).collect::<Vec<_>>(),
+            vec![task.id],
+            "an active task's empty open PR is an anomaly and raises the banner",
+        );
+
+        // The task settles into Done. The review loop stops refreshing its PR rows, so
+        // `pr_state` stays `'open'`, yet the banner must clear: a settled task's PR is
+        // not an anomaly.
+        move_task(&pool, task.id, TaskColumn::Done, task.position)
+            .await
+            .expect("move it into Done");
+        assert!(
+            list_anomalous_empty_prs(&pool)
+                .await
+                .expect("list anomalies")
+                .is_empty(),
+            "a task in Done never raises the empty-PR banner, even with a stale open PR",
+        );
+
+        // Same for a deliberately parked task: an Ignored task's PR is not an anomaly.
+        move_task(&pool, task.id, TaskColumn::Ignored, task.position)
+            .await
+            .expect("move it into Ignored");
+        assert!(
+            list_anomalous_empty_prs(&pool)
+                .await
+                .expect("list anomalies")
+                .is_empty(),
+            "a task in Ignored never raises the empty-PR banner",
         );
 
         db.teardown().await;


### PR DESCRIPTION
## Summary

Fixes #369. The board's empty-PR anomaly banner could get permanently stuck once its task left the review loop.

The banner is derived live from `task_pull_requests` rows that are open, empty, and non-draft (`list_anomalous_empty_prs`). `pr_state` is refreshed only by `refresh_task_prs`, which runs while the review loop still gates a task. Once a task settles into a terminal column, its PR rows stop refreshing. If the PR is then closed outside Seraphim, `pr_state` stays `'open'` forever and the banner stays raised with no dismiss affordance.

This applies the issue's recommended smallest fix: exclude tasks in a terminal column (`done`, `ignored`) from the query. A settled task's PR is simply not an anomaly, which matches the "derive live, reconcile nothing" design. No new state, no reconciliation, no UI change.

## Changes

- `list_anomalous_empty_prs` now excludes PRs whose task is in `done` or `ignored`.
- DB-gated test: an active task's empty open PR raises the banner; the same PR on a Done or Ignored task does not.
- CLAUDE.md updated to document the terminal-column scoping.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features` clean.
- `cargo test --all-features` against Postgres: 194 passed.
- Control-char check passed.