### PR TITLE
Seed the docs/ directory the CLAUDE.md policy requires (#378)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,14 @@ workspace/  Dockerfile + entrypoint.sh (the agent sandbox image)
 tailscale/  serve.json
 litellm/    config.yaml + README (opt-in LiteLLM proxy sidecar, issue #342)
 scripts/    start.sh stop.sh restart.sh
+docs/       Per-category decision records (see docs/README.md)
 ```
+
+This file is the project memory to read first and stays the authoritative
+summary. `docs/` expands each decision category (architecture, the data model,
+the orchestrator loops, the workspace, the frontend, settings, secrets, the LLM
+credentials, self-update, Jira, automation, CI, railways) for anyone browsing the
+repo; keep the two in sync when a decision changes.
 
 ### Backend (`api/`)
 - `src/main.rs` — boot: config, DB connect+migrate, workspace handle, GitHub client, spawn loops, serve.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# Seraphim docs
+
+Per-category decision records for Seraphim. Each file captures the decisions for
+one area of the app: what it does today, where it lives in the code, and the
+roadmap where there is one.
+
+## The policy
+
+`CLAUDE.md` at the repo root is the project memory agents read first, and it
+stays the authoritative summary of every decision. These docs expand each
+category for anyone browsing the repo and point at the code that implements it.
+When a decision changes, update `CLAUDE.md` and the matching doc here in the same
+change.
+
+Two rules carry over from `CLAUDE.md`:
+
+- **Current state and future plans only, no history.** Write "today the system
+  does X" and "the roadmap is Y". Do not write "we used to do X" or "we migrated
+  from Y". A reversed decision is rewritten in place, not annotated.
+- **No em dashes** in this prose. Use a comma, a colon, or two sentences.
+
+Each doc keeps a uniform shape: a short intro, "Decisions today", an optional
+"Roadmap", and "Where it lives" pointers into the code.
+
+## Index
+
+| Doc | Covers |
+|---|---|
+| [architecture.md](./architecture.md) | The Compose services, control flow, ports, and repo layout. |
+| [data-model.md](./data-model.md) | The Postgres tables and what each holds. |
+| [orchestrator.md](./orchestrator.md) | The sync, agent, review, and defibrillator loops. |
+| [workspace.md](./workspace.md) | The agent sandbox: provisioning, setup scripts, baked tooling, the MCPs. |
+| [frontend.md](./frontend.md) | The SvelteKit SPA, dev server, routes, and visual self-review. |
+| [settings.md](./settings.md) | The Settings information architecture and the `settings` row. |
+| [secrets.md](./secrets.md) | How tokens, environment variables, and blobs are stored and masked. |
+| [llm.md](./llm.md) | Claude credential rotation, usage-limit pause, and the LiteLLM sidecar. |
+| [self-update.md](./self-update.md) | The in-app updater and the host update scripts. |
+| [jira.md](./jira.md) | The Jira issue source. |
+| [automation.md](./automation.md) | Board automation rules. |
+| [ci.md](./ci.md) | Local checks, the CI jobs, source hygiene, and version pinning. |
+| [railways.md](./railways.md) | The planned parallel-agent lanes (roadmap). |
+
+## Adding a category
+
+When a decision does not fit an existing file, add a new `docs/<category>.md`
+that follows the shape above, then link it in the index. Keep each file to the
+decisions for its category; the dense cross-cutting detail stays in `CLAUDE.md`
+and the code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,59 @@
+# Architecture
+
+> Decision record for the overall system shape. Current state and roadmap only,
+> no history. `CLAUDE.md` holds the authoritative summary.
+
+Seraphim is a self-hosted autonomous developer agent. It runs on one machine,
+watches an issue board (GitHub and Jira), and works tickets like a developer:
+picks up the next issue, writes code in a persistent Docker workspace, opens a
+pull request, and follows per-repo review rules. A human curates and orders the
+work on a kanban board. The core idea is a long-lived, single-threaded Claude
+Code session that carries context from issue to issue.
+
+## Decisions today
+
+- **Backend:** Rust (Axum, tokio, sqlx, bollard, octocrab, eyre, mimalloc). The
+  `api` service is the only orchestrator: issue sync, the agent loop, REST plus
+  SSE, and Docker control.
+- **Frontend:** SvelteKit (Svelte 5 runes) in SPA mode, with a
+  `svelte-dnd-action` kanban board.
+- **Database:** Postgres 17, holding the board, the issue cache, the conversation
+  log, and all configuration.
+- **Orchestration:** Docker Compose is the primary deployment method. Five
+  services run by default: `postgres`, `api`, `frontend`, `workspace`, and
+  `tailscale`. A sixth, `litellm`, is opt-in under the `llm` profile (see
+  [llm.md](./llm.md)).
+- **Exposure:** a Tailscale sidecar (`tailscale serve`) publishes the UI over the
+  tailnet with HTTPS. A blank `TS_AUTHKEY` idles the sidecar instead of
+  crash-looping it, and the Settings Tailscale panel then reads "disabled".
+- **Hosts:** Windows 11 and Linux only; every service is a Linux container. There
+  is no macOS support.
+- **Ports:** the API is `27182` and the UI is `31415`, host and internal. These
+  are deliberately non-standard. There should be no `8080` or `3000` anywhere.
+
+## Control flow
+
+The `api` is the brain and the `workspace` is a powerful but dumb sandbox. The
+API reaches into the workspace with `docker exec` (bollard) over the mounted host
+Docker socket. Issue sync and PR merge run deterministically from Rust
+(octocrab); the agent itself runs `git` and `gh` inside the workspace.
+
+A poll or a webhook upserts GitHub and Jira issues into Postgres, the board
+streams to the UI over SSE, the operator drags an issue into To Do, the
+orchestrator pulls the top card and runs a Claude turn in the workspace, the API
+detects the resulting PR, and the review policy moves the card to In Review or
+Done.
+
+## Where it lives
+
+- `docker-compose.yml`: the service definitions.
+- `api/src/main.rs`: boots the app (config, DB connect and migrate, workspace
+  handle, GitHub client, spawn the loops, serve).
+- `api/src/state.rs`: `AppState` (clone-cheap) plus the SSE broadcast bus.
+- `api/src/http/`: one file per resource plus `sse.rs`, routed under `/api/v1`.
+- `frontend/`: the SvelteKit UI (see [frontend.md](./frontend.md)).
+- `workspace/`: the agent sandbox image (see [workspace.md](./workspace.md)).
+- `tailscale/serve.json`: the tailnet serve config.
+
+See [self-update.md](./self-update.md) for launch and update, and
+[data-model.md](./data-model.md) for the schema.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,34 @@
+# Board automation
+
+> Decision record for automation rules. Current state and roadmap only, no
+> history. `CLAUDE.md` holds the operator and matcher detail.
+
+Automation rules react to incoming issue events and reorder the board without a
+human. Rules are managed on the Automation page (under Settings).
+
+## Decisions today
+
+- **Shape.** A rule has a source, a trigger (`created`, `updated`, or `comment`),
+  a condition group (AND or OR of `{field, operator, values}` over labels,
+  author, repo, title, body, comment, and state), and an action (move the card to
+  the top or bottom of To Do). The rule shape and the matcher are pure and
+  I/O-free, so they are unit-tested without a database.
+- **Firing paths.** The webhook is the realtime path for every trigger. The poll
+  sync is the reliable fallback for `created` rules: when an issue is first
+  inserted, `created` automation fires exactly once on that first-insert
+  transition, never re-firing as the issue is re-listed each poll. `updated` and
+  `comment` triggers remain webhook-only, since poll-firing them needs change
+  detection.
+- **Source-agnostic, GitHub-wired.** Rules can target any source, but only GitHub
+  events are wired so far.
+- **No silent inertness.** When an enabled rule exists but no GitHub webhook
+  secret is set, the Automation page shows a dismissible notice so a rule never
+  sits silently inert.
+
+## Where it lives
+
+- `api/src/automation/`: the rule shape and the pure matcher (unit-tested).
+- `api/src/orchestrator/`: `run_github_automation`, called from the webhook
+  handler and the poll sync.
+- `api/src/http/webhooks.rs`: the inbound webhook endpoints.
+- See [data-model.md](./data-model.md) for `automation_rules`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,43 @@
+# CI and local checks
+
+> Decision record for the check gates and conventions. Current state and roadmap
+> only, no history. `CLAUDE.md` holds the gotcha-level detail.
+
+## Checks that must pass
+
+```bash
+cd api      && cargo +1.88 fmt && cargo +1.88 clippy --all-targets && cargo +1.88 test
+cd frontend && npm run check && npm run build
+```
+
+CI (`.github/workflows/ci.yml`) runs these as independent jobs, with no
+fail-fast, on every PR and on `main` and `develop`. A separate Source hygiene job
+runs `scripts/check-control-chars.py`, which fails the PR if any tracked text file
+(binary assets and the vendored `.yarn/` bundle excluded) contains a NUL byte or a
+control character other than tab, newline, or carriage return. A "Migrate
+(throwaway Postgres)" job applies the embedded migration set against a disposable
+Postgres, so a broken or duplicate migration fails the PR rather than only a real
+deploy.
+
+## Conventions today
+
+- **Version pinning everywhere.** Never rely on a floating `latest`. The Rust
+  toolchain is pinned to 1.88 (`api/rust-toolchain.toml`); always use `cargo
+  +1.88`. Node, Postgres, and the workspace image's baked tools are pinned to
+  exact versions so local, CI, and production do not drift.
+- **`api/build.rs`** emits `cargo:rerun-if-changed=migrations`, so adding a
+  migration rebuilds the embedded set instead of silently testing a stale list.
+- **sqlx uses runtime queries** (`query_as::<_, T>`), not the compile-time macros,
+  so the crate builds without a live database. Keep it that way.
+- **Search with `rg`, not `grep`.** The agent shell's `grep` is backed by ripgrep
+  with `-I` and `--ignore-files`, so it silently skips files it deems binary or
+  that are gitignored. Prefer `rg` for code search.
+- **No em dashes** in any user-facing text, including commits and PR bodies.
+- **No co-author trailer** on commits, and no self-assigned PR credit.
+
+## Where it lives
+
+- `.github/workflows/ci.yml`: the CI jobs.
+- `scripts/check-control-chars.py`: the source-hygiene gate.
+- `api/rust-toolchain.toml`: the pinned Rust toolchain.
+- `api/build.rs`: the migration rebuild trigger.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,55 @@
+# Data model
+
+> Decision record for the Postgres schema. Current state and roadmap only, no
+> history. `CLAUDE.md` holds the full field-level detail; this is the map.
+
+Migrations live in `api/migrations/` and are embedded at compile time
+(`sqlx::migrate!`), then run on API boot. Queries are runtime sqlx
+(`query_as::<_, T>`), so the crate builds without a live database. `board_column`
+(the kanban lane: available, todo, in_progress, in_review, done, ignored) and
+`status` (the operational sub-state) are intentionally separate columns.
+
+## Tables today
+
+- **`settings`**: one row (`id = 1`) with the org profile, global instructions,
+  default review policy, the pause switch, the Claude model, the base setup
+  script, the config repo URL, the shared Claude session id, the usage-pause
+  columns, the availability schedule, and the notification-sound preferences.
+  See [settings.md](./settings.md) and [secrets.md](./secrets.md).
+- **`llm_credentials`**: the priority-ordered Claude credentials the agent
+  rotates through. See [llm.md](./llm.md).
+- **`environment_variables`**: user-defined key/value rows injected into the
+  agent's execs, with secret values scrubbed from output. See
+  [secrets.md](./secrets.md).
+- **`repositories`**: a tracked repo, holding clone URL, default branch, per-repo
+  setup script, instructions, review policy, the issue-sync toggle and label
+  filter, and the last sync error. A repo with `sync_issues` is its own issue
+  source.
+- **`tasks`**: the board cards, holding source, external id, repo, title,
+  column, fractional position, status, branch, PR URL, `hold`, and `blocking`.
+- **`turns`** / **`events`**: per-task Claude invocations and the append-only
+  parsed stream-json feed. The orchestrator also injects synthetic `ci` and
+  `lifecycle` events into the same stream.
+- **`environment_suggestions`**: agent recommendations about a task, of two
+  kinds: environment setup tips and out-of-scope follow-up work.
+- **`setup_script_changes`**: setup-script edits the agent made to itself
+  through the Seraphim MCP, recorded with a before/after and a reason. See
+  [workspace.md](./workspace.md).
+- **`questions`**: decisions the agent escalated to the operator, answered in
+  the task view.
+- **`task_screenshots`** / **`task_attachments`**: image and file blobs tied to
+  a task, stored as `bytea` and streamed by a dedicated route, never inlined in
+  board or task JSON. See [secrets.md](./secrets.md) for the at-rest caveat.
+- **`heart_attacks`**: recorded turns that died mid-flight, written by the
+  defibrillator loop. See [orchestrator.md](./orchestrator.md).
+- **`automation_rules`**: user-defined board automation. See
+  [automation.md](./automation.md).
+- **`jira_boards`** and the Jira config on the settings row back the Jira source.
+  See [jira.md](./jira.md).
+
+## Where it lives
+
+- `api/migrations/`: the SQL migrations.
+- `api/src/db/models.rs`: the enums and `FromRow` structs.
+- `api/src/db/queries.rs`: the runtime sqlx queries.
+- `api/src/db/mod.rs`: the pool and the migrate call.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,48 @@
+# Frontend
+
+> Decision record for the UI. Current state and roadmap only, no history.
+> `CLAUDE.md` holds the component-level detail.
+
+The frontend is SvelteKit (Svelte 5 runes) in SPA mode (`src/routes/+layout.ts`
+sets `ssr = false`), served by adapter-node. `src/hooks.server.ts` proxies
+`/api/*` to the API in production; `vite.config.ts` proxies it in dev.
+
+## Decisions today
+
+- **Structure.** `src/lib/api.ts` is a ky client with one function per endpoint,
+  `src/lib/types.ts` holds the shared types, components live in
+  `src/lib/components/`, and pages in `src/routes/`.
+- **Key routes.** `/` (the kanban board), `/suggestions`, `/settings` and its
+  subpages, `/task/<id>`, and `/watch` (a kiosk activity monitor). See
+  [settings.md](./settings.md) for the Settings information architecture.
+- **Checks.** `yarn check` (svelte-check), `yarn test` (vitest), and `yarn build`
+  must pass. See [ci.md](./ci.md).
+
+## Dev server and visual review
+
+`cd frontend && yarn dev` runs Vite on `http://localhost:5173`, proxying `/api/*`
+to the API on `localhost:27182`, so the API must be up. For a data-backed page
+(repositories, board, task views), boot a throwaway backend with
+`scripts/dev-api.sh up` first (see [self-update.md](./self-update.md) for the
+script index).
+
+Any UI change is reviewed in a real browser before it is called done: open the
+affected route with the Playwright MCP and check layout with computed styles at
+375px and 1280px, taking a screenshot only to confirm. UI work composes from the
+repo's existing layout primitives and spacing tokens rather than hand-rolled
+margins.
+
+- **Component preview.** `/__components` is a dev-only gallery (guarded by `dev`
+  from `$app/environment`, inert in production) that renders the floating and
+  conditional components (the bulk action bars, the board banners) with stub
+  props, so their review needs no seeded backend. Extend it when adding a new
+  floating or conditional component.
+
+## Where it lives
+
+- `frontend/src/routes/`: the pages, including `+page.svelte` (the board) and
+  `__components/+page.svelte` (the preview gallery).
+- `frontend/src/lib/components/`: the shared components.
+- `frontend/src/lib/settings/sections.ts`: the Settings section registry.
+- `/usr/local/share/seraphim/visual-checks.md`: the computed-style check library
+  baked into the workspace image.

--- a/docs/jira.md
+++ b/docs/jira.md
@@ -1,0 +1,40 @@
+# Jira source
+
+> Decision record for the Jira issue source. Current state and roadmap only, no
+> history. `CLAUDE.md` holds the endpoint-level detail.
+
+Jira is a first-class issue source alongside GitHub. `api/src/jira/` is a
+dual-mode client (Cloud and Server or Data Center); the connection config and a
+secret token live on the settings row (see [secrets.md](./secrets.md)).
+
+## Decisions today
+
+- **Boards and sync.** Followed `jira_boards` each carry a status-to-column map
+  and a repo set. Board auto-discovery seeds them, and tickets sync into `tasks`.
+- **Worked like a GitHub issue.** A Jira ticket inherits its board's repo set as
+  default target repos (operator-overridable on the card, never clobbered by a
+  later sync), the agent pulls it from To Do, the prompt renders the key, summary,
+  description, and link, and the same branch, PR, review-gate, and merge flow runs
+  (one PR per target repo, all-merge-to-Done). A repo-less ticket stays on the
+  board and is skipped until a repo is assigned; the card and task view both flag
+  that with an amber warning so the skip is never silent.
+- **Two-way sync.** On PR open and on Done the agent posts a comment back to the
+  Jira issue with the PR links and outcome, and moving the card to Done transitions
+  the ticket through the board's column-to-status map. The task page renders the
+  Jira discussion into the same thread shape GitHub and internal tickets use, and
+  a reply posts back to Jira. The thread shows the workflow status verbatim, since
+  Jira has no open-or-closed binary.
+- **Attachments.** On first sync and again when worked, a ticket's Jira
+  attachments are downloaded and stored so the agent sees its screenshots and
+  logs with no manual fetch.
+
+## Roadmap
+
+Assignee write-back is not built yet.
+
+## Where it lives
+
+- `api/src/jira/`: the client, sync, and thread reading.
+- `api/src/orchestrator/`: `transition_jira_to_column` and
+  `capture_jira_attachments`.
+- See [settings.md](./settings.md) for the Apps page where Jira is configured.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,0 +1,49 @@
+# LLM credentials and providers
+
+> Decision record for how the agent authenticates to and rotates between models.
+> Current state and roadmap only, no history. `CLAUDE.md` holds the detail.
+
+## Decisions today
+
+- **Multiple credentials with priority rotation.** Claude auth is a
+  priority-ordered set of credentials managed on Settings -> LLMs, stored in
+  `llm_credentials`. Each row is a `kind` (subscription OAuth, a long-lived setup
+  token, or an Anthropic API key), a label, a fractional position (lower runs
+  first), an enabled flag, the secret, optional refreshing OAuth material, an
+  `exhausted_until` rotation timer, and a provider plus base URL. The agent runs
+  on the highest-priority available credential and refreshes its OAuth token ahead
+  of expiry. The API never returns raw secrets, only a masked view (see
+  [secrets.md](./secrets.md)).
+- **Usage-limit rotation and auto-pause.** On a Claude `rate_limit_event` that
+  crosses the configured threshold, the active credential is marked
+  `exhausted_until` its reset and the agent rotates to the next credential. Only
+  when every credential is exhausted does it set `settings.usage_paused_until` to
+  the soonest reset and hold all new work until then, clearing automatically at
+  reset. Escape hatches: a "Resume now" button clears the pause immediately, and
+  raising the threshold or disabling the toggle lifts an active pause.
+- **The board reflects the active credential.** The board header shows the active
+  credential's email or label, and the usage gauge polls the active subscription
+  credential when its consent granted `user:profile`.
+
+## LiteLLM sidecar
+
+The `litellm` service is an opt-in, lightweight LiteLLM proxy (the `llm` compose
+profile) that translates other providers' message shapes to and from the
+Anthropic Messages API the Claude Code CLI speaks. It runs proxy-only: no
+database, no admin UI, no telemetry, reachable in-cluster at
+`http://litellm:4000` and not exposed on a host port. Model routes live in
+`litellm/config.yaml`; provider keys come from `.env`.
+
+## Roadmap
+
+Pointing the agent's `claude` exec at the proxy
+(`ANTHROPIC_BASE_URL=http://litellm:4000`) to run on a non-Anthropic model is
+future work. A credential already carries a provider and base URL for this; the
+sidecar is the translation layer it will build on.
+
+## Where it lives
+
+- `api/src/orchestrator/credentials.rs`: the rotation core.
+- `api/src/orchestrator/usage.rs`: the pause and resume decisions.
+- `api/src/http/credentials.rs`: the credential endpoints.
+- `litellm/config.yaml` and `litellm/README.md`: the proxy configuration.

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,0 +1,49 @@
+# Orchestrator
+
+> Decision record for the agent loops. Current state and roadmap only, no
+> history. `CLAUDE.md` holds the step-by-step detail.
+
+The `api` runs four loops. The agent loop is single-threaded and awaits each task
+to completion before the next; sync, review, and the defibrillator run alongside
+it.
+
+## Loops today
+
+- **sync**: polls every repo with `sync_issues` for open issues and upserts them
+  to the top of Available, never clobbering human-set column or position. Inbound
+  webhooks (`POST /api/v1/webhooks/{github,jira}`) apply the same upsert in
+  realtime, authenticated by a per-provider shared secret. Sync also reflects
+  external state changes onto the board (an issue closed outside Seraphim moves to
+  Done, a reopened one back to Available) only on a genuine transition, and leaves
+  a card the agent is mid-work on alone. A repo whose issue list fails records a
+  per-repo `sync_error`, shows a dismissible banner, and never stops the others.
+- **agent**: when not paused, the config repo is healthy, and inside the
+  availability schedule, it picks work by priority: resume a task whose question
+  was just answered, fix a PR with failing CI, resolve a merge conflict, address
+  review comments, then pull the top of To Do, and finally revisit a PR it gave
+  up on (cooldown-gated). A `blocking` task holds back new To Do work until its PR
+  merges, while its own PR keeps advancing. A `Depends on:` marker stacks fresh
+  work on an unmerged dependency's branch.
+- **review**: gates each task on all of its pull requests (a task can span
+  several repos, one PR each) and reaches Done only once they have all merged. The
+  merge gate is exactly CI green and zero unresolved review threads and no
+  outstanding "changes requested" review; approval alone never merges, and the
+  review lookup fails closed. A PR GitHub cannot squash-merge (an empty net diff
+  or a draft) is held in review, never merge-attempted. CI fixes and review
+  addressing are each bounded by a three-attempt budget before parking for a
+  human.
+- **defibrillator**: recovers turns that die mid-flight (a "heart attack"),
+  detected by an in-turn heartbeat, a loop-level error catch, and a background
+  watchdog. It kills the orphaned process, records a `heart_attacks` incident, and
+  revives the task (To Do if it had no PR, else In Review), bounded by three
+  attempts before leaving it for a human. Each incident raises a dismissible board
+  banner plus a notification.
+
+## Where it lives
+
+- `api/src/orchestrator/mod.rs`: the loops.
+- `api/src/orchestrator/review.rs`: the pure, unit-tested merge decision.
+- `api/src/orchestrator/prompt.rs`: the turn prompts.
+- `api/src/git/`: PR detection, the CI-green check, and squash-merge (octocrab).
+- See [data-model.md](./data-model.md) for `tasks`, `turns`, `events`, and
+  `heart_attacks`.

--- a/docs/railways.md
+++ b/docs/railways.md
@@ -1,0 +1,39 @@
+# Railways (planned)
+
+> Decision record for parallel agent lanes. This is a roadmap: the design is
+> locked but not yet built. `CLAUDE.md` holds the full scoping detail. Tracked by
+> the Railways GitHub milestone.
+
+A railway is a named parallel agent lane with its own workspace container, agent
+loop, Claude session, and repo set. A repo belongs to exactly one railway for
+work, so a task's railway always follows its repo. An undeletable `main` railway
+holds everything by default.
+
+## Locked design
+
+- **Board.** Swimlanes: one board with each railway a horizontal lane across the
+  columns. Moving a card to another railway is a repo-reassign action, not a drag.
+- **Management UI.** A Settings subpage (`/settings/railways`) owns lane
+  create, rename, and describe, the per-railway pause and the global master pause,
+  start and stop, delete-with-confirm, the idle-stop timeout, and the per-repo
+  lane assignment.
+- **Loops.** One agent loop per railway, running in parallel; sync, review, and
+  the defibrillator stay single global loops that are railway-aware.
+- **Container lifecycle.** Lazy start on first work, then auto idle-stop (stopped,
+  not removed, so restart is fast and keeps the clones and session).
+- **Per-railway vs global.** Per-railway: session, pause, name, description, repo
+  set, and lifecycle state. Global: model, setup scripts, config repo,
+  instructions, tokens, one schedule, branch template, review policy, and the
+  operator notepad on the board.
+- **Deletion.** `main` is undeletable; deleting another railway reassigns its
+  repos and their non-active tasks to `main`, then tears down its container and
+  session. Blocked while a live turn runs on it.
+- **Stats and pause.** The subscription usage gauge stays global with an aggregate
+  rollup, while context, cost, tokens, and time are per-railway on each swimlane.
+  A global master pause and a per-railway pause both gate work; one global
+  schedule covers all railways.
+- **Migration.** The existing setup becomes the `main` railway, its session
+  becomes main's session, and all existing repos and tasks move to `main`.
+
+The route planner (assign each drafted issue to a railway and order them) is part
+of the milestone. The Conductor automated-ops agent is out of scope for now.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,36 @@
+# Secrets and sensitive data
+
+> Decision record for how Seraphim stores and exposes secrets. Current state and
+> roadmap only, no history. `CLAUDE.md` holds the endpoint-level detail.
+
+## Decisions today
+
+- **Tokens live in the database, not `.env`.** The Claude credentials and the
+  GitHub token are set in the Settings UI and stored in Postgres, so a worm
+  scanning `.env` files cannot harvest them. The API only ever exposes `*_token_set`
+  booleans plus a masked `*_token_preview`, never the raw values, and writes go
+  through dedicated endpoints. The tokens are injected into the agent's `claude`
+  and `git` execs as environment at call time. See [llm.md](./llm.md) for the
+  Claude credential rotation.
+- **The Postgres password stays in `.env`.** The API needs it to connect before
+  it can read anything. For at-rest protection use host disk encryption (BitLocker
+  or LUKS); Postgres does not encrypt at rest itself.
+- **Environment variables are scrubbed.** User-defined `environment_variables`
+  marked secret are scrubbed out of Claude's output before anything is persisted
+  or streamed (`secrets::Scrubber`), and the API returns their values masked.
+- **Blobs are never inlined.** Task screenshots and attachments are stored as
+  `bytea` and streamed by a dedicated route (`GET /screenshots/:id`,
+  `GET /attachments/:id`), never returned in board or task JSON, which carry
+  metadata only. Because these bytes persist in Postgres, they are for dev and
+  test data only and rely on the same at-rest disk encryption as the tokens.
+- **Webhook authentication.** Inbound GitHub and Jira webhooks are authenticated
+  by a per-provider shared secret on the settings row (GitHub HMAC-signs the body;
+  Jira signs or carries `?secret=`).
+
+## Where it lives
+
+- `api/src/http/settings.rs`: the token and environment-variable endpoints.
+- `api/src/secrets.rs`: the output scrubber.
+- `.env.example`: the non-secret bootstrap configuration (Postgres creds, ports,
+  `SSH_HOME`, `TS_AUTHKEY`, the git identity).
+- See [settings.md](./settings.md) for where these fields sit in the schema.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -1,0 +1,43 @@
+# Self-update
+
+> Decision record for keeping a deployment current. Current state and roadmap
+> only, no history. `scripts/README.md` holds the operator how-to and every knob.
+
+There are two ways to update a running Seraphim, both of which pause the agent
+gracefully, pull the branch, rebuild the compose stack, and resume.
+
+## In-app updater
+
+Settings -> Updates drives this. The running image is stamped with `GIT_SHA` and
+`GIT_BRANCH` (compose build args set by `scripts/start.sh` from host git). An
+hourly check compares that stamp to the branch's latest commit through the GitHub
+API. The "Update" button refuses while a turn is in progress, pauses the agent,
+then launches a detached `docker:cli` updater container over the Docker socket
+that bind-mounts the host repo (`HOST_REPO_DIR`), the socket, and `SSH_HOME` and
+runs `git pull` plus `docker compose up -d --build`. Being outside the compose
+project, the updater survives the API being rebuilt. The UI polls `/version` and
+reloads when the commit changes. `HOST_REPO_DIR` is the only extra env this path
+needs; the check works without it.
+
+## Host self-updater
+
+A host-side alternative for keeping a deployment current with no clicks.
+`scripts/update.sh` (Linux, macOS, Git Bash) and `scripts/update.ps1` (Windows)
+run one pass: only on `main` or `develop`, only when the tree is clean and behind
+its upstream, they wait for the agent to reach a lull, pause it, drain the
+in-flight turn, `git pull --ff-only`, relaunch the stack, then resume unless the
+operator had it paused. The update still proceeds if the API is unreachable,
+without the graceful pause. `scripts/install.sh` installs a systemd timer (or
+prints cron instructions when `systemctl` is absent) and `scripts/install.ps1`
+registers a Scheduled Task; the `uninstall.*` scripts remove them. This path does
+its own pull and compose on the host, so it needs no `HOST_REPO_DIR` and no
+updater container. Every knob is a `SERAPHIM_*` environment variable.
+
+## Where it lives
+
+- `api/src/update/`: the in-app version check and updater launch.
+- `scripts/update.*`, `scripts/install.*`, `scripts/uninstall.*`: the host
+  self-updater and its scheduler.
+- `scripts/start.sh`, `scripts/stop.sh`, `scripts/restart.sh`: the compose
+  wrappers.
+- `scripts/README.md`: the full operator reference and the `SERAPHIM_*` knobs.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,47 @@
+# Settings
+
+> Decision record for configuration and the Settings UI. Current state and
+> roadmap only, no history. `CLAUDE.md` holds the field-level detail.
+
+## Information architecture
+
+`/settings` is a Stripe-style landing grid that links to one dedicated page per
+category at `/settings/[section]`. The grid and every page header are driven by a
+single registry (`src/lib/settings/sections.ts`, `SETTINGS_GROUPS` plus
+`SECTION_BY_ID`), which groups every section under at most three headings sized to
+fit a 1920x1080 screen without scrolling:
+
+- **Agent:** general, LLMs, workspace, availability, usage.
+- **Workflow and integrations:** automation, railways, apps, secrets,
+  notifications.
+- **System:** updates, backup, danger.
+
+The dynamic page renders the section matching the route param, fetches only that
+section's data, and falls back to "Not found" for an unknown id.
+
+Decisions folded into this layout: Automation and Railways moved off the top nav
+into settings, and `/automation` and `/railways` redirect to their `/settings/*`
+homes. Jira and Tailscale are opt-in integrations under a single Apps page, not
+native settings. The Workspace page groups the agent instructions, the base setup
+script, the config repo, environment variables, network access, and container
+restart or recreate. Hard reset lives in a single Danger zone. Usage and stats
+merges the usage-pause controls with the statistics reset. There is no settings
+notepad: the global operator notepad lives on the kanban board.
+
+## The `settings` row
+
+Configuration is one row (`id = 1`) holding the org profile, `global_instructions`,
+`default_review_policy`, `agent_paused`, `claude_model`, `base_setup_script`,
+`config_repo_url`, `default_branch_template`, and `current_session_id` (the one
+shared Claude session). It also holds the usage-pause columns (see
+[llm.md](./llm.md)), the availability schedule (weekly windows and skip dates in
+the operator's time zone, which gate when the agent pulls new work), the
+notification-sound preferences, and the secret token columns (see
+[secrets.md](./secrets.md)).
+
+## Where it lives
+
+- `frontend/src/routes/settings/+page.svelte`: the landing grid.
+- `frontend/src/routes/settings/[section]/+page.svelte`: the dynamic page.
+- `frontend/src/lib/settings/sections.ts`: the section registry.
+- `api/src/http/settings.rs`: the settings endpoints.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,0 +1,48 @@
+# Workspace (the agent sandbox)
+
+> Decision record for the agent runtime. Current state and roadmap only, no
+> history. `CLAUDE.md` holds the build-arg and path detail.
+
+The `workspace` service is a long-lived, powerful but dumb sandbox. The API
+drives it with `docker exec` (bollard). Claude is always spawned at `/workspace`
+as the non-root `codespace` user.
+
+## Decisions today
+
+- **Flat clones.** Every enabled repo is cloned at `/workspace/{repo-name}`, so
+  cross-repo work is natural. A task names a focus repo and branch. Adding or
+  enabling a repo clones it into the workspace in the background so it lands
+  without waiting for a full provision; removing one drains between tasks.
+- **Instructions become files.** Global instructions write to
+  `/workspace/AGENTS.md`, per-repo instructions to `/workspace/{repo}/CLAUDE.md`.
+- **Config repo for `~/.claude`.** The agent's `~/.claude` comes from cloning
+  `settings.config_repo_url` into `CLAUDE_CONFIG_DIR=/workspace/.claude`, not a
+  host mount. This is a dedicated, hard-failing step: on failure it records
+  `settings.config_repo_error`, raises a board banner, and halts the agent until
+  it succeeds. A blank config repo URL bypasses the halt.
+- **Two-tier setup.** Environment setup (`settings.base_setup_script`) runs once
+  per provision or recreate; per-repo setup (`repositories.setup_script`) runs
+  after each clone. A repo can opt into `setup_script_always_run` to re-run its
+  setup before every task on the persistent clone.
+- **Auth.** `CLAUDE_CODE_OAUTH_TOKEN` (or an API key) for Claude, the mounted host
+  `~/.ssh` for `git@` clones, and `GH_TOKEN` for HTTPS plus octocrab. The
+  entrypoint writes a system-wide git identity from `GIT_USER_NAME` and
+  `GIT_USER_EMAIL` so commits work in every clone.
+- **Baked tooling.** The image preinstalls the pinned Rust toolchains, Postgres 17
+  plus `pg-ephemeral` for local migration checks, and Playwright's Chromium, so a
+  fresh workspace has no first-run download stall.
+- **Two MCPs, at user scope.** The Playwright MCP is the agent's eyes for visual
+  self-review, and the Seraphim MCP lets the agent edit its own setup scripts
+  (recorded in `setup_script_changes`). Both are registered at user scope so
+  `claude -p --permission-mode bypassPermissions` loads them with no approval
+  gate.
+
+## Where it lives
+
+- `workspace/Dockerfile` and `workspace/entrypoint.sh`: the image and its setup.
+- `workspace/seraphim-mcp/`: the hand-rolled zero-dep Seraphim MCP.
+- `api/src/claude/exec.rs`: the `docker exec` turn runner.
+- `api/src/docker/`: the `Workspace` handle (exec, restart, recreate) over bollard.
+- `api/src/orchestrator/provision.rs`: provisioning and setup.
+- See [frontend.md](./frontend.md) for the visual self-review loop the Playwright
+  MCP serves.


### PR DESCRIPTION
## What

Creates the `docs/` directory the documentation policy requires: one Markdown file per decision category, with a README that states the policy.

Closes #378.

## Why

The policy calls for a `./docs/` directory with a `.md` per category of decisions, kept in sync as a source of truth. None existed, so decisions lived only in `CLAUDE.md` and the policy was unfulfilled.

## What is in it

- `docs/README.md`: the policy (per-category records; current state and roadmap only, no history; no em dashes) and how `docs/` relates to `CLAUDE.md`, plus an index and a note on adding a category.
- One file per decision category: `architecture`, `data-model`, `orchestrator`, `workspace`, `frontend`, `settings`, `secrets`, `llm`, `self-update` (in-app updater plus host scripts, the named example), `jira`, `automation`, `ci`, and `railways` (roadmap).
- A pointer to `docs/` from `CLAUDE.md`'s repo layout so it is discoverable.

## Design

Each doc is a concise decision summary with a uniform shape (intro, "Decisions today", an optional "Roadmap", and "Where it lives" pointers into the code). It deliberately points at the code and at `CLAUDE.md` rather than re-deriving every detail, so `CLAUDE.md` stays the authoritative summary and the docs stay maintainable instead of becoming a second full copy that drifts. `self-update.md` links the existing `scripts/README.md` rather than duplicating the operator reference.

## Verification

Docs-only change, no code, so no build or visual review applies. Checked: zero em dashes across `docs/` and the `CLAUDE.md` addition; every relative link resolves; every file has an H1; and the Source hygiene gate (`scripts/check-control-chars.py`) passes.