### PR TITLE
Pin the tailscale image to v1.98.9 instead of :latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,10 @@ services:
 
   tailscale:
     container_name: seraphim-tailscale
-    image: tailscale/tailscale:latest
+    # Pinned, not `:latest`: a floating tag can silently pull a new
+    # tailscale/containerboot that changes behavior between rebuilds. Bump
+    # deliberately, per the version-pinning rule (issue #372).
+    image: tailscale/tailscale:v1.98.9
     restart: unless-stopped
     # A blank TS_AUTHKEY means "skip Tailscale" (see .env.example), but the stock
     # containerboot entrypoint keeps exiting when it cannot authenticate, and


### PR DESCRIPTION
## What

The tailscale service used `image: tailscale/tailscale:latest`, a floating tag. CLAUDE.md's version-pinning rule says pin everything and never rely on `latest` (postgres and litellm are already pinned). A floating tag can silently pull a new `tailscale`/`containerboot` that changes behavior between rebuilds (issue #372).

## How

Pinned `tailscale/tailscale:latest` -> `tailscale/tailscale:v1.98.9`, with a "bump deliberately, per the version-pinning rule" comment mirroring the existing litellm pin.

- **v1.98.9** is the current stable release (tailscale's even-minor stable channel; latest patch of the 1.98 series), published 2026-07-16 and verified pullable via `docker manifest inspect`.
- `docker compose config` validates cleanly (image resolves to `tailscale/tailscale:v1.98.9`).
- No other reference to the floating tag remains anywhere in the repo.

## Verification

- `docker compose --env-file .env.example config -q` exits 0.
- The CI "Docker images" job builds only `api frontend workspace` (tailscale uses a prebuilt image, no `build:`), so this pin does not affect the build; it only parses the compose file, which validates.
- No Rust/TS code changed, so the api/frontend gates are unaffected.

## Notes

- **Visual review:** skipped, this is an infrastructure config change with no UI.
- CLAUDE.md documents the pinning policy but not specific image version numbers, so no doc update is needed; the inline comment documents the pin.

Closes #372