### PR TITLE
Reconcile the usage-pause escape hatch with credential rotation (#381)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -924,10 +924,13 @@ has live data to review. Then `cd frontend && yarn dev` and open the route;
   holds all new work until then, then auto-clears it. Escape hatches (issue #292):
   `POST /settings/usage/resume` clears the pause now (the board banner and the
   Settings usage section each have a "Resume now" button), and every settings
-  update runs `orchestrator::reevaluate_usage_pause`, which lifts an active pause
-  when the toggle is turned off or the threshold is raised above the latest known
-  utilization (`usage::should_lift_pause`, re-judging the latest `rate_limit`
-  event). A genuinely exhausted window still stands until reset.
+  update runs `orchestrator::reevaluate_usage_pause`. Because `usage_paused_until`
+  now means "every credential is exhausted" (issue #341), that reevaluate delegates
+  to `credentials::reconcile_pause` so the escape hatch and the rotation path share
+  one source of truth (issue #381): it re-derives the pause from current credential
+  availability (lift once a credential frees, else stand until the soonest reset)
+  rather than re-judging one stale `rate_limit` event against the threshold, which
+  could have lifted an all-exhausted pause off a single old event.
 
 ## Railways (planned)
 

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1368,44 +1368,28 @@ async fn agent_loop(state: AppState, handle: RailwayHandle) {
     }
 }
 
-/// Re-evaluates an active usage auto-pause after a settings change and lifts it if
-/// it no longer applies (issue #292).
+/// Re-derives an active usage auto-pause from the current credential state after a
+/// settings change (issues #292, #381).
 ///
-/// The auto-pause keys only to the window reset time, so without this neither a
-/// raised `usage_limit_threshold` nor a disabled `usage_limit_pause_enabled` would
-/// take effect until the reset. Called on every settings update: when there is an
-/// active (future) pause and [`usage::should_lift_pause`] says it no longer holds
-/// (the feature was turned off, or the latest utilization is now under the raised
-/// threshold), it clears `usage_paused_until` so the agent resumes immediately. A
-/// genuinely exhausted window still stands until reset. Best-effort and idempotent;
-/// when no pause is active it does nothing.
+/// Since issue #341, `usage_paused_until` means "every credential is exhausted" and
+/// is owned solely by [`credentials::reconcile_pause`]. So on a settings change this
+/// delegates to that same reconcile instead of re-judging one stale `rate_limit_event`
+/// against the threshold: if a credential is available now the pause lifts and the
+/// agent resumes, otherwise it stands until the soonest reset. Both the rotation
+/// path and this escape hatch thus share one source of truth, and an all-exhausted
+/// pause can never be lifted off a single old event. Best-effort and idempotent;
+/// when no pause is active it does nothing (and it never creates a pause here).
 pub(crate) async fn reevaluate_usage_pause(
     state: &AppState,
     settings: &crate::db::models::Settings,
 ) -> Result<()> {
-    let Some(until) = settings.usage_paused_until else {
-        return Ok(());
-    };
-    // An already-lapsed pause is cleared by the gate on the next tick; nothing to do.
-    if Utc::now() >= until {
+    // Only reconcile an already-active pause; reconciling with no pause set could
+    // otherwise create one from an all-exhausted credential state, which is the
+    // rotation path's job, not this escape hatch's.
+    if settings.usage_paused_until.is_none() {
         return Ok(());
     }
-    // Re-judge against the latest rate-limit signal at the current threshold. The
-    // stored payload may wrap the info under `rate_limit_info` (the event) or be the
-    // info object itself, so accept either shape.
-    let payload = queries::latest_rate_limit(&state.db).await?;
-    let info = payload
-        .as_ref()
-        .map(|value| value.get("rate_limit_info").unwrap_or(value));
-    if usage::should_lift_pause(
-        info,
-        settings.usage_limit_pause_enabled,
-        settings.usage_limit_threshold,
-    ) {
-        queries::set_usage_paused_until(&state.db, None).await?;
-        state.notify_board();
-        info!("usage auto-pause lifted after a settings change (disabled or threshold raised)");
-    }
+    credentials::reconcile_pause(state).await?;
     Ok(())
 }
 

--- a/api/src/orchestrator/usage.rs
+++ b/api/src/orchestrator/usage.rs
@@ -71,31 +71,6 @@ fn window_pause(
     }
 }
 
-/// Whether an active usage auto-pause should be lifted now (issue #292), given the
-/// latest rate-limit `info` (if any), whether the auto-pause is still `enabled`,
-/// and the operator's current `threshold`.
-///
-/// The auto-pause keys only to the window reset time, so on its own it never
-/// re-evaluates a raised threshold or a disabled toggle. This is the escape hatch:
-/// it returns `true` (lift the pause) when the pause no longer applies, i.e.
-/// - the auto-pause was disabled, or
-/// - re-evaluating the latest signal at the current threshold no longer warrants
-///   pausing (e.g. the threshold was raised above current utilization).
-///
-/// A genuinely exhausted (`rejected`) window still warrants pausing regardless of
-/// the threshold, so [`pause_until`] still returns its reset and this returns
-/// `false`: the pause stands until the window resets, as it should. With no signal
-/// to re-judge (`info` is `None`), it leaves an enabled pause in place.
-pub fn should_lift_pause(info: Option<&Value>, enabled: bool, threshold: i32) -> bool {
-    if !enabled {
-        return true;
-    }
-    match info {
-        Some(info) => pause_until(info, threshold).is_none(),
-        None => false,
-    }
-}
-
 /// Normalizes `utilization` to a 0-100 percent, accepting either a fraction
 /// (`0.82`) or an already-scaled percent (`82`).
 fn parse_utilization(value: &Value) -> Option<f64> {
@@ -152,39 +127,5 @@ mod tests {
             "overageResetsAt": 2000
         });
         assert_eq!(pause_until(&info, 80), Some(2000));
-    }
-
-    #[test]
-    fn disabling_auto_pause_lifts_the_pause() {
-        // The signal still says "over threshold", but turning the feature off must
-        // lift any active pause (issue #292), regardless of the signal.
-        let info = json!({ "status": "allowed_warning", "utilization": 90, "resetsAt": 500 });
-        assert!(should_lift_pause(Some(&info), false, 80));
-    }
-
-    #[test]
-    fn raising_threshold_above_utilization_lifts_the_pause() {
-        // Paused at 83% under an 80% threshold; raising the threshold to 95% (above
-        // current utilization) lifts it now rather than waiting for the reset.
-        let info = json!({ "status": "allowed_warning", "utilization": 83, "resetsAt": 500 });
-        assert!(should_lift_pause(Some(&info), true, 95));
-        // Still below the (lower) threshold it was paused at: stays paused.
-        assert!(!should_lift_pause(Some(&info), true, 80));
-    }
-
-    #[test]
-    fn exhausted_window_stays_paused_even_if_threshold_raised() {
-        // A rejected (exhausted) window cannot be un-exhausted by raising the
-        // threshold; the pause must stand until the window resets.
-        let info = json!({ "status": "rejected", "resetsAt": 500 });
-        assert!(!should_lift_pause(Some(&info), true, 100));
-    }
-
-    #[test]
-    fn no_signal_leaves_an_enabled_pause_in_place() {
-        // With nothing to re-judge, an enabled pause is left to auto-clear at reset.
-        assert!(!should_lift_pause(None, true, 95));
-        // But a disabled toggle still lifts it without needing a signal.
-        assert!(should_lift_pause(None, false, 95));
     }
 }

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -19,8 +19,11 @@
   `exhausted_until` its reset and the agent rotates to the next credential. Only
   when every credential is exhausted does it set `settings.usage_paused_until` to
   the soonest reset and hold all new work until then, clearing automatically at
-  reset. Escape hatches: a "Resume now" button clears the pause immediately, and
-  raising the threshold or disabling the toggle lifts an active pause.
+  reset. Escape hatches: a "Resume now" button clears the pause immediately, and a
+  settings change re-derives the pause from current credential availability (the
+  reevaluate delegates to the same reconcile the rotation path uses, so both share
+  one source of truth), lifting it once a credential frees rather than off a stale
+  usage event.
 - **The board reflects the active credential.** The board header shows the active
   credential's email or label, and the usage gauge polls the active subscription
   credential when its consent granted `user:profile`.


### PR DESCRIPTION
## What

Makes the usage-pause escape hatch (`reevaluate_usage_pause`, issue #292) delegate to `credentials::reconcile_pause`, so it and the credential-rotation path share one source of truth.

Closes #381.

## Why

Since issue #341, `settings.usage_paused_until` means "every credential is exhausted" and is owned solely by `credentials::reconcile_pause`. The #292 escape hatch, however, still re-judged a single latest `rate_limit_event` against the threshold via `usage::should_lift_pause`. So raising the threshold (or disabling the toggle) could clear an all-exhausted pause off one stale event while every credential was in fact still exhausted, wrongly signaling "resumed".

## Changes

- **`api/src/orchestrator/mod.rs`:** `reevaluate_usage_pause` now, when a pause is active, delegates to `credentials::reconcile_pause`, which re-derives the pause from current credential availability: lift once a credential frees, otherwise stand until the soonest reset. It never creates a pause here (that stays the rotation path's job).
- **`api/src/orchestrator/usage.rs`:** removed the now-dead `should_lift_pause` and its four tests. `pause_until` (still used by the rate-limit handler) and its tests are untouched.
- **`CLAUDE.md`, `docs/llm.md`:** updated the escape-hatch description.

## Behavior note

Under #341 semantics, credential exhaustion is a per-credential timer set when the limit is hit, not a live threshold read. So raising the threshold no longer un-exhausts a credential and no longer lifts an active pause off a stale event; the raised threshold instead makes future events pause less eagerly. A pause now lifts exactly when a credential becomes available (its window reset, or it was reconnected/enabled/added, which already call `reconcile_pause`), or via the manual "Resume now". This is the intended single-source-of-truth the issue asked for.

## Verification

- `cargo +1.88 fmt --check`: clean. `cargo +1.88 clippy --all-targets`: no new warnings (my code is clippy-clean).
- `cargo +1.88 test` against an ephemeral Postgres: 191 passed, 0 failed (the 4 removed tests covered the deleted dead function; the decision cores `is_available` and `pause_until` stay tested).

Backend-only change, so visual review does not apply.