### PR TITLE
Extract a shared BoardBanner for the six board alert banners (#376)

### DIFF
--- a/frontend/src/lib/components/BoardBanner.svelte
+++ b/frontend/src/lib/components/BoardBanner.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { LucideIcon } from '@lucide/svelte'
+  import type { AlertVariant } from './ui/alert'
+
+  import { X } from '@lucide/svelte'
+
+  import { cn } from '$lib/utils.js'
+  import * as Alert from './ui/alert'
+  import { Button } from './ui/button'
+
+  // The shared chrome for the board's alert banners (issue #376): the inset,
+  // full-width container, the title row (optional leading icon and trailing badge),
+  // and the standard dismiss button. Each banner supplies only its own icon, title,
+  // and description body, so the layout and inset live in one place. A container fix
+  // (e.g. the mx-6 overflow, issue #349) then reaches every banner at once instead
+  // of drifting to some and not others.
+  let {
+    variant = 'default',
+    icon,
+    title,
+    align = 'start',
+    dismiss,
+    dismissLabel,
+    titleBadge,
+    action,
+    children,
+    class: className
+  }: {
+    variant?: AlertVariant
+    // Optional leading icon for the title row.
+    icon?: LucideIcon
+    title: string
+    // How the body and the trailing button align across the pill's height. Banners
+    // with multi-line bodies use `start`; a short single-line banner uses `center`.
+    align?: 'start' | 'center'
+    // A dismiss handler renders the standard outline X button; pair it with the
+    // accessible label naming what is dismissed. Leave unset for a banner that acts
+    // through `action` instead.
+    dismiss?: () => void
+    dismissLabel?: string
+    // Optional trailing content in the title row, e.g. the heart-attack railway tag.
+    titleBadge?: Snippet
+    // A custom trailing control (e.g. Retry, Resume now) for banners that act rather
+    // than dismiss. Ignored when `dismiss` is set.
+    action?: Snippet
+    // The banner's description body (an `Alert.Description`, whose own classes vary
+    // per banner, so it stays with the caller).
+    children: Snippet
+    class?: string
+  } = $props()
+</script>
+
+<Alert.Root
+  {variant}
+  class={cn(
+    'mx-6 mt-4 flex w-auto justify-between gap-4',
+    align === 'center' ? 'items-center' : 'items-start',
+    className
+  )}
+>
+  <div class="min-w-0">
+    {#if icon || titleBadge}
+      {@const TitleIcon = icon}
+      <Alert.Title class="flex items-center gap-1.5">
+        {#if TitleIcon}
+          <TitleIcon class="size-4 flex-none" />
+        {/if}
+        {title}
+        {#if titleBadge}
+          {@render titleBadge()}
+        {/if}
+      </Alert.Title>
+    {:else}
+      <Alert.Title>{title}</Alert.Title>
+    {/if}
+    {@render children()}
+  </div>
+
+  {#if dismiss}
+    <Button
+      variant="outline"
+      size="icon"
+      class="flex-none"
+      title="Dismiss"
+      aria-label={dismissLabel}
+      onclick={dismiss}
+    >
+      <X class="size-4" />
+    </Button>
+  {:else if action}
+    {@render action()}
+  {/if}
+</Alert.Root>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -50,6 +50,7 @@
   import { isWithinSchedule } from '$lib/schedule'
   import { subscribeBoardStream } from '$lib/boardStream'
   import { type SortKey, sortTasks, loadSort, saveSort } from '$lib/columnSort'
+  import BoardBanner from '$lib/components/BoardBanner.svelte'
   import BulkActionBar from '$lib/components/BulkActionBar.svelte'
   import Card from '$lib/components/Card.svelte'
   import ColumnSort from '$lib/components/ColumnSort.svelte'
@@ -928,81 +929,66 @@
          visible (monospaced) so the operator can patch the underlying cause, with
          a dismiss once they have read it. The banner stays global but is tagged
          with the railway it belongs to. -->
-    <Alert.Root variant="destructive" class="mx-6 w-auto mt-4 flex items-start justify-between gap-4">
-      <div class="min-w-0">
-        <Alert.Title class="flex items-center gap-1.5">
-          <HeartPulse class="size-4 flex-none" />
-          Agent heart attack: "{incident.task_title}"
-          {#if lane}
-            <span class="rounded border border-current/40 px-1.5 py-0 text-[10px] font-normal opacity-80">
-              {lane}
-            </span>
-          {/if}
-        </Alert.Title>
-        <Alert.Description class="break-words">
-          <span class="font-mono text-xs break-words">{incident.detail}</span>
-          {#if incident.recovery}
-            <span class="mt-1 block text-xs opacity-80">{incident.recovery}</span>
-          {/if}
-          {#if incident.task_id}
-            <a href={`/task/${incident.task_id}`} class="mt-1 inline-block text-xs underline">
-              Open the task to see the full activity log
-            </a>
-          {/if}
-        </Alert.Description>
-      </div>
-      <Button
-        variant="outline"
-        size="icon"
-        class="flex-none"
-        title="Dismiss"
-        aria-label="Dismiss heart attack"
-        onclick={() => dismissHeartAttack(incident.id)}
-      >
-        <X class="size-4" />
-      </Button>
-    </Alert.Root>
+    <BoardBanner
+      variant="destructive"
+      icon={HeartPulse}
+      title={`Agent heart attack: "${incident.task_title}"`}
+      dismiss={() => dismissHeartAttack(incident.id)}
+      dismissLabel="Dismiss heart attack"
+    >
+      {#snippet titleBadge()}
+        {#if lane}
+          <span class="rounded border border-current/40 px-1.5 py-0 text-[10px] font-normal opacity-80">
+            {lane}
+          </span>
+        {/if}
+      {/snippet}
+      <Alert.Description class="break-words">
+        <span class="font-mono text-xs break-words">{incident.detail}</span>
+        {#if incident.recovery}
+          <span class="mt-1 block text-xs opacity-80">{incident.recovery}</span>
+        {/if}
+        {#if incident.task_id}
+          <a href={`/task/${incident.task_id}`} class="mt-1 inline-block text-xs underline">
+            Open the task to see the full activity log
+          </a>
+        {/if}
+      </Alert.Description>
+    </BoardBanner>
   {/each}
 
   {#if settings?.config_repo_error}
-    <Alert.Root variant="destructive" class="mx-6 w-auto mt-4 flex items-center justify-between gap-4">
-      <div>
-        <Alert.Title>Config repo (~/.claude) failed to set up — the agent is halted.</Alert.Title>
-        <Alert.Description class="font-mono text-xs break-words">
-          {settings.config_repo_error}
-        </Alert.Description>
-      </div>
-      <Button variant="outline" size="sm" disabled={retrying} onclick={retryProvision}>
-        {retrying ? 'Retrying…' : 'Retry'}
-      </Button>
-    </Alert.Root>
+    <BoardBanner
+      variant="destructive"
+      align="center"
+      title="Config repo (~/.claude) failed to set up — the agent is halted."
+    >
+      <Alert.Description class="font-mono text-xs break-words">
+        {settings.config_repo_error}
+      </Alert.Description>
+      {#snippet action()}
+        <Button variant="outline" size="sm" disabled={retrying} onclick={retryProvision}>
+          {retrying ? 'Retrying…' : 'Retry'}
+        </Button>
+      {/snippet}
+    </BoardBanner>
   {/if}
 
   {#each visibleSyncErrors as repo (repo.full_name)}
     <!-- A repo's issue sync is failing (issue #213). Persist the reason until it
          recovers (it clears itself on the next successful sync), with a dismiss for
          operators who have read it. -->
-    <Alert.Root variant="destructive" class="mx-6 w-auto mt-4 flex items-start justify-between gap-4">
-      <div class="min-w-0">
-        <Alert.Title class="flex items-center gap-1.5">
-          <RefreshCw class="size-4 flex-none" />
-          Issue sync failed: {repo.full_name}
-        </Alert.Title>
-        <Alert.Description class="break-words">
-          {repo.sync_error}
-        </Alert.Description>
-      </div>
-      <Button
-        variant="outline"
-        size="icon"
-        class="flex-none"
-        title="Dismiss"
-        aria-label="Dismiss sync error"
-        onclick={() => dismissedSyncRepos.add(repo.full_name)}
-      >
-        <X class="size-4" />
-      </Button>
-    </Alert.Root>
+    <BoardBanner
+      variant="destructive"
+      icon={RefreshCw}
+      title={`Issue sync failed: ${repo.full_name}`}
+      dismiss={() => dismissedSyncRepos.add(repo.full_name)}
+      dismissLabel="Dismiss sync error"
+    >
+      <Alert.Description class="break-words">
+        {repo.sync_error}
+      </Alert.Description>
+    </BoardBanner>
   {/each}
 
   {#each visibleEmptyPrs as pr (pr.pr_url)}
@@ -1010,110 +996,89 @@
          squash a zero-change PR and the agent did not deliberately park it as a
          draft, so it is held in review and surfaced here. Self-clears when the PR
          gains changes, is closed, or is marked draft; dismissible once read. -->
-    <Alert.Root variant="destructive" class="mx-6 w-auto mt-4 flex items-start justify-between gap-4">
-      <div class="min-w-0">
-        <Alert.Title class="flex items-center gap-1.5">
-          <GitPullRequestArrow class="size-4 flex-none" />
-          Empty pull request: {pr.repo_full_name}#{pr.pr_number}
-        </Alert.Title>
-        <Alert.Description class="break-words">
-          <span>
-            "{pr.task_title}" opened a pull request with no changes that is not a draft, so it
-            cannot be merged. It is held in review; close it or push the intended changes.
-          </span>
-          <a href={pr.pr_url} target="_blank" rel="noreferrer" class="mt-1 inline-block text-xs underline">
-            Open the pull request
-          </a>
-          <a href={`/task/${pr.task_id}`} class="mt-1 ml-3 inline-block text-xs underline">
-            Open the task
-          </a>
-        </Alert.Description>
-      </div>
-      <Button
-        variant="outline"
-        size="icon"
-        class="flex-none"
-        title="Dismiss"
-        aria-label="Dismiss empty pull request anomaly"
-        onclick={() => dismissedEmptyPrs.add(pr.pr_url)}
-      >
-        <X class="size-4" />
-      </Button>
-    </Alert.Root>
+    <BoardBanner
+      variant="destructive"
+      icon={GitPullRequestArrow}
+      title={`Empty pull request: ${pr.repo_full_name}#${pr.pr_number}`}
+      dismiss={() => dismissedEmptyPrs.add(pr.pr_url)}
+      dismissLabel="Dismiss empty pull request anomaly"
+    >
+      <Alert.Description class="break-words">
+        <span>
+          "{pr.task_title}" opened a pull request with no changes that is not a draft, so it
+          cannot be merged. It is held in review; close it or push the intended changes.
+        </span>
+        <a href={pr.pr_url} target="_blank" rel="noreferrer" class="mt-1 inline-block text-xs underline">
+          Open the pull request
+        </a>
+        <a href={`/task/${pr.task_id}`} class="mt-1 ml-3 inline-block text-xs underline">
+          Open the task
+        </a>
+      </Alert.Description>
+    </BoardBanner>
   {/each}
 
   {#each setupScriptChanges as change (change.id)}
+    {@const scriptTarget =
+      change.target === 'base' ? 'environment setup' : (change.repo_full_name ?? 'a repository')}
     <!-- The agent edited one of its own setup scripts (issue #340). Not an error,
          so this is an informational banner (primary accent, not destructive): it
          names what changed and why, shows the new script, and links to the task,
          with a dismiss that acknowledges it server-side so it clears for good. -->
-    <Alert.Root class="mx-6 w-auto mt-4 flex items-start justify-between gap-4 border-primary/40">
-      <div class="min-w-0">
-        <Alert.Title class="flex items-center gap-1.5">
-          <Wrench class="size-4 flex-none" />
-          Agent updated the setup script: {change.target === 'base'
-            ? 'environment setup'
-            : (change.repo_full_name ?? 'a repository')}
-        </Alert.Title>
-        <Alert.Description class="break-words">
-          {#if change.summary}
-            <span class="block">{change.summary}</span>
-          {/if}
-          {#if change.always_run !== null}
-            <span class="mt-1 block text-xs opacity-80">
-              {change.always_run
-                ? 'Now re-runs before every task on the existing clone.'
-                : 'Now runs only on first clone / full provision.'}
-            </span>
-          {/if}
-          <pre
-            class="mt-1 max-h-40 overflow-auto rounded-md border border-border bg-muted/40 p-2 font-mono text-xs whitespace-pre-wrap">{change.new_script ||
-              '(empty script)'}</pre>
-          {#if change.target === 'base'}
-            <span class="mt-1 block text-xs opacity-80">
-              Takes effect on the next workspace provision/recreate.
-            </span>
-          {/if}
-          {#if change.task_id}
-            <a href={`/task/${change.task_id}`} class="mt-1 inline-block text-xs underline">
-              Open the task that made this change
-            </a>
-          {/if}
-        </Alert.Description>
-      </div>
-      <Button
-        variant="outline"
-        size="icon"
-        class="flex-none"
-        title="Dismiss"
-        aria-label="Dismiss setup-script change"
-        onclick={() => dismissSetupChange(change.id)}
-      >
-        <X class="size-4" />
-      </Button>
-    </Alert.Root>
+    <BoardBanner
+      icon={Wrench}
+      title={`Agent updated the setup script: ${scriptTarget}`}
+      class="border-primary/40"
+      dismiss={() => dismissSetupChange(change.id)}
+      dismissLabel="Dismiss setup-script change"
+    >
+      <Alert.Description class="break-words">
+        {#if change.summary}
+          <span class="block">{change.summary}</span>
+        {/if}
+        {#if change.always_run !== null}
+          <span class="mt-1 block text-xs opacity-80">
+            {change.always_run
+              ? 'Now re-runs before every task on the existing clone.'
+              : 'Now runs only on first clone / full provision.'}
+          </span>
+        {/if}
+        <pre
+          class="mt-1 max-h-40 overflow-auto rounded-md border border-border bg-muted/40 p-2 font-mono text-xs whitespace-pre-wrap">{change.new_script ||
+            '(empty script)'}</pre>
+        {#if change.target === 'base'}
+          <span class="mt-1 block text-xs opacity-80">
+            Takes effect on the next workspace provision/recreate.
+          </span>
+        {/if}
+        {#if change.task_id}
+          <a href={`/task/${change.task_id}`} class="mt-1 inline-block text-xs underline">
+            Open the task that made this change
+          </a>
+        {/if}
+      </Alert.Description>
+    </BoardBanner>
   {/each}
 
   {#if settings?.usage_paused_until && new Date(settings.usage_paused_until).getTime() > Date.now()}
-    <Alert.Root class="mx-6 w-auto mt-4 flex items-start justify-between gap-4 border-warning/40">
-      <div class="min-w-0">
-        <Alert.Title>Paused: subscription usage limit reached.</Alert.Title>
-        <Alert.Description>
-          New work is on hold until the usage window resets at
-          {new Date(settings.usage_paused_until).toLocaleString()}, when it resumes automatically.
-          To resume sooner, raise the usage threshold in Settings or resume now.
-        </Alert.Description>
-      </div>
-      <Button
-        variant="outline"
-        size="sm"
-        class="flex-none"
-        disabled={resumingUsage}
-        onclick={resumeUsageNow}
-      >
-        {resumingUsage ? 'Resuming…' : 'Resume now'}
-      </Button>
-    </Alert.Root>
+    <BoardBanner title="Paused: subscription usage limit reached." class="border-warning/40">
+      <Alert.Description>
+        New work is on hold until the usage window resets at
+        {new Date(settings.usage_paused_until).toLocaleString()}, when it resumes automatically.
+        To resume sooner, raise the usage threshold in Settings or resume now.
+      </Alert.Description>
+      {#snippet action()}
+        <Button
+          variant="outline"
+          size="sm"
+          class="flex-none"
+          disabled={resumingUsage}
+          onclick={resumeUsageNow}
+        >
+          {resumingUsage ? 'Resuming…' : 'Resume now'}
+        </Button>
+      {/snippet}
+    </BoardBanner>
   {/if}
 
   <div class="flex items-center justify-between px-6 pb-1 pt-4">


### PR DESCRIPTION
## What

Extracts the duplicated `Alert.Root` chrome shared by the six board banners into a single `BoardBanner`, so the layout and inset live in one place and per-banner drift becomes impossible.

Closes #376.

## Why

The heart-attack, config-repo, sync-error, empty-PR, setup-script, and usage-paused banners each repeated the same structure: `Alert.Root` with `mx-6 w-auto mt-4 flex items-... justify-between gap-4`, a `min-w-0` body, an icon+title row, and a trailing button. That copy-paste is exactly why the `w-full`/`mx-6` overflow (issue #349) affected all of them identically.

## Changes

- **New** `frontend/src/lib/components/BoardBanner.svelte`: owns the container, inset, title row (optional leading `icon` + optional `titleBadge`), and the standard dismiss button. Props: `variant`, `icon`, `title`, `align` (`start` default, `center` for the short config-repo banner), `dismiss` + `dismissLabel`, `titleBadge` (the heart-attack railway tag), `action` (a custom trailing control for the banners that act rather than dismiss, i.e. Retry / Resume now), and the description `children`.
- `frontend/src/routes/+page.svelte`: all six banners now render through `BoardBanner`; each keeps only its own `Alert.Description` body (their classes genuinely differ) and its handlers. The `Alert.Root` / `min-w-0` / dismiss-button boilerplate is gone from every banner.

## Scope

Pure refactor: no banner's rendered output changes. The description body stays with each caller because those classes vary (mono, links, a `<pre>` block, plain); centralizing the uniform chrome while slotting the varied body is the clean split.

## Verification

- `yarn check` (svelte-check): 0 errors, 0 warnings. `yarn build`: clean.
- Visual self-review with the Playwright MCP against the **real** board, driving five of the six banner states by injecting them into the ephemeral Postgres (`scripts/dev-api.sh` + SQL: a heart-attack row, `config_repo_error`, `usage_paused_until`, a repo `sync_error`, a `setup_script_change`; the empty-PR banner is structurally identical to sync-error). At 1280px and 375px:
  - All banners render with the `mx-6` inset preserved exactly (24px both sides), `w-auto`, and no horizontal overflow.
  - Alignment is correct per banner (config-repo `center`, the rest `start`), and each shows the right trailing control: dismiss X (heart-attack, sync, setup) or action button (Retry, Resume now).
  - The setup-script `<pre>` scrolls rather than widening the pill on mobile.