### PR TITLE
Bake shellcheck and PowerShell into the workspace image (#379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,27 @@ jobs:
       - name: Reject NUL bytes and control characters in tracked sources
         run: python3 scripts/check-control-chars.py
 
+  # Lint the host shell scripts (scripts/*.sh) so a shell mistake in the compose
+  # wrappers or the self-updater fails the PR instead of surfacing on an operator's
+  # machine (issue #379). PowerShell parse-checks run in the workspace image, which
+  # now bakes pwsh; this job guards the bash side.
+  scripts:
+    name: Scripts (shellcheck)
+    runs-on: [self-hosted, Linux, X64, fedora]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned shellcheck (matches workspace/Dockerfile's SHELLCHECK_VERSION),
+      # fetched as the prebuilt static binary so the job needs nothing preinstalled
+      # on the runner. Run straight from the temp dir: no sudo, no PATH mutation.
+      - name: Lint host shell scripts
+        run: |
+          version=0.11.0
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz" -o /tmp/shellcheck.tar.xz
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          "/tmp/shellcheck-v${version}/shellcheck" --version
+          "/tmp/shellcheck-v${version}/shellcheck" scripts/*.sh
+
   api:
     name: API (Rust)
     runs-on: [self-hosted, Linux, X64, fedora]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,7 +494,13 @@ operator notepad lives on the kanban board.
   can verify migrations / integration tests against the same major as CI and
   prod without a daemon. The entrypoint also aligns the agent to the mounted host
   Docker socket's group, so `docker` / `earthly` work without `sudo` too.
-- **Browser e2e (issue #215):** Playwright's Chromium plus its OS libraries are
+- **Host-script linting baked (issue #379):** shellcheck and PowerShell (`pwsh`)
+  are baked into the workspace image (pinned release tarballs plus a build-time
+  PATH gate, like actionlint), so an agent working the host scripts can lint the
+  bash (`shellcheck scripts/*.sh`) and parse-check the Windows PowerShell
+  (`pwsh -Command '[System.Management.Automation.Language.Parser]::ParseFile(...)'`)
+  as real checks instead of a manual read. A CI `scripts` job runs shellcheck on
+  `scripts/*.sh` to guard the bash side going forward.
   baked into the workspace image, into a shared world-readable
   `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` (the official Playwright-in-Docker
   convention) so any user finds it, so the agent can run Plunder's `yarn test:e2e`

--- a/scripts/dev-api.sh
+++ b/scripts/dev-api.sh
@@ -148,14 +148,14 @@ seed_tasks() {
   local todo_id
   todo_id="$(create_task "Fix the flaky checkout integration test" \
     "The checkout test fails intermittently in CI, roughly one run in five. Track down the race and make it deterministic.")"
-  move_card "$todo_id" todo 1.0
+  move_card "$todo_id" "todo" 1.0
   log "  seeded 1 card in To Do"
 
   # In Progress: the rich card, with a comment thread and notes to review.
   local wip_id
   wip_id="$(create_task "Migrate file uploads to object storage" \
     "Uploads currently sit on the API host's local disk, which does not survive a redeploy. Move them to object storage and stream through a signed URL.")"
-  move_card "$wip_id" in_progress 1.0
+  move_card "$wip_id" "in_progress" 1.0
   comment_on "$wip_id" agent \
     "Starting on this. Plan: add an object-storage client behind the existing upload trait, then backfill the on-disk files in a one-off migration."
   comment_on "$wip_id" user \
@@ -169,14 +169,14 @@ seed_tasks() {
   local review_id
   review_id="$(create_task "Add rate limiting to the public API" \
     "The public endpoints have no throttle. Add a per-client rate limit with a clear 429 response so a single caller cannot starve the others.")"
-  move_card "$review_id" in_review 1.0
+  move_card "$review_id" "in_review" 1.0
   log "  seeded 1 card in In Review"
 
   # Done: a finished card, so the terminal lane is not empty.
   local done_id
   done_id="$(create_task "Upgrade the database to Postgres 17" \
     "Move the stack from Postgres 16 to 17 and confirm the migrations, extensions, and backups all still work.")"
-  move_card "$done_id" done 1.0
+  move_card "$done_id" "done" 1.0
   log "  seeded 1 card in Done"
 
   log "Seeded 6 dev board tasks across every column."

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,8 +16,9 @@ fi
 # check) and tell the API where the repo lives on the host (so its self-updater
 # can git pull + rebuild). HOST_REPO_DIR can be overridden in .env (e.g. on
 # Windows, set it to a Docker-friendly path).
-export GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-export GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+export GIT_SHA GIT_BRANCH
 export HOST_REPO_DIR="${HOST_REPO_DIR:-$(pwd)}"
 
 docker compose up -d --build

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -4,9 +4,10 @@
 # Java, .NET, PHP, Ruby, plus version managers, out of the box. On top we add the
 # tools the agents need that it doesn't ship: Rust/Cargo, the Claude Code CLI, the
 # GitHub CLI, a Docker client, Earthly, actionlint, the org cloud CLIs (jira,
-# doctl, gcloud, wrangler, bunny), and Playwright's Chromium for Plunder's e2e
-# suite. Work runs as the image's non-root `codespace` user; the API drives it
-# via `docker exec`, the container itself just idles.
+# doctl, gcloud, wrangler, bunny), Playwright's Chromium for Plunder's e2e suite,
+# and shellcheck plus PowerShell for linting the host scripts. Work runs as the
+# image's non-root `codespace` user; the API drives it via `docker exec`, the
+# container itself just idles.
 
 FROM mcr.microsoft.com/devcontainers/universal:latest
 
@@ -220,6 +221,48 @@ RUN node_dir="$(runuser -l codespace -c 'command -v node' | xargs dirname)" \
     && test -x /usr/local/bin/playwright-mcp \
     && runuser -l codespace -c 'command -v playwright-mcp >/dev/null' \
     && rm -rf /home/codespace/.npm/_npx /tmp/*
+
+# --- Host-script linting: shellcheck + PowerShell (issue #379) ----------------
+# The host scripts ship in two flavors: bash (scripts/*.sh) and Windows
+# PowerShell (scripts/*.ps1). Bake shellcheck and pwsh so an agent working a
+# host-script task can lint the shell and parse-check the PowerShell as real
+# checks (`shellcheck scripts/*.sh`, and
+# `pwsh -Command '[System.Management.Automation.Language.Parser]::ParseFile(...)'`),
+# instead of a manual, error-prone read. Pinned, prebuilt release tarballs with no
+# apt source, matching the gh/actionlint pattern above. Placed late so a bump here
+# never invalidates the expensive Rust and Playwright layers above.
+#
+# pwsh runs only for headless parse checks, so opt out of its telemetry and update
+# check: no runtime network calls, no data collection.
+ENV POWERSHELL_TELEMETRY_OPTOUT=1 \
+    POWERSHELL_UPDATECHECK=Off
+
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" -o /tmp/shellcheck.tar.xz \
+    && tar -xJf /tmp/shellcheck.tar.xz -C /tmp \
+    && install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck \
+    && rm -rf /tmp/shellcheck*
+
+# PowerShell 7 as the self-contained linux-x64 archive: it bundles its own .NET
+# runtime, so no dotnet install is needed. The archive extracts flat, so it is
+# unpacked into a versioned dir under /opt and symlinked onto PATH, mirroring the
+# gcloud layout above.
+ARG POWERSHELL_VERSION=7.6.4
+RUN curl -fsSL "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-x64.tar.gz" -o /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell/7 \
+    && tar -xzf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -sf /opt/microsoft/powershell/7/pwsh /usr/local/bin/pwsh \
+    && rm -f /tmp/powershell.tar.gz
+
+# Verification gate (mirrors the actionlint gate, issue #252): fail the BUILD
+# unless both tools resolve on PATH for root (the default docker exec user) and
+# for the codespace agent user, so a binary that lands off PATH can never ship
+# silently.
+RUN shellcheck --version \
+    && pwsh --version \
+    && runuser -l codespace -c 'shellcheck --version' \
+    && runuser -l codespace -c 'pwsh --version'
 
 # --- Seraphim agent helpers (post to the API; env injected per turn) ---------
 COPY seraphim-suggest /usr/local/bin/seraphim-suggest


### PR DESCRIPTION
## What

Bakes `shellcheck` and PowerShell (`pwsh`) into the workspace image so host-script tasks can lint and parse-check as real checks, and adds a CI `scripts` job that runs shellcheck.

Closes #379.

## Why

The host scripts ship in two flavors, bash (`scripts/*.sh`) and Windows PowerShell (`scripts/*.ps1`), but the workspace image had neither a confirmed shellcheck nor pwsh. A host-script task could therefore only get a manual, error-prone read (5.1-compat review by eye), not a parser or linter.

## Changes

- **`workspace/Dockerfile`:** install shellcheck `0.11.0` and PowerShell `7.6.4` as pinned, prebuilt release tarballs (no apt source), matching the gh/actionlint pattern. A build-time gate fails the image unless both resolve on PATH for root and the `codespace` user, like the actionlint gate. pwsh telemetry and the update check are disabled. Placed late so a bump never invalidates the expensive Rust and Playwright layers.
- **`.github/workflows/ci.yml`:** a `scripts` job runs `shellcheck scripts/*.sh` (pinned shellcheck, fetched as the static binary so the runner needs nothing preinstalled) to guard the bash side going forward.
- **`scripts/dev-api.sh`, `scripts/start.sh`:** made shellcheck-clean so the new gate is green: quote the `done` column literal (SC1010) and split declare-from-export so the git command's exit status is not masked (SC2155).
- **`CLAUDE.md`:** record the baked tooling and the CI guard.

## Verification

The workspace image build runs in CI's `images` job. Disk on this runner was too tight to pull the multi-GB universal base for a full local build, so I validated the exact install and runtime on the identical base (the agent runs inside that image):

- `shellcheck 0.11.0` installs from the pinned tarball, runs, and lints `scripts/*.sh` clean (exit 0).
- `pwsh 7.6.4` installs from the pinned tarball, runs (`pwsh --version`), and the issue's real check, `[System.Management.Automation.Language.Parser]::ParseFile(...)`, parses all three `.ps1` scripts with no errors.
- Both download URLs return HTTP 200.
- `actionlint` passes on the updated workflow, and the CI job's own shell snippet is shellcheck-clean.

No UI, so visual review does not apply.