### PR TITLE
Extract a shared floating shell for the bulk action bars (#375)

### DIFF
--- a/frontend/src/lib/components/BulkActionBar.svelte
+++ b/frontend/src/lib/components/BulkActionBar.svelte
@@ -7,7 +7,6 @@
     ArrowLeftRight,
     ArrowDownUp,
     Trash2,
-    X,
     Circle,
     ListTodo,
     CheckCircle2,
@@ -15,10 +14,11 @@
     ChevronUp
   } from '@lucide/svelte'
 
-  import { Badge } from './ui/badge'
   import { Button, buttonVariants } from './ui/button'
   import * as AlertDialog from './ui/alert-dialog'
   import * as DropdownMenu from './ui/dropdown-menu'
+
+  import BulkActionBarShell from './BulkActionBarShell.svelte'
 
   // A floating bottom bar (Jira-style) for the board's multi-select mode. It owns
   // its own modals/menus and reports whether any is open via `dialogOpen`, so the
@@ -148,95 +148,65 @@
   }
 </script>
 
-<!-- Mobile-safe (issue #350): cap the bar at the viewport width (matching
-     RepoBulkActionBar, issue #331). This bar has more actions than that one, so
-     capping alone still overflows; below sm it takes the full capped width and
-     wraps its actions onto multiple rows, then reverts to a single auto-width row
-     from sm up. -->
-<div
-  class="fixed bottom-6 left-1/2 z-50 flex w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl sm:w-auto sm:flex-nowrap"
-  role="toolbar"
-  aria-label="Bulk actions"
->
-  <!-- Far left: count badge + the word "selected" (label drops on narrow screens
-       so the compact bar stays within a 375px viewport). -->
-  <div class="flex items-center gap-2 pl-1 pr-1">
-    <Badge variant="default" class="tabular-nums">{count}</Badge>
-    <span class="hidden text-sm text-muted-foreground sm:inline">selected</span>
-  </div>
+<BulkActionBarShell {count} {onClear} ariaLabel="Bulk actions">
+  {#snippet actions()}
+    <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={openEdit}>
+      <SlidersHorizontal class="size-4" />
+      Edit fields
+    </Button>
 
-  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+    <DropdownMenu.Root bind:open={statusOpen}>
+      <DropdownMenu.Trigger
+        disabled={noneSelected || busy}
+        class={buttonVariants({ variant: 'ghost', size: 'sm' })}
+      >
+        <ArrowLeftRight class="size-4" />
+        Change status
+        <ChevronUp class="size-4 opacity-60" />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content side="top" align="center" class="min-w-44">
+        {#each STATUS_OPTIONS as option (option.column)}
+          {@const Icon = option.icon}
+          <DropdownMenu.Item onclick={() => pickStatus(option.column)}>
+            <Icon class="size-4" />
+            {option.label}
+          </DropdownMenu.Item>
+        {/each}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
 
-  <!-- Middle: the three actions. -->
-  <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={openEdit}>
-    <SlidersHorizontal class="size-4" />
-    Edit fields
-  </Button>
+    <DropdownMenu.Root bind:open={sortOpen}>
+      <DropdownMenu.Trigger
+        disabled={noneSelected || busy}
+        class={buttonVariants({ variant: 'ghost', size: 'sm' })}
+        title="Re-order the selected cards"
+      >
+        <ArrowDownUp class="size-4" />
+        Sort selected
+        <ChevronUp class="size-4 opacity-60" />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content side="top" align="center" class="min-w-52">
+        <DropdownMenu.Label>Re-order the selection by</DropdownMenu.Label>
+        {#each SORT_OPTIONS as option (option.key)}
+          <DropdownMenu.Item onclick={() => pickSort(option.key)}>
+            {option.label}
+          </DropdownMenu.Item>
+        {/each}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
 
-  <DropdownMenu.Root bind:open={statusOpen}>
-    <DropdownMenu.Trigger
+    <Button
+      variant="ghost"
+      size="sm"
+      class="text-destructive hover:bg-destructive/10 hover:text-destructive"
       disabled={noneSelected || busy}
-      class={buttonVariants({ variant: 'ghost', size: 'sm' })}
+      onclick={() => (deleteOpen = true)}
     >
-      <ArrowLeftRight class="size-4" />
-      Change status
-      <ChevronUp class="size-4 opacity-60" />
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content side="top" align="center" class="min-w-44">
-      {#each STATUS_OPTIONS as option (option.column)}
-        {@const Icon = option.icon}
-        <DropdownMenu.Item onclick={() => pickStatus(option.column)}>
-          <Icon class="size-4" />
-          {option.label}
-        </DropdownMenu.Item>
-      {/each}
-    </DropdownMenu.Content>
-  </DropdownMenu.Root>
-
-  <DropdownMenu.Root bind:open={sortOpen}>
-    <DropdownMenu.Trigger
-      disabled={noneSelected || busy}
-      class={buttonVariants({ variant: 'ghost', size: 'sm' })}
-      title="Re-order the selected cards"
-    >
-      <ArrowDownUp class="size-4" />
-      Sort selected
-      <ChevronUp class="size-4 opacity-60" />
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content side="top" align="center" class="min-w-52">
-      <DropdownMenu.Label>Re-order the selection by</DropdownMenu.Label>
-      {#each SORT_OPTIONS as option (option.key)}
-        <DropdownMenu.Item onclick={() => pickSort(option.key)}>
-          {option.label}
-        </DropdownMenu.Item>
-      {/each}
-    </DropdownMenu.Content>
-  </DropdownMenu.Root>
-
-  <Button
-    variant="ghost"
-    size="sm"
-    class="text-destructive hover:bg-destructive/10 hover:text-destructive"
-    disabled={noneSelected || busy}
-    onclick={() => (deleteOpen = true)}
-  >
-    <Trash2 class="size-4" />
-    Delete
-  </Button>
-
-  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
-
-  <!-- Far right: clear selection and exit. -->
-  <Button
-    variant="ghost"
-    size="icon"
-    title="Clear all"
-    aria-label="Clear all and exit multi-select"
-    onclick={onClear}
-  >
-    <X class="size-4" />
-  </Button>
-</div>
+      <Trash2 class="size-4" />
+      Delete
+    </Button>
+  {/snippet}
+</BulkActionBarShell>
 
 <!-- Edit fields modal: one row per editable field, each a "keep as is / true /
      false" dropdown. Native selects render outside the dialog's focus scope, so

--- a/frontend/src/lib/components/BulkActionBarShell.svelte
+++ b/frontend/src/lib/components/BulkActionBarShell.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+
+  import { X } from '@lucide/svelte'
+
+  import { Badge } from './ui/badge'
+  import { Button } from './ui/button'
+
+  // The shared floating-pill chrome for the app's multi-select bulk-action bars
+  // (issue #375): the fixed, mobile-safe container, the count badge and "selected"
+  // label, the dividers, and the exit button. Each bar renders only its own action
+  // buttons into `actions`, so the container, sizing, and mobile behavior live in
+  // exactly one place and cannot drift apart again (the divergence issue #350 had
+  // to fix by hand, when the mobile treatment reached one bar but not the other).
+  let {
+    count,
+    onClear,
+    ariaLabel,
+    actions
+  }: {
+    count: number
+    onClear: () => void
+    // The toolbar's accessible name, e.g. "Bulk actions".
+    ariaLabel: string
+    // The bar's action buttons, rendered between the count and the exit button.
+    actions: Snippet
+  } = $props()
+</script>
+
+<!-- Mobile-safe (issues #331, #350): the pill is capped at the viewport width and,
+     below sm, takes the full capped width and wraps its actions onto multiple rows,
+     reverting to a single auto-width row from sm up. Sharing it here keeps every
+     bar's chrome identical no matter how many actions it holds. -->
+<div
+  class="fixed bottom-6 left-1/2 z-50 flex w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl sm:w-auto sm:flex-nowrap"
+  role="toolbar"
+  aria-label={ariaLabel}
+>
+  <!-- Far left: count badge + the word "selected" (label drops on narrow screens
+       so the compact bar stays within a 375px viewport). -->
+  <div class="flex items-center gap-2 pl-1 pr-1">
+    <Badge variant="default" class="tabular-nums">{count}</Badge>
+    <span class="hidden text-sm text-muted-foreground sm:inline">selected</span>
+  </div>
+
+  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+
+  <!-- Middle: each bar's own actions. -->
+  {@render actions()}
+
+  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
+
+  <!-- Far right: clear selection and exit. -->
+  <Button
+    variant="ghost"
+    size="icon"
+    title="Clear all"
+    aria-label="Clear all and exit multi-select"
+    onclick={onClear}
+  >
+    <X class="size-4" />
+  </Button>
+</div>

--- a/frontend/src/lib/components/RepoBulkActionBar.svelte
+++ b/frontend/src/lib/components/RepoBulkActionBar.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import type { ReposDeletionImpact } from '$lib/types'
 
-  import { SlidersHorizontal, Trash2, X } from '@lucide/svelte'
+  import { SlidersHorizontal, Trash2 } from '@lucide/svelte'
 
-  import { Badge } from './ui/badge'
   import { Button } from './ui/button'
   import * as AlertDialog from './ui/alert-dialog'
+
+  import BulkActionBarShell from './BulkActionBarShell.svelte'
 
   // A floating bottom bar (Jira-style) for the repositories page's multi-select
   // mode, modeled on the board's BulkActionBar (issue #331). It owns its own
@@ -113,50 +114,25 @@
   }
 </script>
 
-<div
-  class="fixed bottom-6 left-1/2 z-50 flex max-w-[calc(100vw-1rem)] -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl"
-  role="toolbar"
-  aria-label="Bulk repository actions"
->
-  <!-- Far left: count badge + the word "selected" (label drops on narrow screens
-       so the compact bar stays within a 375px viewport). -->
-  <div class="flex items-center gap-2 pl-1 pr-1">
-    <Badge variant="default" class="tabular-nums">{count}</Badge>
-    <span class="hidden text-sm text-muted-foreground sm:inline">selected</span>
-  </div>
+<BulkActionBarShell {count} {onClear} ariaLabel="Bulk repository actions">
+  {#snippet actions()}
+    <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={openEdit}>
+      <SlidersHorizontal class="size-4" />
+      Edit fields
+    </Button>
 
-  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
-
-  <!-- Middle: the actions. -->
-  <Button variant="ghost" size="sm" disabled={noneSelected || busy} onclick={openEdit}>
-    <SlidersHorizontal class="size-4" />
-    Edit fields
-  </Button>
-
-  <Button
-    variant="ghost"
-    size="sm"
-    class="text-destructive hover:bg-destructive/10 hover:text-destructive"
-    disabled={noneSelected || busy}
-    onclick={openDelete}
-  >
-    <Trash2 class="size-4" />
-    Delete
-  </Button>
-
-  <div class="mx-1 h-6 w-px bg-border" aria-hidden="true"></div>
-
-  <!-- Far right: clear selection and exit. -->
-  <Button
-    variant="ghost"
-    size="icon"
-    title="Clear all"
-    aria-label="Clear all and exit multi-select"
-    onclick={onClear}
-  >
-    <X class="size-4" />
-  </Button>
-</div>
+    <Button
+      variant="ghost"
+      size="sm"
+      class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+      disabled={noneSelected || busy}
+      onclick={openDelete}
+    >
+      <Trash2 class="size-4" />
+      Delete
+    </Button>
+  {/snippet}
+</BulkActionBarShell>
 
 <!-- Edit fields modal: one row per editable field, each a "keep as is / on / off"
      dropdown. Native selects render outside the dialog's focus scope, so they


### PR DESCRIPTION
## What

Extracts the duplicated floating-pill chrome shared by `BulkActionBar` and `RepoBulkActionBar` into a single `BulkActionBarShell`, so their container, sizing, and mobile behavior live in one place and cannot diverge again.

Closes #375.

## Why

Both bars hand-rolled the same chrome: the fixed `bottom-6 left-1/2 -translate-x-1/2` pill, the `max-w-[calc(100vw-1rem)]` cap, the count badge + hidden-under-sm "selected" label, the dividers, and the exit X. That copy-paste is exactly what let the mobile overflow fix reach the repos bar (#331) but not the board bar (#350).

## Changes

- **New** `frontend/src/lib/components/BulkActionBarShell.svelte`: owns the chrome once. Props: `count`, `onClear`, `ariaLabel` (the toolbar's accessible name), and an `actions` snippet for each bar's own buttons.
- `BulkActionBar.svelte` and `RepoBulkActionBar.svelte`: render their action buttons through the shell; the container, count, dividers, and exit button are gone from both. Each bar keeps its own modals/menus and handlers unchanged. Net -54 lines.
- The repositories bar picks up the same viewport-cap-and-wrap treatment the board bar already had, so it stays within a 375px screen no matter how many actions it grows. This is the intended unification; its desktop rendering is unchanged.

## Scope

Kept to the two bars the issue names. `SuggestionBulkBar` shares the same chrome but uses slightly different clear-button wording ("Clear selection" vs "Clear all"), so migrating it needs a wording decision; filed as a follow-up rather than folded in here.

## Verification

- `yarn check` (svelte-check): 0 errors, 0 warnings. `yarn build`: clean.
- Visual self-review with the Playwright MCP against the live board and repositories pages (seeded via `scripts/dev-api.sh`), in bulk-select mode, at 1280px and 375px:
  - **Board bar**: 1280px centered (0px offset), single row, no overflow; 375px wraps to full width (359px, symmetric 8px gaps), no overflow, "selected" label hidden. Matches its prior behavior exactly.
  - **Repositories bar**: 1280px centered, no overflow; 375px full-width single row (fits), centered, no overflow. Now consistent with the board bar.
  - Both keep their count badge, correct actions, and the clear/exit button.