### PR TITLE
Add api/build.rs so new migrations rebuild the embedded set (#377)

### DIFF
--- a/api/build.rs
+++ b/api/build.rs
@@ -1,0 +1,18 @@
+//! Build script: rebuild whenever the SQL migrations change (issue #377).
+//!
+//! `sqlx::migrate!("./migrations")` embeds the migration set at compile time,
+//! but adding a `.sql` file touches no `.rs` source, so cargo may skip
+//! recompiling the crate. `cargo run --bin migrate` (and the API's own
+//! boot-time migrate) would then silently apply a STALE list, stopping short of
+//! the newly added migration until some `.rs` file is force-touched.
+//!
+//! Emitting `rerun-if-changed=migrations` ties the crate's freshness to that
+//! directory, so a new or edited migration always rebuilds the embedded set.
+//! Local runs and the CI "Migrate (throwaway Postgres)" step then never test a
+//! stale migration list.
+
+fn main() {
+    // A directory path: cargo scans it recursively, so both a new file and an
+    // edit to an existing migration invalidate the build and re-embed the set.
+    println!("cargo:rerun-if-changed=migrations");
+}


### PR DESCRIPTION
## What

Adds a one-line `api/build.rs` that emits `cargo:rerun-if-changed=migrations`, so cargo rebuilds the crate whenever a SQL migration is added or edited.

Closes #377.

## Why

`sqlx::migrate!("./migrations")` embeds the migration set at compile time, but `api/` had no build script. Adding a `.sql` file touches no `.rs` source, so cargo could skip recompiling `seraphim-api`: `cargo run --bin migrate` (and the API's own boot-time migrate) would then silently apply a STALE list, stopping short of the newest migration until some `.rs` file was force-touched. That is a silent "migration not actually applied" footgun for every future migration, and it means the CI "Migrate (throwaway Postgres)" step could test a stale set.

Tying the crate's freshness to the `migrations` directory is the canonical sqlx fix.

## Verification

- `cargo +1.88 fmt --check`: clean. `cargo +1.88 clippy --all-targets`: no new warnings (the file is clippy-clean; pre-existing warnings elsewhere are untouched).
- `cargo +1.88 test` against an ephemeral Postgres: 195 passed, 0 failed (the embedded migration set applies cleanly).
- Confirmed the mechanism directly: with the crate fully built, `cargo build --bin migrate` reports up to date; touching an existing migration OR adding a new `.sql` file then recompiles `seraphim-api`, re-embedding the current set.

No Cargo.toml change is needed: cargo auto-detects `build.rs` at the package root.

Backend-only change, no UI, so visual review does not apply.