### PR TITLE
Preinstall the pinned nightly rustfmt in the workspace image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,13 @@ operator notepad lives on the kanban board.
   (`.env`, with a safe `Seraphim` fallback), so the agent can commit in every flat
   clone under `/workspace` without per-repo setup. A repo-local `user.*` still
   overrides it.
+- **Rust toolchains baked (issue #370):** the workspace image preinstalls rustup +
+  stable, the pinned `1.88` build toolchain (with `rustfmt` + `clippy`), and the
+  date-pinned nightly (with `rustfmt`) that a repo's nightly-only fmt gate uses
+  (crew's `Format (nightly)`, `cargo +$NIGHTLY fmt`), so both `cargo +1.88 fmt` and
+  `cargo +<nightly> fmt` run on a fresh workspace with no first-run "component not
+  installed" stall. The nightly is the `RUST_NIGHTLY` Dockerfile build arg; keep it
+  in sync with that repo's `.github/workflows/ci.yml` `NIGHTLY`.
 - **Local DB validation:** PostgreSQL 17 (client + server) is baked into the
   workspace image, and `pg-ephemeral` boots a throwaway PG17 on `127.0.0.1` and
   prints a `DATABASE_URL` (`export DATABASE_URL="$(pg-ephemeral)"`), so the agent

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -80,6 +80,11 @@ RUN actionlint --version \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
+# The date-pinned nightly a repo's nightly-only rustfmt gate uses (crew's
+# `Format (nightly)` job, `cargo +$NIGHTLY fmt`, issue #370). A build-time knob so
+# a bump is one line; keep it in sync with that repo's `.github/workflows/ci.yml`
+# `NIGHTLY`.
+ARG RUST_NIGHTLY=nightly-2026-07-22
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable \
     && rustup component add rustfmt clippy \
@@ -88,6 +93,11 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     # with no first-run download or "component not installed" stall.
     && rustup toolchain install 1.88 --profile minimal \
     && rustup component add --toolchain 1.88 rustfmt clippy \
+    # Pre-install the pinned nightly with rustfmt so the nightly-only fmt gate
+    # (`cargo +$RUST_NIGHTLY fmt --check`) runs with no first-run "cargo-fmt is
+    # not installed" stall (issue #370). rustfmt only: clippy and test run on the
+    # pinned stable, not the nightly.
+    && rustup toolchain install "$RUST_NIGHTLY" --profile minimal --component rustfmt \
     && chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"
 
 # --- Org cloud CLIs (jira, doctl, gcloud) ------------------------------------


### PR DESCRIPTION
## What

The nightly-only formatting gate a repo can run (crew's `Format (nightly)`, `cargo +nightly-2026-07-22 fmt`) failed on a fresh workspace because the pinned nightly toolchain had no `rustfmt` component, so the agent had to run `rustup toolchain install ... --component rustfmt` by hand before the check would run (issue #370).

## How

Extend the workspace image's existing Rust preinstall (`workspace/Dockerfile`), which already bakes `1.88` with rustfmt + clippy so `cargo +1.88 fmt` runs with no first-run stall, to also install the date-pinned nightly with rustfmt:

```dockerfile
ARG RUST_NIGHTLY=nightly-2026-07-22
...
    && rustup toolchain install "$RUST_NIGHTLY" --profile minimal --component rustfmt \
```

- **Mirrors CI:** the same `rustup toolchain install "$NIGHTLY" --profile minimal --component rustfmt` crew's `Format (nightly)` job runs.
- **rustfmt only:** clippy and test run on the pinned stable, not the nightly, so no extra components are baked.
- **Discoverable knob:** the version is a `RUST_NIGHTLY` build arg (matching the file's `ACTIONLINT_VERSION` / Playwright version args), so a bump is one line. A comment tells the reader to keep it in sync with the repo's `ci.yml` `NIGHTLY`.

## Verification

- `rustup toolchain install nightly-2026-07-22 --profile minimal --component rustfmt` yields a working `cargo +nightly-2026-07-22 fmt` (rustfmt 1.9.0-nightly), the exact first-run failure the issue describes, now preinstalled.
- `docker build --check ./workspace` passes with no warnings.
- No api/frontend code changed, so the Seraphim CI (fmt/clippy/test) is unaffected.

## Docs

Added a "Rust toolchains baked" bullet to CLAUDE.md's workspace-runtime section (alongside the PG17 and Playwright bakes), documenting the previously-undocumented Rust toolchain bake plus the new nightly.

## Note on drift

Baking a date-pinned nightly hardcodes a version, the same maintenance the existing `1.88` bake already carries. When the consuming repo bumps its `NIGHTLY`, this arg needs the same bump or a fresh workspace re-hits the stall on the new date. Filed a follow-up to make that sync automatic (or drift-free) so it does not recur.

Closes #370