### PR TITLE
Give pg-ephemeral a --fresh mode for from-scratch migration checks (#386)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,8 +504,12 @@ operator notepad lives on the kanban board.
   workspace image, and `pg-ephemeral` boots a throwaway PG17 on `127.0.0.1` and
   prints a `DATABASE_URL` (`export DATABASE_URL="$(pg-ephemeral)"`), so the agent
   can verify migrations / integration tests against the same major as CI and
-  prod without a daemon. The entrypoint also aligns the agent to the mounted host
-  Docker socket's group, so `docker` / `earthly` work without `sudo` too.
+  prod without a daemon. Its default `app` database persists between runs, so to
+  apply the whole migration chain from `0001` use `pg-ephemeral --fresh` (issue
+  #386): it prints a URL to a brand-new empty database each call, avoiding the
+  `type "..." already exists` failure re-applying `0001` to a used database hits.
+  The entrypoint also aligns the agent to the mounted host Docker socket's group,
+  so `docker` / `earthly` work without `sudo` too.
 - **Host-script linting baked (issue #379):** shellcheck and PowerShell (`pwsh`)
   are baked into the workspace image (pinned release tarballs plus a build-time
   PATH gate, like actionlint), so an agent working the host scripts can lint the

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -33,8 +33,9 @@ as the non-root `codespace` user.
   entrypoint writes a system-wide git identity from `GIT_USER_NAME` and
   `GIT_USER_EMAIL` so commits work in every clone.
 - **Baked tooling.** The image preinstalls the pinned Rust toolchains, Postgres 17
-  plus `pg-ephemeral` for local migration checks, and Playwright's Chromium, so a
-  fresh workspace has no first-run download stall.
+  plus `pg-ephemeral` for local migration checks (use `pg-ephemeral --fresh` for a
+  clean database to apply the whole chain from `0001`, issue #386), and Playwright's
+  Chromium, so a fresh workspace has no first-run download stall.
 - **Two MCPs, at user scope.** The Playwright MCP is the agent's eyes for visual
   self-review, and the Seraphim MCP lets the agent edit its own setup scripts
   (recorded in `setup_script_changes`). Both are registered at user scope so

--- a/workspace/pg-ephemeral
+++ b/workspace/pg-ephemeral
@@ -9,6 +9,9 @@
 #
 # Usage:
 #   pg-ephemeral [start]   start it if needed and print the DATABASE_URL (default)
+#   pg-ephemeral fresh     start if needed, then print a URL to a BRAND-NEW empty
+#                          database (also `--fresh`); apply the whole migration chain
+#                          from scratch without the default `app` DB's state colliding
 #   pg-ephemeral url       print the DATABASE_URL without touching the cluster
 #   pg-ephemeral stop      stop the cluster (keeps the data dir)
 #   pg-ephemeral reset     stop and delete the data dir for a clean slate
@@ -16,6 +19,11 @@
 # Typical use:
 #   export DATABASE_URL="$(pg-ephemeral)"
 #   psql "$DATABASE_URL" -f migration.sql
+#
+#   # Validate the full migration chain from 0001 (issue #386): each `fresh` call
+#   # gives a clean, empty database, so re-applying 0001 never hits "already exists".
+#   DATABASE_URL="$(pg-ephemeral --fresh)"
+#   for f in api/migrations/*.sql; do psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"; done
 #
 # PostgreSQL refuses to run as root, so run this as the non-root workspace agent
 # user (codespace); everything lives under a writable temp dir it owns.
@@ -78,9 +86,34 @@ start() {
   echo "${URL}"
 }
 
+# Create a brand-new, empty database on the running cluster and print its URL, so a
+# caller can apply the full migration chain (0001..N) from scratch (issue #386). The
+# default `app` database persists state between runs, so re-applying 0001 there fails
+# with `type "..." already exists`; a fresh database sidesteps that. Each call yields
+# a distinct database (a nanosecond-stamped name), so repeated validations never
+# collide, and the default `app` database is left untouched.
+fresh() {
+  # Ensure the cluster is up. `start` prints the default URL on stdout, which we
+  # drop here so only the fresh URL below reaches the caller; its status/log lines
+  # already go to stderr.
+  start >/dev/null
+
+  local name
+  name="fresh_$(date +%s%N)"
+  PGPASSWORD="${PGSUPERPASS}" "${PG_BIN}/createdb" \
+    -h 127.0.0.1 -p "${PGPORT}" -U "${PGSUPERUSER}" "${name}" >/dev/null \
+    || die "failed to create the fresh database ${name}"
+
+  echo "pg-ephemeral: fresh database ready at ${name}" >&2
+  echo "postgresql://${PGSUPERUSER}:${PGSUPERPASS}@127.0.0.1:${PGPORT}/${name}"
+}
+
 case "${1:-start}" in
   start | "")
     start
+    ;;
+  fresh | --fresh)
+    fresh
     ;;
   url)
     echo "${URL}"
@@ -93,6 +126,6 @@ case "${1:-start}" in
     rm -rf "${PGDATA}"
     ;;
   *)
-    die "usage: pg-ephemeral [start|url|stop|reset]"
+    die "usage: pg-ephemeral [start|fresh|url|stop|reset]"
     ;;
 esac


### PR DESCRIPTION
## What

Adds `pg-ephemeral fresh` (also spelled `--fresh`): it prints a URL to a brand-new empty database each call, so the full migration chain (0001..N) can be applied from scratch without the persisted `app` database colliding.

Closes #386.

## Why

`pg-ephemeral`'s default `app` database persists state between runs. Re-applying `0001` to it fails with `type "source_kind" already exists`, which forced a hand-rolled `CREATE DATABASE` on the same server to validate the whole chain.

## Change

`workspace/pg-ephemeral` gains a `fresh` verb (and `--fresh` alias) that:
- ensures the cluster is up (reusing the existing `start`),
- creates a brand-new empty database with a nanosecond-stamped name (`fresh_<ns>`),
- prints only that database's URL on stdout (status lines go to stderr), so `export DATABASE_URL="$(pg-ephemeral --fresh)"` captures a clean slate.

Each call yields a distinct database, so repeated validations never collide, and the default `app` database is left untouched. Documented in the script header, `CLAUDE.md`, and `docs/workspace.md`.

## Verification (in the workspace image, on the real 50-migration chain)

- `bash -n` and `shellcheck`: clean.
- `--fresh` started the cluster, made a fresh DB, and applied all 50 migrations `0001..0050` cleanly.
- A second `--fresh` returned a different database and re-applied `0001` cleanly (repeated runs do not collide).
- `stdout` is exactly one line (the URL), so `$(...)` capture is clean.
- The default `app` database is untouched (`pg-ephemeral url` unchanged, `app` still empty).
- Contrast: applying `0001` twice to the same `app` database reproduces the exact reported error, `ERROR: type "source_kind" already exists`, which `--fresh` avoids.

Backend and tooling only, so visual review does not apply.