### PR TITLE
Add a pre-commit hook running the control-char check (#394)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Pre-commit hook: reject NUL bytes and stray control characters locally, the
+# same guard the CI "Source hygiene" job runs (issues #295, #394).
+#
+# A literal NUL pasted into a source file compiles fine but makes git, grep, and
+# ripgrep treat the file as binary and silently skip it in code search. Running
+# the check here shifts it left, so a paste artifact is caught before the commit
+# instead of after a push round-trips through CI.
+#
+# It runs the exact same script CI does (scripts/check-control-chars.py), which
+# scans every tracked text source in the working tree, so local and CI never
+# disagree. Bypass with `git commit --no-verify` if you must.
+#
+# Enable it once per clone with: scripts/install-git-hooks.sh
+set -euo pipefail
+
+# Run from the repository root so the relative script path resolves no matter
+# where git invoked the hook from.
+cd "$(git rev-parse --show-toplevel)"
+
+# The check is a stdlib Python scan. If python3 is absent, warn and allow the
+# commit rather than blocking it: CI's Source hygiene job is still the gate, and
+# a hard block on a missing interpreter would only push devs to disable the hook.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "pre-commit: python3 not found; skipping the control-character check." >&2
+  echo "pre-commit: CI still enforces it. Install python3 for instant local feedback." >&2
+  exit 0
+fi
+
+# The script exits non-zero (with a per-file report) on a violation, which aborts
+# the commit; exec so that exit code is the hook's.
+exec python3 scripts/check-control-chars.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -896,7 +896,11 @@ has live data to review. Then `cd frontend && yarn dev` and open the route;
   `scripts/check-control-chars.py`, which fails the PR if any tracked text file
   (binary assets and the vendored `.yarn/` bundle excluded) contains a NUL byte or
   other control character besides tab / newline / carriage return. Run it locally
-  the same way: `python3 scripts/check-control-chars.py`.
+  the same way: `python3 scripts/check-control-chars.py`. A committed pre-commit
+  hook (`.githooks/pre-commit`) runs that exact script on every commit so a paste
+  artifact is caught before push, not after a CI round-trip (issue #394); enable it
+  once per clone with `scripts/install-git-hooks.sh` (sets `core.hooksPath`).
+  Bypass a single commit with `git commit --no-verify`.
 - **Rust toolchain is pinned to 1.88** (`api/rust-toolchain.toml`) because some
   transitive deps ship edition2024 crates. The host default may be older — always
   use `cargo +1.88`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,21 @@ Wrappers the operator runs on the host that hosts the Docker stack.
 | `uninstall.sh` / `uninstall.ps1` | Linux / Windows | Remove the scheduled updater. |
 | `dev-api.sh` | Linux, macOS, Git Bash | Boot a throwaway backend (ephemeral PG + API + seeded dev repos) for UI review. |
 
+## Contributor git hooks (issue #394)
+
+`install-git-hooks.sh` points this clone at the committed `.githooks/` directory
+(`git config core.hooksPath .githooks`), so the `pre-commit` hook runs
+`check-control-chars.py` on every commit. That catches a stray NUL or other
+control byte from a paste artifact locally, before a push round-trips through
+CI's **Source hygiene** job. Run it once per clone:
+
+```sh
+scripts/install-git-hooks.sh
+```
+
+The hook mirrors CI exactly (same script, same exit codes) and skips cleanly when
+`python3` is absent. Bypass a single commit with `git commit --no-verify`.
+
 ## Self-updater (issue #346)
 
 Keeps a deployment current with its branch. One pass:

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Point this clone's git hooks at the committed .githooks/ directory, so the
+# pre-commit control-character guard runs on every commit (issue #394).
+#
+# Version-controlled hooks live in .githooks/ (not the untracked .git/hooks), and
+# `core.hooksPath` is per-clone local config, so each fresh clone runs this once.
+# Idempotent: re-running it just re-asserts the setting.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath .githooks
+echo "Git hooks enabled: core.hooksPath -> .githooks"
+echo "  pre-commit now runs scripts/check-control-chars.py before every commit."


### PR DESCRIPTION
Closes #394.

## Problem

The control-byte guard (`scripts/check-control-chars.py`, #295) only ran in CI's **Source hygiene** job, so a stray NUL/control byte from a paste artifact was caught only *after* a push round-trips through CI.

## Change

Shift the same check left with a committed git pre-commit hook:

- **`.githooks/pre-commit`** runs the *exact* CI script (`python3 scripts/check-control-chars.py`) on every commit, so local and CI never disagree. It runs from the repo root, skips cleanly (warn + allow) when `python3` is absent so a missing interpreter never hard-blocks commits (CI is still the gate), and is bypassable with `git commit --no-verify`.
- **`scripts/install-git-hooks.sh`** activates it per clone (`git config core.hooksPath .githooks`). Dependency-free, no husky/node coupling, which suits a repo-wide guard in a Rust + TypeScript + shell monorepo.
- Docs in `scripts/README.md` (new "Contributor git hooks" section) and `CLAUDE.md` (the hygiene paragraph).

## Verification

- Negative: staging a file with a NUL byte blocks the commit with the per-file report (`badfile.txt:1:6: disallowed control byte NUL`).
- Positive: this PR's own commit ran the hook and passed ("Control-byte check passed").
- `python3 scripts/check-control-chars.py` passes over the full tree; `shellcheck scripts/*.sh` (CI-pinned 0.11.0) exits 0, and the new `install-git-hooks.sh` is shellcheck-clean.

No app/UI code changed, so visual review does not apply.