### PR TITLE
Add claude-sonnet-5 to KNOWN_MODELS (#395)

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -680,13 +680,15 @@ export const COLUMNS: { key: TaskColumn; label: string }[] = [
 
 // Known Claude models for the settings dropdown: friendly labels shown to the
 // user, coded model ids sent to the agent. Custom ids are still allowed.
-// Fable 5, Opus 4.x, and Sonnet 4.6 are 1M-context; Haiku 4.5 is 200K. The
-// `[1m]` suffix is Claude Code's way to opt Opus into its 1M window.
+// Fable 5, Opus 4.x, and the Sonnet models are 1M-context; Haiku 4.5 is 200K.
+// The `[1m]` suffix is Claude Code's way to opt Opus into its 1M window; the
+// plain ids are what `claude -p --model` accepts, so they are passed verbatim.
 export const KNOWN_MODELS: { value: string; label: string }[] = [
   { value: 'claude-opus-4-8[1m]', label: 'Claude Opus 4.8 (1M)' },
   { value: 'claude-opus-4-8', label: 'Claude Opus 4.8 (200K)' },
   { value: 'claude-opus-4-7[1m]', label: 'Claude Opus 4.7 (1M)' },
   { value: 'claude-fable-5', label: 'Claude Fable 5 (1M)' },
+  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5 (1M)' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (1M)' },
   { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5 (200K)' }
 ]


### PR DESCRIPTION
Closes #395.

## What

The Sonnet entry in the settings model dropdown (`frontend/src/lib/types.ts`, `KNOWN_MODELS`) was a generation behind: it offered only `claude-sonnet-4-6` (previous-gen Sonnet), so the current **`claude-sonnet-5`** (1M context, near-Opus quality on coding/agentic work at Sonnet-tier cost) could not be selected from the UI.

Add it as a plain id, listed above the previous-gen entry, exactly as `claude-fable-5` is:

```ts
{ value: 'claude-fable-5', label: 'Claude Fable 5 (1M)' },
{ value: 'claude-sonnet-5', label: 'Claude Sonnet 5 (1M)' },   // added
{ value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (1M)' },
```

## Care taken per the issue's cautions

- **Plain id, no suffix.** These values are passed verbatim to `claude -p --model`. `claude-sonnet-5` is the canonical Sonnet 5 id and is added plain, matching `claude-fable-5`. No invented `claude-sonnet-5[1m]` variant.
- **Opus `[1m]` suffix left intact** (Claude Code alias syntax, no API equivalent).
- **Haiku entry left alone** (`claude-haiku-4-5` is the recommended alias, not the dated snapshot), per the issue comment.
- `claude-sonnet-4-6` kept, since the proposal was to *add* Sonnet 5, not remove the prior entry.

Also refreshed the adjacent comment so the 1M/200K note stays accurate.

## Verification

Purely additive data rendered by the existing `{#each KNOWN_MODELS as model}` loop into the repo's shared `Select.Item`, so it renders identically to the five existing options (no layout/component change). Frontend CI steps pass locally:

- `yarn check` (svelte-check): 0 errors, 0 warnings
- `yarn test` (vitest): 19/19 pass
- `yarn build`: succeeds

No unit test or snapshot references these ids, so none needed updating.

**Visual review:** skipped. The change adds one option to an existing dropdown via the shared `Select` primitive with no new layout, spacing, or component, so a browser session is disproportionate for a one-line additive data change; `yarn build` + typecheck confirm it renders.