### PR TITLE
Guard the workspace disk against stale cargo target dirs (#390)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,6 +497,20 @@ operator notepad lives on the kanban board.
   (`.env`, with a safe `Seraphim` fallback), so the agent can commit in every flat
   clone under `/workspace` without per-repo setup. A repo-local `user.*` still
   overrides it.
+- **Workspace disk guard (issue #390):** `/workspace` is one volume shared across
+  every sibling repo, so a Rust-heavy repo whose incremental `target/` balloons
+  over many rebuilds (crew hit 21G once) can fill the disk and starve every other
+  task. A full disk surfaces as a misleading `cc: No space left on device` link
+  error, not an obvious disk problem, which can burn CI-fix attempts. So before
+  each turn the agent loop runs `orchestrator::disk::guard_workspace_disk` (in
+  `work_task`, once the container is up): it measures the free space on
+  `/workspace`, prunes every repo's stale Rust `target/` dir when it dips below a
+  reclaim threshold (a `cargo clean`, worth ~20G on crew, since a clean rebuild is
+  only a few GB), and if that still leaves too little it refuses the turn with a
+  loud "workspace disk full" error. The refusal rides the normal turn-abort path,
+  so it lands as a heart-attack incident (board banner + notification), turning a
+  confusing link error into an obvious disk problem. Thresholds are documented
+  constants in `disk.rs` (reclaim below 10G, refuse below 2G).
 - **Rust toolchains baked (issue #370):** the workspace image preinstalls rustup +
   stable, the pinned `1.88` build toolchain (with `rustfmt` + `clippy`), and the
   date-pinned nightly (with `rustfmt`) that a repo's nightly-only fmt gate uses

--- a/api/src/orchestrator/disk.rs
+++ b/api/src/orchestrator/disk.rs
@@ -1,0 +1,232 @@
+//! Pre-turn workspace disk guard (issue #390).
+//!
+//! `/workspace` is one volume shared across every sibling repo, so a single
+//! Rust-heavy repo whose incremental `target/` grows over many rebuilds (crew
+//! reached 21G in one incident) can fill the disk and starve every other task on
+//! the box. A full disk does not announce itself: it surfaces as a misleading
+//! `cc: No space left on device` link error that looks like a code failure,
+//! which can burn CI-fix attempts and even push a task to `ci_blocked` for a
+//! cause that has nothing to do with the code.
+//!
+//! Before each turn [`guard_workspace_disk`] measures the free space and:
+//!
+//! - proceeds untouched when there is ample room;
+//! - reclaims stale Rust `target/` dirs (a `cargo clean`, worth ~20G in the crew
+//!   incident) when the free space dips below [`RECLAIM_BELOW_BYTES`], since a
+//!   clean rebuild is only a few GB;
+//! - refuses the turn with a loud, unambiguous "workspace disk full" error when
+//!   even that leaves less than [`HARD_FLOOR_BYTES`], so the operator sees the
+//!   real cause (a shared-volume disk problem) instead of a masqueraded link
+//!   error.
+//!
+//! The refusal rides the normal turn-abort path, so it lands as a `heart_attacks`
+//! incident with a board banner and a notification rather than a silent stall.
+
+use eyre::{eyre, Context, Result};
+use tracing::{info, warn};
+
+use super::railway::RailwayHandle;
+use crate::state::AppState;
+
+/// The one shared volume every railway's repos are cloned under.
+const WORKSPACE_ROOT: &str = "/workspace";
+
+/// Bytes per gibibyte, so the thresholds below read in the units operators use.
+const GIB: u64 = 1024 * 1024 * 1024;
+
+/// Free space below which stale Rust `target/` dirs are pruned before the turn.
+///
+/// Set above the largest realistic clean build (a from-scratch crew build is
+/// ~4-8G) so pruning restores enough headroom for the turn's own compiles, yet
+/// low enough that it fires only when a bloated `target/` is the actual cause,
+/// not on every turn. Reclaiming forces the next build to compile from scratch,
+/// so it must stay rare; raise this only if turns routinely run the disk down
+/// between the reclaim floor and here.
+const RECLAIM_BELOW_BYTES: u64 = 10 * GIB;
+
+/// Free space below which the turn is refused rather than run into a misleading
+/// link failure.
+///
+/// A compile needs more than this, so proceeding would only produce a `No space
+/// left on device` error misattributed to the code. Kept well under
+/// [`RECLAIM_BELOW_BYTES`] so a reclaim gets the chance to recover the disk
+/// before the turn is refused.
+const HARD_FLOOR_BYTES: u64 = 2 * GIB;
+
+// A reclaim must get the chance to recover the disk before the turn is refused,
+// so the floor is strictly the lower of the two thresholds. Enforced at compile
+// time, since both are constants.
+const _: () = assert!(HARD_FLOOR_BYTES < RECLAIM_BELOW_BYTES);
+
+/// The marker `free_bytes` tags the `df` figure with, so parsing survives any
+/// shell-profile or `git`-helper noise the exec's combined output carries.
+const AVAIL_MARKER: &str = "SERAPHIM_AVAIL_KB:";
+
+/// Ensures `/workspace` has room for the turn, reclaiming stale build artifacts
+/// and refusing loudly when the disk is genuinely full (issue #390).
+///
+/// # Errors
+///
+/// Returns an error when the free space stays below [`HARD_FLOOR_BYTES`] even
+/// after reclaiming, so the caller aborts the turn with a clear disk-full cause
+/// instead of letting the agent hit a masqueraded link error. A failure to read
+/// the free space is surfaced the same way rather than silently skipped, since a
+/// guard that cannot measure the disk is not guarding it.
+pub async fn guard_workspace_disk(state: &AppState, handle: &RailwayHandle) -> Result<()> {
+    let free = free_bytes(state, handle).await?;
+    if free >= RECLAIM_BELOW_BYTES {
+        return Ok(());
+    }
+
+    warn!(
+        free_bytes = free,
+        "workspace disk low; pruning stale Rust target dirs before the turn"
+    );
+    prune_rust_target_dirs(state, handle).await;
+
+    let free_after = free_bytes(state, handle).await?;
+    if free_after < HARD_FLOOR_BYTES {
+        return Err(eyre!(
+            "workspace disk full: only {}G free on {WORKSPACE_ROOT} after reclaiming build \
+             artifacts (a build needs at least {}G). Free space on the shared workspace volume, \
+             then retry: this is a disk problem, not a code failure.",
+            gib(free_after),
+            gib(HARD_FLOOR_BYTES),
+        ));
+    }
+
+    info!(
+        free_bytes = free_after,
+        reclaimed_bytes = free_after.saturating_sub(free),
+        "reclaimed workspace disk space before the turn"
+    );
+    Ok(())
+}
+
+/// Reads the free bytes on the workspace volume via `df` inside the container.
+///
+/// `df -Pk` prints the POSIX one-line-per-filesystem format whose fourth column
+/// is the available space in 1K blocks; `awk` tags that figure with
+/// [`AVAIL_MARKER`] so [`parse_avail_bytes`] can pick it out of the combined
+/// stdout/stderr the exec returns.
+async fn free_bytes(state: &AppState, handle: &RailwayHandle) -> Result<u64> {
+    let script = format!("df -Pk {WORKSPACE_ROOT} | awk 'NR==2 {{print \"{AVAIL_MARKER}\" $4}}'");
+    let output = state
+        .workspace
+        .exec_capture_in(
+            handle.container(),
+            WORKSPACE_ROOT,
+            vec!["bash".to_string(), "-c".to_string(), script],
+            Vec::new(),
+        )
+        .await
+        .wrap_err("failed to run df in the workspace container")?;
+    if !output.succeeded() {
+        return Err(eyre!(
+            "df exited {} while checking the workspace disk: {}",
+            output.exit_code,
+            output.output.trim()
+        ));
+    }
+    parse_avail_bytes(&output.output)
+}
+
+/// Extracts the available bytes from `free_bytes`'s marked `df` output. Pure, so
+/// the parsing is unit-tested against real and malformed `df` shapes.
+fn parse_avail_bytes(output: &str) -> Result<u64> {
+    let kib = output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(AVAIL_MARKER))
+        .ok_or_else(|| eyre!("df output missing the {AVAIL_MARKER} marker: {output:?}"))?
+        .trim()
+        .parse::<u64>()
+        .wrap_err_with(|| format!("df available figure was not a number: {output:?}"))?;
+    Ok(kib * 1024)
+}
+
+/// Removes every top-level repo's Rust `target/` dir to reclaim disk, best
+/// effort.
+///
+/// Runs between turns (before the turn execs), so no build is in flight. It
+/// finds each `Cargo.toml` up to three levels deep (a repo's root crate at
+/// `/workspace/{repo}` or a nested one at `/workspace/{repo}/{crate}`) and drops
+/// the `target/` beside it, pruning `target`, `node_modules`, and `.git` from
+/// the walk so it neither descends the very dirs it clears nor trips on a
+/// vendored manifest. Guarding on `Cargo.toml` keeps a non-Rust `target` dir
+/// safe. Best effort: a reclaim failure is logged, and the caller's re-measure
+/// still decides whether the turn may proceed.
+async fn prune_rust_target_dirs(state: &AppState, handle: &RailwayHandle) {
+    let script = format!(
+        "find {WORKSPACE_ROOT} -maxdepth 3 \\( -name target -o -name node_modules -o -name .git \\) \
+         -prune -o -type f -name Cargo.toml -print 2>/dev/null | \
+         while IFS= read -r manifest; do \
+           target=\"$(dirname \"$manifest\")/target\"; \
+           [ -d \"$target\" ] && rm -rf \"$target\"; \
+         done"
+    );
+    match state
+        .workspace
+        .exec_capture_in(
+            handle.container(),
+            WORKSPACE_ROOT,
+            vec!["bash".to_string(), "-c".to_string(), script],
+            Vec::new(),
+        )
+        .await
+    {
+        Ok(output) if output.succeeded() => {}
+        Ok(output) => warn!(
+            exit = output.exit_code,
+            output = %output.output.trim(),
+            "pruning workspace target dirs reported an error"
+        ),
+        Err(error) => warn!(error = %error, "failed to prune workspace target dirs"),
+    }
+}
+
+/// Bytes rendered as gibibytes to one decimal, for human-readable error text.
+///
+/// Integer arithmetic (not a float cast) keeps the figure exact to the tenth,
+/// so "1.8" never drifts to "1.7999".
+fn gib(bytes: u64) -> String {
+    format!("{}.{}", bytes / GIB, (bytes % GIB) * 10 / GIB)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_available_bytes_from_marked_df_output() {
+        // `df -Pk` reports 1K blocks; the marker carries the fourth column.
+        let output = "SERAPHIM_AVAIL_KB:20971520\n";
+        assert_eq!(parse_avail_bytes(output).unwrap(), 20 * GIB);
+    }
+
+    #[test]
+    fn ignores_shell_profile_noise_before_the_marker() {
+        // A login shell or the git-credential helper may print ahead of df; the
+        // marker still pins the figure.
+        let output = "some profile banner\ngh auth noise\nSERAPHIM_AVAIL_KB:1048576\n";
+        assert_eq!(parse_avail_bytes(output).unwrap(), GIB);
+    }
+
+    #[test]
+    fn errors_when_the_marker_is_absent() {
+        // A df that failed to match (e.g. an empty mount table) must be an error,
+        // not a silent zero that would trip the hard floor spuriously.
+        assert!(parse_avail_bytes("df: /workspace: No such file or directory\n").is_err());
+    }
+
+    #[test]
+    fn errors_when_the_figure_is_not_a_number() {
+        assert!(parse_avail_bytes("SERAPHIM_AVAIL_KB:not-a-number\n").is_err());
+    }
+
+    #[test]
+    fn renders_gibibytes_to_one_decimal() {
+        assert_eq!(gib(2 * GIB), "2.0");
+        // 1.5 GiB, exact to the tenth with no float drift.
+        assert_eq!(gib(GIB + GIB / 2), "1.5");
+    }
+}

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -16,6 +16,10 @@ pub mod compose;
 // the HTTP layer's LLMs page can resolve the active credential for the board.
 pub(crate) mod credentials;
 mod dependencies;
+// Pre-turn workspace disk guard (issue #390): reclaim stale cargo target dirs and
+// refuse a turn loudly when the shared /workspace volume is full, so a disk problem
+// never masquerades as a link error.
+mod disk;
 mod network;
 mod placement;
 mod prompt;
@@ -1488,6 +1492,12 @@ async fn work_task(
     // Lazy start: ensure this railway's container is running and provisioned the
     // moment it has actionable work, before the turn execs into it.
     handle.ensure_running(state).await?;
+
+    // Guard the shared /workspace disk before the turn (issue #390): reclaim stale
+    // Rust target dirs, and refuse loudly if the volume is genuinely full, so a disk
+    // problem surfaces as itself (a heart-attack incident) rather than a misleading
+    // `No space left on device` link error the agent would misread as a code failure.
+    disk::guard_workspace_disk(state, handle).await?;
 
     match mode {
         WorkMode::Fresh => work_fresh(state, handle, task, false).await,

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -23,7 +23,11 @@ it.
   review comments, then pull the top of To Do, and finally revisit a PR it gave
   up on (cooldown-gated). A `blocking` task holds back new To Do work until its PR
   merges, while its own PR keeps advancing. A `Depends on:` marker stacks fresh
-  work on an unmerged dependency's branch.
+  work on an unmerged dependency's branch. Before each turn execs, it guards the
+  shared `/workspace` disk (`disk::guard_workspace_disk`, issue #390): reclaim
+  stale Rust `target/` dirs when space is low, and refuse the turn with a loud
+  "workspace disk full" heart attack rather than let a full disk masquerade as a
+  link error.
 - **review**: gates each task on all of its pull requests (a task can span
   several repos, one PR each) and reaches Done only once they have all merged. The
   merge gate is exactly CI green and zero unresolved review threads and no

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -44,6 +44,15 @@ as the non-root `codespace` user.
   (recorded in `setup_script_changes`). Both are registered at user scope so
   `claude -p --permission-mode bypassPermissions` loads them with no approval
   gate.
+- **Disk guard (issue #390).** `/workspace` is one volume shared across every
+  sibling repo, so a Rust-heavy repo whose incremental `target/` balloons over
+  many rebuilds can fill it and starve every other task, surfacing as a misleading
+  `No space left on device` link error. Before each turn the agent loop guards it
+  (`orchestrator::disk::guard_workspace_disk`): it prunes every repo's stale Rust
+  `target/` dir when free space dips below a reclaim threshold (a `cargo clean`,
+  since a clean rebuild is only a few GB), and refuses the turn with a loud
+  "workspace disk full" heart-attack incident when even that leaves too little, so
+  a disk problem reads as itself rather than a code failure.
 
 ## Where it lives
 


### PR DESCRIPTION
Closes #390.

## Problem

`/workspace` is one volume shared across every sibling repo, so a single Rust-heavy repo whose incremental `target/` grows over many rebuilds (crew reached **21G** in the reported incident) can fill the disk and starve every other task on the box. The failure mode is silent and misleading: a full disk surfaces as a spurious `cc: No space left on device` link error that looks like a code failure, so the agent (and CI-fix loop) chase a compiler error that has nothing to do with the code, and a task can land in `ci_blocked` for a disk problem.

## Change

New `orchestrator::disk::guard_workspace_disk`, run in `work_task` before every turn (all work modes) once the container is up:

1. Measures free space on `/workspace` (`df -Pk`, parsed through a marked, unit-tested pure function so shell/`git`-helper noise can't fool it).
2. When free space dips below the **reclaim threshold** (10G), prunes every repo's stale Rust `target/` dir, best effort (a `cargo clean`, worth ~20G in the crew incident). It finds each `Cargo.toml` up to three levels deep and drops the sibling `target/`, pruning `target`/`node_modules`/`.git` from the walk and guarding on `Cargo.toml` so a non-Rust `target` dir is never touched. A clean rebuild is only a few GB, so reclaiming restores ample headroom.
3. If even that leaves less than the **hard floor** (2G), it refuses the turn with a loud, unambiguous `workspace disk full: ...` error.

The refusal rides the existing turn-abort path, so it lands as a **heart-attack incident** with a board banner + notification (bounded by the normal 3-attempt budget), turning a confusing link error into an obvious disk problem, exactly the "loud preflight worth having regardless" the issue asks for. In the common case (a bloated `target/`), the reclaim frees the disk and the turn just proceeds with no incident.

Thresholds are documented constants in `disk.rs`, and their ordering (floor strictly below reclaim) is a compile-time assertion.

## Tests

Unit tests cover the `df` parsing (valid, profile-noise-prefixed, marker-absent, non-numeric) and the human GiB rendering. Full `cargo +1.88 test` passes (204).

## Docs

Updated `CLAUDE.md` (workspace runtime section), `docs/workspace.md`, and `docs/orchestrator.md` per the source-of-truth policy.

## Checks

`cargo +1.88 fmt --check`, `cargo +1.88 clippy --all-targets` (no new warnings), and `cargo +1.88 test` all green. Backend-only change, so no visual self-review.