### PR TITLE
Stop provisioning from deleting a repo's committed CLAUDE.md (#385)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,7 +409,11 @@ operator notepad lives on the kanban board.
 - **Every enabled repo** is cloned flat at `/workspace/{repo-name}` (name = part
   after `/`), so cross-repo work is natural. The task names a focus repo + branch.
 - **Instructions become files:** global → `/workspace/AGENTS.md`; per-repo →
-  `/workspace/{repo}/CLAUDE.md` (Claude auto-loads them).
+  `/workspace/{repo}/CLAUDE.md` (Claude auto-loads them). A repo that commits its
+  own `CLAUDE.md` is never clobbered (issue #385): provisioning only writes or
+  clears that path for repos that do not track one, so it can no longer delete a
+  repo's committed `CLAUDE.md` and leave it staged for deletion. Per-repo operator
+  instructions therefore do not apply to a repo that ships its own `CLAUDE.md`.
 - **Visual self-review (issues #244, #245):** every task prompt carries a standing
   instruction (`prompt::VISUAL_SELF_REVIEW`, in the shared header so it applies on
   fresh work and fix/revisit turns alike) to look at any UI change in a real

--- a/api/src/orchestrator/prompt.rs
+++ b/api/src/orchestrator/prompt.rs
@@ -531,6 +531,10 @@ fn context_header(
     // at it before declaring done, so the standing instruction lives in the header
     // too (fresh work, CI fixes, revisits all alike).
     prompt.push_str(VISUAL_SELF_REVIEW);
+    // Keep each commit to the task's own changes: the persistent workspace can carry
+    // a prior session's lockfile rewrite that `git add -A` would otherwise sweep in
+    // (issue #385). Shared by every mode this header serves.
+    prompt.push_str(WORKING_TREE_HYGIENE);
     prompt
 }
 
@@ -799,6 +803,26 @@ const ASKING_FOR_HELP: &str = "\n\
     automatically resumed once the user answers. Prefer asking over guessing \
     whenever it matters.\n";
 
+/// Standing guard (issue #385): keep each commit to the task's own changes.
+///
+/// The workspace persists between tasks, so a prior session's build (which can
+/// rewrite a lockfile) or a provisioning step can leave the tree dirty, and
+/// `git add -A` would sweep those unrelated changes into the PR. The provisioning
+/// side is fixed at the source (a repo's committed `CLAUDE.md` is no longer
+/// clobbered), but a build artifact like `yarn.lock` still needs the agent to
+/// notice and restore it before committing, so this rides in every prompt.
+const WORKING_TREE_HYGIENE: &str = "\n\
+    # Keep the commit to your own changes\n\
+    Before you stage or commit, run `git status` (and skim `git diff`) and look for \
+    changes to files this task never touched, especially `CLAUDE.md` and lockfiles \
+    like `yarn.lock`. The workspace persists between tasks, so a prior session's \
+    build or a provisioning step can leave the tree dirty, and `git add -A` would \
+    sweep those unrelated changes into your commit. Restore any such file from the \
+    base before committing (e.g. `git restore <file>` or `git checkout -- <file>`), \
+    so the pull request contains only your work. Commit and push completed work \
+    promptly, since uncommitted changes can be reverted when a task is resumed or \
+    the workspace is re-provisioned.\n";
+
 /// Builds the prompt that resumes a parked task once the user has answered.
 ///
 /// The shared Claude session is also used by other tasks while this one is
@@ -840,6 +864,9 @@ pub fn build_resume(repo: &Repository, task: &Task, branch: &str, answers: &[Que
         }
     }
 
+    // A resume prep deliberately does not reset the tree (it preserves the agent's
+    // parked work), so cross-task dirt is most likely to surface here (issue #385).
+    prompt.push_str(WORKING_TREE_HYGIENE);
     prompt.push_str(
         "When you are finished, open the pull request as described in your original \
          working agreement. If you need another decision, you may ask again with \
@@ -1094,6 +1121,32 @@ mod tests {
         // It reads per-repo dev facts from the repo's CLAUDE.md and skips cleanly.
         assert!(prompt.contains("CLAUDE.md"));
         assert!(prompt.contains("SKIP this review"));
+    }
+
+    #[test]
+    fn fresh_and_resume_prompts_guard_the_working_tree_before_committing() {
+        // The commit-hygiene guard (issue #385) is a standing instruction, so both a
+        // fresh brief and a resume carry it: check the tree and restore unrelated
+        // CLAUDE.md / yarn.lock changes a prior session left behind before add -A.
+        let fresh = build(
+            &sample_settings(),
+            &sample_repo(),
+            &sample_task(),
+            "seraphim/issue-57",
+            &[],
+            &[],
+            &[],
+            &[],
+        );
+        assert!(fresh.contains("Keep the commit to your own changes"));
+        assert!(fresh.contains("yarn.lock"));
+        assert!(fresh.contains("git add -A"));
+
+        // The resume path bypasses the shared header, so it must carry the guard on
+        // its own (it is the path most exposed to cross-task dirt).
+        let resume = build_resume(&sample_repo(), &sample_task(), "seraphim/issue-57", &[]);
+        assert!(resume.contains("Keep the commit to your own changes"));
+        assert!(resume.contains("yarn.lock"));
     }
 
     #[test]

--- a/api/src/orchestrator/provision.rs
+++ b/api/src/orchestrator/provision.rs
@@ -47,6 +47,33 @@ fn write_file_snippet(path: &str, content: &str) -> String {
     }
 }
 
+/// Bash that installs the operator's per-repo `instructions` as `{dir}/CLAUDE.md`
+/// (so Claude auto-loads them) WITHOUT ever clobbering a `CLAUDE.md` the repo
+/// commits itself (issue #385).
+///
+/// Per-repo instructions ride in the repo's own `CLAUDE.md` path, but many repos
+/// (Seraphim included) track their own `CLAUDE.md`. Managing that path
+/// unconditionally deleted it whenever `instructions` was empty (the common case),
+/// leaving the repo's tracked file staged for deletion, which a later `git add -A`
+/// then swept into the commit. So the write-or-clear only runs when the repo does
+/// NOT track a `CLAUDE.md` of its own; a committed one is left untouched. A repo
+/// that ships its own `CLAUDE.md` therefore ignores per-repo instructions here,
+/// the safe trade against destroying its file.
+fn per_repo_claude_md_snippet(dir: &str, instructions: &str) -> String {
+    let manage = write_file_snippet(&format!("{dir}/CLAUDE.md"), instructions);
+    // `git ls-files --error-unmatch` exits non-zero for an untracked path; it sits
+    // in an `if` condition, so it is safe under the outer script's `set -e`.
+    format!(
+        "if git -C \"{dir}\" ls-files --error-unmatch CLAUDE.md >/dev/null 2>&1; then\n\
+         \x20 : # the repo commits its own CLAUDE.md; never clobber it (issue #385)\n\
+         else\n\
+         {manage}\
+         fi\n",
+        dir = dir,
+        manage = manage,
+    )
+}
+
 /// Clone-or-update the `~/.claude` config repo into `CLAUDE_CONFIG_DIR`. Uses
 /// init+fetch+checkout so a non-empty dir (with a persisted `projects/`) is fine.
 fn config_repo_snippet(config_repo_url: &str) -> String {
@@ -547,7 +574,7 @@ fn repo_block(repo: &Repository, always_setup: bool) -> String {
         dir = dir,
         clone_url = repo.clone_url,
         submodules = submodules,
-        claude_md = write_file_snippet(&format!("{dir}/CLAUDE.md"), &repo.instructions),
+        claude_md = per_repo_claude_md_snippet(&dir, &repo.instructions),
     )
 }
 
@@ -588,8 +615,9 @@ async fn run(state: &AppState, container: &str, script: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        branch_prep_snippet, is_safe_repo_dir, orphan_repo_dirs, parse_listed_dirs, removal_script,
-        repo_block, submodule_update_snippet, REPO_DIR_LIST_SCRIPT,
+        branch_prep_snippet, is_safe_repo_dir, orphan_repo_dirs, parse_listed_dirs,
+        per_repo_claude_md_snippet, removal_script, repo_block, submodule_update_snippet,
+        REPO_DIR_LIST_SCRIPT,
     };
     use crate::db::models::Repository;
     use chrono::Utc;
@@ -803,5 +831,32 @@ mod tests {
         assert!(REPO_DIR_LIST_SCRIPT.contains("${path}.git"));
         assert!(REPO_DIR_LIST_SCRIPT.contains("REPODIR:"));
         assert!(REPO_DIR_LIST_SCRIPT.contains("nullglob"));
+    }
+
+    #[test]
+    fn per_repo_claude_md_never_clobbers_a_committed_claude_md() {
+        // Empty instructions: the write_file_snippet form is the destructive
+        // `rm -f`, but it must sit behind the tracked-file guard so a repo that
+        // commits its own CLAUDE.md is never deleted (issue #385).
+        let empty = per_repo_claude_md_snippet("/workspace/Seraphim", "");
+        assert!(empty.contains("git -C \"/workspace/Seraphim\" ls-files --error-unmatch CLAUDE.md"));
+        let guard_pos = empty.find("ls-files --error-unmatch").unwrap();
+        let rm_pos = empty.find("rm -f").unwrap();
+        assert!(
+            rm_pos > guard_pos,
+            "the rm must run only in the untracked (else) branch, after the guard"
+        );
+        assert!(empty.contains("else"));
+
+        // Non-empty instructions are written to the repo's CLAUDE.md, still behind
+        // the same guard so a committed one is left untouched.
+        let with = per_repo_claude_md_snippet("/workspace/Repo", "Do the thing.");
+        assert!(with.contains("ls-files --error-unmatch CLAUDE.md"));
+        assert!(with.contains("base64 -d > \"/workspace/Repo/CLAUDE.md\""));
+        // The base64 write is likewise inside the else branch, not run for a
+        // repo that tracks its own CLAUDE.md.
+        let with_guard = with.find("ls-files --error-unmatch").unwrap();
+        let with_write = with.find("base64 -d").unwrap();
+        assert!(with_write > with_guard);
     }
 }

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -19,6 +19,9 @@ as the non-root `codespace` user.
   an empty desired set so a transient empty read never mass-deletes.
 - **Instructions become files.** Global instructions write to
   `/workspace/AGENTS.md`, per-repo instructions to `/workspace/{repo}/CLAUDE.md`.
+  A repo that commits its own `CLAUDE.md` is never clobbered (issue #385):
+  provisioning writes or clears that path only for repos that do not track one, so
+  it can no longer delete a repo's committed `CLAUDE.md` between tasks.
 - **Config repo for `~/.claude`.** The agent's `~/.claude` comes from cloning
   `settings.config_repo_url` into `CLAUDE_CONFIG_DIR=/workspace/.claude`, not a
   host mount. This is a dedicated, hard-failing step: on failure it records


### PR DESCRIPTION
## What

Fixes the root cause of the "workspace tree arrives with CLAUDE.md deleted between tasks" reports, and adds the interim commit-hygiene guard the issue asks for.

Closes #385.

## Root cause

`provision::repo_block` writes the operator's per-repo `instructions` to the repo's own `CLAUDE.md` path (`{dir}/CLAUDE.md`) via `write_file_snippet`, which emits `rm -f` when `instructions` is empty (the common case). For a repo that commits its own `CLAUDE.md` (Seraphim does), that deletes the tracked file.

`provision_workspace` (boot/recreate) and `clone_repo` (realtime add) run `repo_block` with **no** following `git reset --hard`, and a **resume** never re-preps the tree (`work_fresh` skips `prepare_branch` for resumes, to preserve the agent's parked work). So the deletion persists into the next turn and `git add -A` sweeps it into the commit. PR #293 shipped with exactly this.

## Fix

- **`per_repo_claude_md_snippet`** (`provision.rs`): only writes or clears `{dir}/CLAUDE.md` when the repo does **not** track its own, checked with `git ls-files --error-unmatch CLAUDE.md` (safe under `set -e` since it sits in an `if` condition). A committed `CLAUDE.md` is left untouched, so provisioning can no longer delete it. Per-repo operator instructions therefore do not apply to a repo that ships its own `CLAUDE.md`, the safe trade against destroying its file.
- **`WORKING_TREE_HYGIENE`** standing prompt instruction (`prompt.rs`): in the shared `context_header` (fresh, CI fix, conflict, revisit, review) and in `build_resume`, telling the agent to `git status` before `git add -A` and restore unrelated `CLAUDE.md`/`yarn.lock` changes a prior session left. This covers the `yarn.lock` build-artifact case, which the resume path preserves by design and so cannot be structurally reset without destroying parked work.
- `CLAUDE.md` and `docs/workspace.md` updated.

## Verification

- `cargo +1.88 fmt --check`: clean. `cargo +1.88 clippy --all-targets`: no new warnings.
- `cargo +1.88 test` against ephemeral Postgres: 199 passed, 0 failed (2 new: the CLAUDE.md guard snippet, and both fresh + resume prompts carrying the hygiene guard).
- Empirical: `git ls-files --error-unmatch CLAUDE.md` in the Seraphim checkout reports it tracked, so the generated bash takes the no-op branch and the `rm` is skipped; Seraphim's committed `CLAUDE.md` is preserved.

Backend and docs only, so visual review does not apply.